### PR TITLE
0.4.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+# Version 0.4.15
+## Fixes: Pose Studio Tab State and Workflow Size
+
+*   **Fix: Frame zoom and position lost on tab switch**: When adjusting the capture frame (zoom/offset) without moving any bones, the viewer's internal `cameraParams` remained stale. On tab switch, `getPose()` saved these stale params, so returning to the tab restored the wrong frame. Fixed by always reading `exportParams` (the authoritative widget state) as the source of truth when saving a pose — in `switchTab`, `addTab`, and `syncToNode`.
+
+*   **Fix: Copy/Paste ignoring frame settings**: `copyPose` saved the pose using the potentially stale viewer-internal `cameraParams`, and `pastePose` did not restore frame zoom/offset to the widget or viewport. Both are now fixed: copy captures current `exportParams`, paste restores zoom/offset sliders and calls `snapToCaptureCamera`.
+
+*   **Fix: "Failed to save workflow draft" with 4+ poses**: Captured images (base64 PNG, ~500 KB each at 1024×1024) were being serialized into the `pose_data` widget on every sync, quickly exceeding ComfyUI's localStorage limit. Captured images are now kept only in JS memory (`poseCaptures`) and injected directly into the execution upload payload at queue time — the widget no longer stores them.
+
+*   **Fix: All poses captured with wrong frame on queue**: During full capture (`syncToNode(true)`), every pose was rendered using the global `exportParams.cam_zoom/offset` (the active tab's settings) instead of each pose's own saved `cameraParams`. Each pose is now captured with its own frame zoom and offset.
+
 # Version 0.4.14
 ## Fix: Root Bone Drift on Age Change
 *   **Fix: Model floating above root bone**: When changing the AGE parameter, the mesh would shrink but the root bone stayed at the old position, causing the model to appear floating. This was caused by stale absolute IK positions (`hipBonePosition`, `ikEffectorPositions`, `poleTargetPositions`) being restored from saved pose data after skeleton rebuild. Now all saved poses are stripped of absolute position data before re-applying after a mesh parameter change.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What This Is
+
+A ComfyUI custom nodes extension providing utility nodes for image generation workflows. Installed as a folder inside ComfyUI's `custom_nodes/` directory and loaded automatically by ComfyUI on startup.
+
+**Dependencies**: opencv-python, huggingface_hub, aiohttp, kornia, requests, torch, numpy, Pillow
+
+## No Build Step
+
+There is no build, lint, or test command. Changes to Python files take effect after restarting ComfyUI. Changes to JavaScript files in `web/` take effect after refreshing the browser (hard refresh if cached).
+
+To verify the extension loads correctly, check the ComfyUI server console for `[VNCCS ...]` log lines on startup.
+
+## Architecture
+
+### ComfyUI Integration Points
+
+`__init__.py` is the entry point. ComfyUI loads it and reads:
+- `NODE_CLASS_MAPPINGS` — dict of node_id → Python class
+- `NODE_DISPLAY_NAME_MAPPINGS` — dict of node_id → display name
+- `WEB_DIRECTORY = "./web"` — tells ComfyUI to serve all JS from this folder
+
+`__init__.py` also registers custom HTTP endpoints on `PromptServer.instance.routes` (aiohttp) for the character mesh preview (`/vnccs/character_studio/update_preview`) and pose library CRUD.
+
+### Node Structure
+
+Each Python node class must implement:
+- `INPUT_TYPES(cls)` classmethod returning a dict of input specs
+- `RETURN_TYPES`, `RETURN_NAMES`, `CATEGORY`, `FUNCTION` class attributes
+- The method named by `FUNCTION` that does the actual work
+
+### Custom Widgets (JavaScript)
+
+Nodes with interactive UIs have matching JS files in `web/`. ComfyUI loads all `.js` files from `WEB_DIRECTORY` as ES modules. They use:
+```js
+import { app } from "../../scripts/app.js";   // ComfyUI app
+import { api } from "../../scripts/api.js";    // ComfyUI API client
+```
+
+Widgets register themselves via `app.registerExtension({ name, ..., nodeCreated })`.
+
+### Pose Studio Architecture (most complex node)
+
+Split across two JS files by design:
+- **`vnccs_pose_studio_core.js`** — UI-agnostic Three.js viewer, IK solvers, skeleton rendering. Exports `PoseViewerCore` and `IK_CHAINS`. No ComfyUI dependencies.
+- **`vnccs_pose_studio.js`** — ComfyUI node shell. Consumes `PoseViewerCore` exclusively via its public API. All ComfyUI-specific logic lives here.
+
+The Python side (`nodes/pose_studio.py`) handles image rendering at queue time: it receives pose data (bone rotations + camera params) from the JS widget as a JSON string, renders frames using PIL, and outputs them as tensors.
+
+### CharacterData Module
+
+Parses MakeHuman `.mhskel` and `.target` files at runtime to build a morphable 3D human mesh. Data is loaded lazily on first use and cached in `POSE_STUDIO_CACHE` (singleton dict in `pose_studio.py`). Requires MakeHuman data files placed at `CharacterData/makehuman/`.
+
+The `/vnccs/character_studio/update_preview` endpoint (registered in `__init__.py`) accepts morph parameters (age, gender, weight, etc.), solves the mesh via `HumanSolver`, and returns vertices + bone positions as JSON for the Three.js frontend.
+
+### Pose Library
+
+Saved poses are stored in `PoseLibrary/` at the extension root (created at runtime). Each pose is a `.json` file + optional `.png` preview. CRUD endpoints registered in `api/pose_library.py` and mounted in `__init__.py`.
+
+### Model Manager
+
+`nodes/vnccs_model_manager.py` downloads models from HuggingFace using `huggingface_hub`. It reads a `model_updater.json` config from a user-specified HF repo. Downloads run in a background thread queue. Config is cached in memory with a two-tier TTL (5 min for UI, 60 min for remote update checks).
+
+### Three.js Vendoring
+
+Three.js and its extensions (`OrbitControls.js`, `TransformControls.js`) are vendored locally in `web/` to avoid CSP violations and CDN dependencies. Do not replace with CDN imports.
+
+## Key Conventions
+
+- The `EXTENSION_URL` pattern in JS files (`new URL(".", import.meta.url)`) is required to resolve asset paths correctly regardless of the extension's directory name on disk.
+- `AnyType` in `vnccs_model_manager.py` is a ComfyUI pattern to create a universal wildcard type that accepts any connection.
+- All new API endpoints must use the `/vnccs/` prefix and be registered in `__init__.py` or `api/pose_library.py`.
+- Version is tracked in `pyproject.toml` and `CHANGELOG.md`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs-utils"
 description = "VNCCS - Collection of utility nodes. VNCCS Visual Camera Control for Qwen-Image-Edit-2511-Multiple-Angles LoRa. VNCCS QWEN Detailer - For spot corrections in images of any size. VNCCS Pose Studio - Combined mesh editor and multi-pose generator. "
-version = "0.4.14"
+version = "0.4.15"
 license = {file = "LICENSE"} 
 
 dependencies = ["opencv-python", "huggingface_hub", "aiohttp", "kornia", "requests", "torch", "numpy", "Pillow"]

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -2559,7 +2559,13 @@ class PoseStudioWidget {
 
     copyPose() {
         if (this.viewer && this.viewer.isInitialized()) {
-            this.poses[this.activeTab] = this.viewer.getPose();
+            const pose = this.viewer.getPose();
+            pose.cameraParams = {
+                offset_x: this.exportParams.cam_offset_x,
+                offset_y: this.exportParams.cam_offset_y,
+                zoom: this.exportParams.cam_zoom
+            };
+            this.poses[this.activeTab] = pose;
         }
         this._clipboard = JSON.parse(JSON.stringify(this.poses[this.activeTab]));
     }
@@ -2569,6 +2575,21 @@ class PoseStudioWidget {
         this.poses[this.activeTab] = JSON.parse(JSON.stringify(this._clipboard));
         if (this.viewer && this.viewer.isInitialized()) {
             this.viewer.setPose(this.poses[this.activeTab]);
+        }
+        if (this._clipboard.cameraParams) {
+            this.exportParams.cam_offset_x = this._clipboard.cameraParams.offset_x || 0;
+            this.exportParams.cam_offset_y = this._clipboard.cameraParams.offset_y || 0;
+            this.exportParams.cam_zoom = this._clipboard.cameraParams.zoom || 1.0;
+            if (this.exportWidgets.cam_offset_x) this.exportWidgets.cam_offset_x.value = this.exportParams.cam_offset_x;
+            if (this.exportWidgets.cam_offset_y) this.exportWidgets.cam_offset_y.value = this.exportParams.cam_offset_y;
+            if (this.exportWidgets.cam_zoom) this.exportWidgets.cam_zoom.value = this.exportParams.cam_zoom;
+            if (this.viewer) this.viewer.snapToCaptureCamera(
+                this.exportParams.view_width,
+                this.exportParams.view_height,
+                this.exportParams.cam_zoom,
+                this.exportParams.cam_offset_x,
+                this.exportParams.cam_offset_y
+            );
         }
         this.syncToNode();
     }
@@ -4073,9 +4094,10 @@ class PoseStudioWidget {
                     } else {
                         // Normal mode
                         this.viewer.setPose(this.poses[i]);
-                        const z = this.exportParams.cam_zoom || 1.0;
-                        const oX = this.exportParams.cam_offset_x || 0;
-                        const oY = this.exportParams.cam_offset_y || 0;
+                        const poseCam = this.poses[i].cameraParams || {};
+                        const z = poseCam.zoom || this.exportParams.cam_zoom || 1.0;
+                        const oX = (poseCam.offset_x !== undefined ? poseCam.offset_x : this.exportParams.cam_offset_x) || 0;
+                        const oY = (poseCam.offset_y !== undefined ? poseCam.offset_y : this.exportParams.cam_offset_y) || 0;
 
                         // Lighting Toggle
                         if (isOriginalLighting) {
@@ -4153,13 +4175,15 @@ class PoseStudioWidget {
         const exportToSave = { ...this.exportParams };
         delete exportToSave.background_url;
 
+        // captured_images are excluded from the widget to avoid inflating workflow size
+        // (each 1024×1024 PNG is ~500KB base64; multiple poses exceed ComfyUI localStorage limit)
+        // They are kept in this.poseCaptures (JS memory) and injected at upload time in vnccs_req_pose_sync
         const data = {
             mesh: this.meshParams,
             export: exportToSave,
             poses: this.poses,
             lights: this.lightParams,
             activeTab: this.activeTab,
-            captured_images: this.poseCaptures,
             lighting_prompts: this.lightingPrompts,
             background_url: this.exportParams.background_url || null
         };
@@ -4319,6 +4343,9 @@ app.registerExtension({
                     if (poseWidget) {
                         const data = JSON.parse(poseWidget.value);
                         data.node_id = nodeId;
+                        // Inject captured_images from JS memory (not stored in widget to avoid size overflow)
+                        data.captured_images = node.studioWidget.poseCaptures || [];
+                        data.lighting_prompts = node.studioWidget.lightingPrompts || [];
 
                         // 3. Upload to sync endpoint
                         await fetch('/vnccs/pose_sync/upload_capture', {

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -2431,7 +2431,13 @@ class PoseStudioWidget {
 
         // Save current pose & capture
         if (this.viewer && this.viewer.isInitialized()) {
-            this.poses[this.activeTab] = this.viewer.getPose();
+            const savedPose = this.viewer.getPose();
+            savedPose.cameraParams = {
+                offset_x: this.exportParams.cam_offset_x,
+                offset_y: this.exportParams.cam_offset_y,
+                zoom: this.exportParams.cam_zoom
+            };
+            this.poses[this.activeTab] = savedPose;
             this.syncToNode(false);
         }
 
@@ -2482,7 +2488,13 @@ class PoseStudioWidget {
 
         // Save current & capture
         if (this.viewer && this.viewer.isInitialized()) {
-            this.poses[this.activeTab] = this.viewer.getPose();
+            const savedPose = this.viewer.getPose();
+            savedPose.cameraParams = {
+                offset_x: this.exportParams.cam_offset_x,
+                offset_y: this.exportParams.cam_offset_y,
+                zoom: this.exportParams.cam_zoom
+            };
+            this.poses[this.activeTab] = savedPose;
             this.syncToNode(false);
         }
 
@@ -3985,7 +3997,13 @@ class PoseStudioWidget {
 
         // Save current pose before syncing (only if we are NOT in a sub-sync loop)
         if (!fullCapture && this.viewer && this.viewer.isInitialized()) {
-            this.poses[this.activeTab] = this.viewer.getPose();
+            const syncPose = this.viewer.getPose();
+            syncPose.cameraParams = {
+                offset_x: this.exportParams.cam_offset_x,
+                offset_y: this.exportParams.cam_offset_y,
+                zoom: this.exportParams.cam_zoom
+            };
+            this.poses[this.activeTab] = syncPose;
         }
 
         // Cache Handling


### PR DESCRIPTION
# Version 0.4.15
## Fixes: Pose Studio Tab State and Workflow Size

*   **Fix: Frame zoom and position lost on tab switch**: When adjusting the capture frame (zoom/offset) without moving any bones, the viewer's internal `cameraParams` remained stale. On tab switch, `getPose()` saved these stale params, so returning to the tab restored the wrong frame. Fixed by always reading `exportParams` (the authoritative widget state) as the source of truth when saving a pose — in `switchTab`, `addTab`, and `syncToNode`.

*   **Fix: Copy/Paste ignoring frame settings**: `copyPose` saved the pose using the potentially stale viewer-internal `cameraParams`, and `pastePose` did not restore frame zoom/offset to the widget or viewport. Both are now fixed: copy captures current `exportParams`, paste restores zoom/offset sliders and calls `snapToCaptureCamera`.

*   **Fix: "Failed to save workflow draft" with 4+ poses**: Captured images (base64 PNG, ~500 KB each at 1024×1024) were being serialized into the `pose_data` widget on every sync, quickly exceeding ComfyUI's localStorage limit. Captured images are now kept only in JS memory (`poseCaptures`) and injected directly into the execution upload payload at queue time — the widget no longer stores them.

*   **Fix: All poses captured with wrong frame on queue**: During full capture (`syncToNode(true)`), every pose was rendered using the global `exportParams.cam_zoom/offset` (the active tab's settings) instead of each pose's own saved `cameraParams`. Each pose is now captured with its own frame zoom and offset.