### PR TITLE
Fix for QWEN Detailer. Rework ColorFix and DriftFix methods.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+# Version 0.3.1
+## Changed:
+### VNCCS QWEN Detailer
+- **Drift Fix Logic**: Completely refactored `distortion_fix`. It now **only** controls square padding/cropping. The previously coupled logic that disabled VL tokens has been removed; the model now *always* sees vision tokens.
+- **Color Match Tuning**: Reduced default `color_match_strength` from 1.0 to **0.8** to prevent over-brightening of shadows.
+- **Padding Color**: Changed padding fill color from black to **white** (value 1.0) when squaring images.
+- **Color Correction Migration**: Switched from `color-matcher` to **Kornia** for faster, GPU-accelerated color transfer.
+- **Default Method**:  The default `color_match_method` is now `kornia_reinhard`.
+- **Dependencies**: Removed `color-matcher` from requirements. Added `kornia`.
+
+### Fixed
+- **Kornia Import**: Fixed possible `ImportError` for `histogram_matching` on older Kornia versions (wrapped in try-except).
+
+### Deprecated / Temporary
+- **Legacy Compatibility Layer**: Added a transient frontend/backend fix to support legacy workflows using removed methods (e.g., `mkl`).
+    - *Note: This auto-replacement logic (JS auto-fix on load + Backend auto-fix on execution) is temporary and will be removed in a future update. Users are encouraged to save their workflows with the new settings.*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs-utils"
 description = "VNCCS - Collection of utility nodes. VNCCS Visual Camera Control for Qwen-Image-Edit-2511-Multiple-Angles LoRa. VNCCS QWEN Detailer - For spot corrections in images of any size. "
-version = "0.3.0"
+version = "0.3.1"
 license = {file = "LICENSE"} 
 
 dependencies = ["opencv-python", "color-matcher", "huggingface_hub", "aiohttp"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 opencv-python
-color-matcher
 huggingface_hub
 aiohttp
+kornia

--- a/web/vnccs_legacy_compatibility.js
+++ b/web/vnccs_legacy_compatibility.js
@@ -1,0 +1,24 @@
+import { app } from "../../scripts/app.js";
+
+app.registerExtension({
+	name: "vnccs.legacy_compatibility",
+	nodeCreated(node) {
+		if (node.comfyClass === "VNCCS_QWEN_Detailer") {
+			const onConfigure = node.onConfigure;
+			node.onConfigure = function (w) {
+				if (onConfigure) {
+					onConfigure.apply(this, arguments);
+				}
+
+				const widget = this.widgets.find((w) => w.name === "color_match_method");
+				if (widget) {
+					const valid_methods = ["disabled", "kornia_reinhard"];
+					if (!valid_methods.includes(widget.value)) {
+						console.warn(`[VNCCS] Auto-fixing deprecated color match method '${widget.value}' to 'kornia_reinhard'`);
+						widget.value = "kornia_reinhard";
+					}
+				}
+			};
+		}
+	},
+});


### PR DESCRIPTION
# Version 0.3.1
## Changed:
### VNCCS QWEN Detailer
- **Drift Fix Logic**: Completely refactored `distortion_fix`. It now **only** controls square padding/cropping. The previously coupled logic that disabled VL tokens has been removed; the model now *always* sees vision tokens.
- **Color Match Tuning**: Reduced default `color_match_strength` from 1.0 to **0.8** to prevent over-brightening of shadows.
- **Padding Color**: Changed padding fill color from black to **white** (value 1.0) when squaring images.
- **Color Correction Migration**: Switched from `color-matcher` to **Kornia** for faster, GPU-accelerated color transfer.
- **Default Method**:  The default `color_match_method` is now `kornia_reinhard`.
- **Dependencies**: Removed `color-matcher` from requirements. Added `kornia`.

### Fixed
- **Kornia Import**: Fixed possible `ImportError` for `histogram_matching` on older Kornia versions (wrapped in try-except).

### Deprecated / Temporary
- **Legacy Compatibility Layer**: Added a transient frontend/backend fix to support legacy workflows using removed methods (e.g., `mkl`).
    - *Note: This auto-replacement logic (JS auto-fix on load + Backend auto-fix on execution) is temporary and will be removed in a future update. Users are encouraged to save their workflows with the new settings.*
