### PR TITLE
0.4.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# Version 0.4.25
+## Pose Studio: Pose Manager Grid and Hand Control Options
+
+### New Features
+
+*   **Hand control mode toggle**: Added a Settings option to enable or disable the newer floating hand-control interface introduced in `0.4.18`.
+    *   When disabled, hand editing returns to the pre-`0.4.18` direct-joint workflow with individual finger joints visible and selectable.
+    *   The option is persisted in `pose_data` so workflows reopen with the selected hand-control behavior.
+
+*   **Foot Size proportion control**: Added a `Foot Size` slider to Mesh Proportions.
+    *   Scales both feet live in the Pose Studio viewer.
+    *   Persists with the other mesh proportion settings.
+
+### Improvements
+
+*   **Pose Manager preview grid**: Reworked Pose Manager card layout using the same adaptive image-grid strategy as `VNCCS Character Generator`.
+    *   Preview images are measured by their real dimensions before layout.
+    *   The grid now chooses rows, columns, and cell sizes to maximize usable preview area across different pose counts and output aspect ratios.
+    *   Pose cards stay centered and scale more consistently in wide, tall, compact, and sparse layouts.
+
+*   **Settings toggle visibility**: Improved active-state styling for segmented controls in Settings so the selected option remains clearly visible against the dark background.
+
 # Version 0.4.24
 ## Pose Studio: Pose Manager, Age Camera Fit, and Character Creator Sync
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs-utils"
 description = "VNCCS - Collection of utility nodes. VNCCS Visual Camera Control for Qwen-Image-Edit-2511-Multiple-Angles LoRa. VNCCS QWEN Detailer - For spot corrections in images of any size. VNCCS Pose Studio - Combined mesh editor and multi-pose generator. "
-version = "0.4.24"
+version = "0.4.25"
 license = {file = "LICENSE"} 
 
 dependencies = [

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -2500,7 +2500,8 @@ class PoseStudioWidget {
             prompt_template: "Draw character from image2\n<lighting>\n<user_prompt>",
             skin_type: "naked", // naked | naked_marks | dummy_white
             background_url: null,
-            interface_mode: "studio"
+            interface_mode: "studio",
+            hand_controls_v2: true
         };
 
         // Lighting settings (array of light configs)
@@ -3467,6 +3468,7 @@ class PoseStudioWidget {
             showSkeletonHelper: true,
             showCaptureFrame: true,
             syncMode: 'end',
+            useHandControlPopover: this.exportParams.hand_controls_v2 !== false,
             onHandHover: ({ side }) => {
                 this._hoveredHandSide = side;
                 if (!side && !this._activeHandSide) {
@@ -3486,6 +3488,7 @@ class PoseStudioWidget {
         });
 
         this.viewer.init();
+        this.viewer.setUseHandControlPopover?.(this.exportParams.hand_controls_v2 !== false);
         if (this.lightParams) {
             this.viewer.updateLights(this.lightParams);
         }
@@ -7056,6 +7059,37 @@ class PoseStudioWidget {
         interfaceRow.appendChild(interfaceToggle);
         content.appendChild(interfaceRow);
 
+        const handControlsRow = document.createElement("div");
+        handControlsRow.className = "vnccs-ps-field";
+        handControlsRow.style.marginBottom = "14px";
+
+        const handControlsLabel = document.createElement("label");
+        handControlsLabel.style.display = "flex";
+        handControlsLabel.style.alignItems = "center";
+        handControlsLabel.style.gap = "10px";
+        handControlsLabel.style.cursor = "pointer";
+        handControlsLabel.style.userSelect = "none";
+
+        const handControlsCheckbox = document.createElement("input");
+        handControlsCheckbox.type = "checkbox";
+        handControlsCheckbox.checked = this.exportParams.hand_controls_v2 !== false;
+        handControlsCheckbox.onchange = () => {
+            this.exportParams.hand_controls_v2 = handControlsCheckbox.checked;
+            if (!handControlsCheckbox.checked) {
+                this.hideHandControlPopover();
+            }
+            this.viewer?.setUseHandControlPopover?.(handControlsCheckbox.checked);
+            this.syncToNode(false);
+        };
+
+        const handControlsText = document.createElement("div");
+        handControlsText.innerHTML = "<strong>New Hand Controls</strong><div style='font-size:11px; color:#888; margin-top:4px;'>When enabled, clicking a hand opens the floating hand editor. Disable to show and edit every finger joint directly.</div>";
+
+        handControlsLabel.appendChild(handControlsCheckbox);
+        handControlsLabel.appendChild(handControlsText);
+        handControlsRow.appendChild(handControlsLabel);
+        content.appendChild(handControlsRow);
+
         const debugSection = this.createSection("Debug", false);
 
         // SAM Camera Override Toggle
@@ -8561,6 +8595,7 @@ class PoseStudioWidget {
             if (this.viewer?.setKpFigureVisible) {
                 this.viewer.setKpFigureVisible(this.exportParams.debugShowSAMHelper !== false);
             }
+            this.viewer?.setUseHandControlPopover?.(this.exportParams.hand_controls_v2 !== false);
             if (this.updateOverrideBtn) this.updateOverrideBtn();
 
             if (data.poses && Array.isArray(data.poses)) {

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -379,7 +379,9 @@ const STYLES = `
 }
 
 .vnccs-ps-toggle-btn.active {
+    background: linear-gradient(135deg, var(--ps-accent), var(--ps-accent-hover));
     color: #1a1525;
+    box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.12), 0 2px 8px var(--ps-accent-glow);
 }
 
 .vnccs-ps-toggle-btn.male.active {

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -2468,6 +2468,7 @@ class PoseStudioWidget {
             head_size: 1.0,
             arm_size: 1.0,
             hand_size: 1.0,
+            foot_size: 1.0,
             upper_arm_l_length: 0.5,
             upper_arm_r_length: 0.5,
             forearm_l_length: 0.5,
@@ -2982,6 +2983,7 @@ class PoseStudioWidget {
             { key: "head_size", label: "Head Size", min: 0.5, max: 2.0, step: 0.01, def: 1.0 },
             { key: "arm_size",  label: "Arm Size",  min: 0.5, max: 2.0, step: 0.01, def: 1.0 },
             { key: "hand_size", label: "Hand Size", min: 0.5, max: 2.0, step: 0.01, def: 1.0 },
+            { key: "foot_size", label: "Foot Size", min: 0.5, max: 2.0, step: 0.01, def: 1.0 },
             { key: "upper_arm_l_length", label: "Left Upper Arm Length", min: 0, max: 1, step: 0.01, def: 0.5 },
             { key: "upper_arm_r_length", label: "Right Upper Arm Length", min: 0, max: 1, step: 0.01, def: 0.5 },
             { key: "forearm_l_length", label: "Left Forearm Length", min: 0, max: 1, step: 0.01, def: 0.5 },
@@ -4046,6 +4048,10 @@ class PoseStudioWidget {
                     this.syncToNode(false);
                 } else if (key === 'hand_size') {
                     if (this.viewer) this.viewer.updateHandScale(val);
+                    this.meshParams[key] = val;
+                    this.syncToNode(false);
+                } else if (key === 'foot_size') {
+                    if (this.viewer) this.viewer.updateFootScale(val);
                     this.meshParams[key] = val;
                     this.syncToNode(false);
                 } else if (key.endsWith('_length')) {
@@ -8531,6 +8537,9 @@ class PoseStudioWidget {
                 }
                 if (this.viewer && this.meshParams.hand_size !== undefined) {
                     this.viewer.updateHandScale(this.meshParams.hand_size);
+                }
+                if (this.viewer && this.meshParams.foot_size !== undefined) {
+                    this.viewer.updateFootScale(this.meshParams.foot_size);
                 }
                 if (data.mesh.arm_length !== undefined) {
                     if (data.mesh.upper_arm_l_length === undefined) this.meshParams.upper_arm_l_length = data.mesh.arm_length;

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -1274,16 +1274,21 @@ const STYLES = `
 .vnccs-ps-manager-grid {
     height: 100%;
     display: grid;
-    grid-template-columns: repeat(var(--pm-cols, 1), minmax(0, 1fr));
-    align-content: flex-start;
+    grid-template-columns: repeat(var(--pm-cols, 1), var(--pm-cell-w, 220px));
+    grid-template-rows: repeat(var(--pm-rows, 1), var(--pm-cell-h, 320px));
+    align-content: center;
+    justify-content: center;
     gap: 14px;
+    overflow: hidden;
 }
 
 .vnccs-ps-pose-card {
-    width: 100%;
+    width: var(--pm-card-w);
     height: var(--pm-card-h);
     min-width: 28px;
     min-height: 40px;
+    justify-self: center;
+    align-self: center;
     display: flex;
     flex-direction: column;
     overflow: hidden;
@@ -2532,6 +2537,8 @@ class PoseStudioWidget {
         this.managerDetailStrip = null;
         this.managerResizeObserver = null;
         this.managerBackBtn = null;
+        this.managerImageMetrics = new Map();
+        this.managerLayoutFrame = null;
         this._defaultHandPresets = HAND_PRESETS;
         this._handSliderValues = { spread: 0, grasp: 0, thumb: 0, index: 0, middle: 0, ring: 0, pinky: 0 };
         this._handSliderDefaults = { spread: 0, grasp: 0, thumb: 0, index: 0, middle: 0, ring: 0, pinky: 0 };
@@ -2633,7 +2640,7 @@ class PoseStudioWidget {
         this.container.appendChild(this.managerPanel);
 
         if (typeof ResizeObserver !== "undefined") {
-            this.managerResizeObserver = new ResizeObserver(() => this.layoutPoseManager());
+            this.managerResizeObserver = new ResizeObserver(() => this.schedulePoseManagerGridLayout());
             this.managerResizeObserver.observe(this.managerStage);
         }
         this.renderPoseManager();
@@ -2871,7 +2878,7 @@ class PoseStudioWidget {
             this._lastResizeH = 0;
             this.resize();
             this.updateCaptureCameraPreview();
-            this.layoutPoseManager();
+            this.schedulePoseManagerGridLayout();
         }
         this.refreshPoseManagerControls();
         if (isDimension) {
@@ -3583,7 +3590,7 @@ class PoseStudioWidget {
         if (normalized === "manager") {
             this.refreshPoseManagerControls();
             this.renderPoseManager();
-            requestAnimationFrame(() => this.layoutPoseManager());
+            this.schedulePoseManagerGridLayout();
         } else {
             requestAnimationFrame(() => this.resize());
         }
@@ -3678,7 +3685,45 @@ class PoseStudioWidget {
             this.managerGrid.appendChild(card);
         }
 
-        this.layoutPoseManager();
+        this.schedulePoseManagerGridLayout();
+    }
+
+    schedulePoseManagerGridLayout() {
+        if (this.managerLayoutFrame) cancelAnimationFrame(this.managerLayoutFrame);
+        this.managerLayoutFrame = requestAnimationFrame(() => {
+            this.managerLayoutFrame = null;
+            this.layoutPoseManager();
+        });
+        for (const capture of this.poseCaptures || []) {
+            if (capture) this.ensurePoseManagerImageMetrics(capture, () => this.layoutPoseManager());
+        }
+    }
+
+    ensurePoseManagerImageMetrics(src, onReady) {
+        const existing = this.managerImageMetrics.get(src);
+        if (existing) {
+            if (existing.loading && onReady) existing.callbacks.push(onReady);
+            else onReady?.();
+            return;
+        }
+
+        this.managerImageMetrics.set(src, { width: 1, height: 1, loading: true, callbacks: onReady ? [onReady] : [] });
+        const img = new Image();
+        img.onload = () => {
+            const callbacks = this.managerImageMetrics.get(src)?.callbacks || [];
+            this.managerImageMetrics.set(src, {
+                width: img.naturalWidth || 1,
+                height: img.naturalHeight || 1,
+                loading: false,
+            });
+            callbacks.forEach(callback => callback?.());
+        };
+        img.onerror = () => {
+            const callbacks = this.managerImageMetrics.get(src)?.callbacks || [];
+            this.managerImageMetrics.set(src, { width: 1, height: 1, loading: false });
+            callbacks.forEach(callback => callback?.());
+        };
+        img.src = src;
     }
 
     layoutPoseManager() {
@@ -3688,57 +3733,58 @@ class PoseStudioWidget {
         const padX = (parseFloat(stageStyle.paddingLeft) || 0) + (parseFloat(stageStyle.paddingRight) || 0);
         const padY = (parseFloat(stageStyle.paddingTop) || 0) + (parseFloat(stageStyle.paddingBottom) || 0);
         const width = Math.max(1, this.managerStage.clientWidth - padX - 2);
-        const height = Math.max(1, this.managerStage.clientHeight - padY - 18);
+        const height = Math.max(1, this.managerStage.clientHeight - padY - 2);
         const gap = 14;
-        const preferredRows = count <= 6 ? 1 : (count <= 12 ? 2 : Math.ceil(count / 6));
-        const minCardW = count <= 6 ? 130 : 80;
-        const minCardH = 130;
-        const previewAspect = Math.max(0.35, Math.min(4, (Number(this.exportParams.view_height) || 1024) / (Number(this.exportParams.view_width) || 1024)));
+        const fallbackAspect = Math.max(0.05, Math.min(20, (Number(this.exportParams.view_width) || 1024) / (Number(this.exportParams.view_height) || 1024)));
+        const aspects = Array.from({ length: count }, (_, index) => {
+            const capture = this.poseCaptures?.[index];
+            const metrics = capture ? this.managerImageMetrics.get(capture) : null;
+            return Math.max(0.05, Math.min(20, (metrics?.width && metrics?.height) ? metrics.width / metrics.height : fallbackAspect));
+        });
         let best = null;
 
-        for (let rows = 1; rows <= count; rows++) {
-            const cols = Math.ceil(count / rows);
-            const cardW = (width - gap * (cols - 1)) / cols;
-            const rowH = (height - gap * (rows - 1)) / rows;
-            if (cardW <= 0) continue;
-            if (rowH <= 0) continue;
+        for (let cols = 1; cols <= count; cols++) {
+            const rows = Math.ceil(count / cols);
+            const cellW = (width - gap * (cols - 1)) / cols;
+            const cellH = (height - gap * (rows - 1)) / rows;
+            if (cellW <= 0 || cellH <= 0) continue;
 
-            const footerH = Math.max(44, Math.min(60, cardW * 0.18));
-            const previewH = Math.max(40, Math.min(cardW * previewAspect, rowH - footerH));
-            const cardH = previewH + footerH;
-            if ((cardW < minCardW || cardH < minCardH) && count > 1) continue;
-
+            const footerH = Math.max(36, Math.min(56, cellW * 0.18));
+            const previewCellH = Math.max(1, cellH - footerH);
+            let minArea = Infinity;
+            let totalArea = 0;
+            for (const aspect of aspects) {
+                const drawW = Math.min(cellW, previewCellH * aspect);
+                const drawH = drawW / aspect;
+                const area = drawW * drawH;
+                minArea = Math.min(minArea, area);
+                totalArea += area;
+            }
             const emptySlots = rows * cols - count;
-            const rowPenalty = Math.abs(rows - preferredRows) * 100000;
-            const aspect = previewH / Math.max(1, cardW);
-            const aspectPenalty = Math.abs(aspect - Math.min(previewAspect, 1.8)) * 80;
-            const unusedRowH = Math.max(0, rowH - cardH);
-            const sizeScore = Math.min(cardW, previewH / Math.min(previewAspect, 1.8)) * 100;
-            const fillBonus = previewAspect > 1.6 ? -unusedRowH * 0.2 : -unusedRowH * 0.02;
-            const score = sizeScore - rowPenalty - emptySlots * 80 - aspectPenalty;
-
+            const score = minArea * 1000000 + totalArea - emptySlots * 1000;
             if (!best || score > best.score) {
-                best = { cols, rows, cardW, cardH, footerH, score: score + fillBonus };
+                best = { cols, rows, cellW, cellH, footerH, score };
             }
         }
 
-        if (!best) {
-            const rows = Math.min(count, Math.max(1, preferredRows));
-            const cols = Math.ceil(count / rows);
-            const cardW = Math.max(28, (width - gap * (cols - 1)) / cols);
-            const rowH = Math.max(40, (height - gap * (rows - 1)) / rows);
-            const footerH = Math.max(44, Math.min(60, cardW * 0.18));
-            const cardH = Math.max(40, Math.min(rowH, cardW * previewAspect + footerH));
-            best = { cols, rows, cardW, cardH, footerH, score: 0 };
-        }
+        if (!best) return;
 
-        const cardWidth = Math.max(28, Math.floor(best.cardW));
-        const cardHeight = Math.max(40, Math.floor(best.cardH));
-        const footerHeight = Math.max(44, Math.floor(best.footerH));
-        this.managerStage.style.setProperty("--pm-card-w", `${cardWidth}px`);
-        this.managerStage.style.setProperty("--pm-card-h", `${cardHeight}px`);
-        this.managerStage.style.setProperty("--pm-card-footer-h", `${footerHeight}px`);
         this.managerGrid.style.setProperty("--pm-cols", String(best.cols));
+        this.managerGrid.style.setProperty("--pm-rows", String(best.rows));
+        this.managerGrid.style.setProperty("--pm-cell-w", `${Math.max(1, Math.floor(best.cellW))}px`);
+        this.managerGrid.style.setProperty("--pm-cell-h", `${Math.max(1, Math.floor(best.cellH))}px`);
+
+        [...this.managerGrid.children].forEach((card, index) => {
+            if (!card.classList?.contains("vnccs-ps-pose-card")) return;
+            const aspect = aspects[index] || fallbackAspect;
+            const drawW = Math.min(best.cellW, Math.max(1, best.cellH - best.footerH) * aspect);
+            const drawH = drawW / aspect;
+            const cardW = Math.max(28, Math.floor(drawW));
+            const footerH = Math.max(36, Math.floor(best.footerH));
+            card.style.setProperty("--pm-card-w", `${cardW}px`);
+            card.style.setProperty("--pm-card-h", `${Math.max(40, Math.floor(drawH) + footerH)}px`);
+            card.style.setProperty("--pm-card-footer-h", `${footerH}px`);
+        });
     }
 
     renderPoseManagerDetailStrip() {
@@ -7870,7 +7916,7 @@ class PoseStudioWidget {
     resize() {
         this.updateMainUIScale();
         if (this.interfaceMode === "manager") {
-            this.layoutPoseManager();
+            this.schedulePoseManagerGridLayout();
             return;
         }
         if (this.viewer && this.canvasContainer) {
@@ -8996,6 +9042,10 @@ app.registerExtension({
                 if (this.studioWidget.managerResizeObserver) {
                     this.studioWidget.managerResizeObserver.disconnect();
                     this.studioWidget.managerResizeObserver = null;
+                }
+                if (this.studioWidget.managerLayoutFrame) {
+                    cancelAnimationFrame(this.studioWidget.managerLayoutFrame);
+                    this.studioWidget.managerLayoutFrame = null;
                 }
                 if (this.studioWidget._resizeRaf) {
                     cancelAnimationFrame(this.studioWidget._resizeRaf);

--- a/web/vnccs_pose_studio_core.js
+++ b/web/vnccs_pose_studio_core.js
@@ -956,6 +956,7 @@ export class PoseViewerCore {
         this.headScale = 1.0;
         this.armScale = 1.0;
         this.handScale = 1.0;
+        this.footScale = 1.0;
         this.boneLengthParams = {
             upper_arm_l: 0.5,
             upper_arm_r: 0.5,
@@ -2463,6 +2464,9 @@ export class PoseViewerCore {
         if (this.handScale !== 1.0) {
             this.updateHandScale(this.handScale);
         }
+        if (this.footScale !== 1.0) {
+            this.updateFootScale(this.footScale);
+        }
         this.applyBoneLengthScales();
 
         this._initIKHelpers();
@@ -2702,6 +2706,17 @@ export class PoseViewerCore {
         for (const bone of this.boneList) {
             const n = bone.name.toLowerCase();
             if (n === 'hand_l' || n === 'hand_r') {
+                bone.scale.set(scale, scale, scale);
+            }
+        }
+        this.requestRender();
+    }
+
+    updateFootScale(scale) {
+        this.footScale = scale;
+        for (const bone of this.boneList) {
+            const n = bone.name.toLowerCase();
+            if (n === 'foot_l' || n === 'foot_r') {
                 bone.scale.set(scale, scale, scale);
             }
         }

--- a/web/vnccs_pose_studio_core.js
+++ b/web/vnccs_pose_studio_core.js
@@ -987,6 +987,7 @@ export class PoseViewerCore {
         this.cameraParams = null; // Store widget camera params explicitly
         this.isInteractionActive = null;
         this._hoveredHandSide = null;
+        this.useHandControlPopover = this.options.useHandControlPopover !== false;
     }
 
     _getHandSideFromBoneName(name) {
@@ -1006,6 +1007,7 @@ export class PoseViewerCore {
     _shouldMarkerBeVisible(marker) {
         const bone = this.boneList?.[marker?.userData?.boneIndex];
         if (!bone) return false;
+        if (!this.useHandControlPopover) return true;
         return !this._isFingerHandBoneName(bone.name);
     }
 
@@ -1014,12 +1016,14 @@ export class PoseViewerCore {
     }
 
     _resolveHandBone(bone) {
+        if (!this.useHandControlPopover) return bone;
         const side = this._getHandSideFromBoneName(bone?.name);
         if (!side) return bone;
         return this.bones?.[`hand_${side}`] || bone;
     }
 
     _isHandSurfaceActivation(side, point) {
+        if (!this.useHandControlPopover) return false;
         if (!side || !point || !this.THREE) return false;
 
         const wrist = this.bones?.[`hand_${side}`];
@@ -1056,6 +1060,7 @@ export class PoseViewerCore {
     }
 
     _updateHoveredHand(side) {
+        if (!this.useHandControlPopover) side = null;
         if (this._hoveredHandSide === side) return;
         this._hoveredHandSide = side;
 
@@ -1068,6 +1073,20 @@ export class PoseViewerCore {
         if (this.options.onHandHover) {
             this.options.onHandHover({ side });
         }
+    }
+
+    setUseHandControlPopover(enabled) {
+        this.useHandControlPopover = enabled !== false;
+        if (!this.useHandControlPopover) {
+            this._updateHoveredHand(null);
+        }
+        if (this.jointMarkers) {
+            this.jointMarkers.forEach(marker => {
+                marker.visible = this._mannequinVisible !== false && this._shouldMarkerBeVisible(marker);
+            });
+        }
+        this.updateMarkers();
+        this.requestRender();
     }
 
     dispatchPoseChange() {


### PR DESCRIPTION
# Version 0.4.25
## Pose Studio: Pose Manager Grid and Hand Control Options

### New Features

*   **Hand control mode toggle**: Added a Settings option to enable or disable the newer floating hand-control interface introduced in `0.4.18`.
    *   When disabled, hand editing returns to the pre-`0.4.18` direct-joint workflow with individual finger joints visible and selectable.
    *   The option is persisted in `pose_data` so workflows reopen with the selected hand-control behavior.

*   **Foot Size proportion control**: Added a `Foot Size` slider to Mesh Proportions.
    *   Scales both feet live in the Pose Studio viewer.
    *   Persists with the other mesh proportion settings.

### Improvements

*   **Pose Manager preview grid**: Reworked Pose Manager card layout using the same adaptive image-grid strategy as `VNCCS Character Generator`.
    *   Preview images are measured by their real dimensions before layout.
    *   The grid now chooses rows, columns, and cell sizes to maximize usable preview area across different pose counts and output aspect ratios.
    *   Pose cards stay centered and scale more consistently in wide, tall, compact, and sparse layouts.

*   **Settings toggle visibility**: Improved active-state styling for segmented controls in Settings so the selected option remains clearly visible against the dark background.