### PR TITLE
0.4.29

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,42 @@
+# Version 0.4.29
+## Pose Studio Live Morph Performance and Pose Manager Stability
+
+### Improvements
+
+*   **Pose Studio live morphing moved to the browser**: Added a dedicated browser-side morph data pipeline for realtime body-parameter previews.
+    *   MakeHuman base vertices, morph targets, joint data, and skeleton metadata are exposed through a compact binary endpoint for the live worker.
+    *   Age, Gender, Weight, Muscle, Height, breast, firmness, and genital morph parameters can now update the visible mesh without a full Python preview rebuild on every slider input.
+    *   A shared morph worker is reused across Pose Studio widgets so multiple active nodes do not each create their own heavy morph worker and duplicate morph-data downloads.
+    *   Worker messages are routed by client id so concurrent Pose Studio widgets receive only their own live morph results.
+
+*   **Pose Manager realtime preview updates**: Reworked manager-mode body-slider updates so all pose cards refresh during live morph changes.
+    *   Pose Manager now updates every visible pose preview during realtime Age/Weight/Muscle/Height edits instead of waiting for a final Python sync.
+    *   Preview refresh work is chunked across animation frames to keep the UI responsive while multiple cards are being recaptured.
+    *   Stale worker results are ignored by sequence id so quick slider movement cannot apply older mesh states over newer ones.
+
+*   **Non-blocking Pose Studio startup load**: Reworked the MakeHuman preload path used by the preview API to cooperate with ComfyUI's async server loop.
+    *   Startup model loading still happens when the Pose Studio widget opens, but OBJ and target-file reads now yield between chunks instead of monopolizing the server handler.
+    *   Preview payload building runs off the aiohttp request path after the shared Pose Studio data cache is loaded.
+    *   Cache loading remains serialized so parallel widget startup does not create partially initialized shared MakeHuman state.
+
+### Fixes
+
+*   **Age and Height live skinning**: Fixed live Age/Height morph updates that could temporarily detach the mesh from the skeleton while dragging.
+    *   Live morph results now include updated bone/joint positions so the frontend can keep skinned geometry aligned during realtime body-size changes.
+    *   The final Python sync remains available for full authoritative mesh rebuilds after dragging, without hammering the server on every input event.
+
+*   **Pose Manager card flicker**: Reduced manager-card flicker after final body-scale recalculation.
+    *   Pose cards preserve measured preview dimensions while captures are refreshed.
+    *   Capture replacement updates existing card images instead of forcing avoidable full-grid layout churn.
+    *   Deleted/reordered poses keep their card metrics aligned with the correct pose index during subsequent live morph refreshes.
+
+*   **Pose Manager lighting restore**: Fixed Pose Manager reloads that could show black/unlit model previews until any parameter was changed.
+    *   Lighting is now applied when model data is loaded so restored cards match the configured light state immediately.
+
+*   **Preview API cleanup**: Removed obsolete unreachable preview-generation code left behind during the live morph refactor.
+    *   Removed the rejected subprocess preload experiment and all related helper code.
+    *   Removed the remaining synchronous data-load fallback from the new preview payload path.
+
 # Version 0.4.28
 ## Security Hardening, Pose Studio Fixes, and XPU BiRefNet
 

--- a/__init__.py
+++ b/__init__.py
@@ -33,12 +33,14 @@ import os
 import json
 import re
 import numpy as np
+import struct
 
 _SAFE_ID_RE = re.compile(r"[^A-Za-z0-9_-]+")
 _CAPTURE_CACHE_MAX_IMAGES = 16
 _CAPTURE_CACHE_MAX_TOTAL_CHARS = 64 * 1024 * 1024
 _SAM3D_MAX_UPLOAD_BYTES = 32 * 1024 * 1024
 _SAM3D_MAX_PIXELS = 4096 * 4096
+_VNCCS_MORPH_DATA_BINARY = None
 
 def _vnccs_content_length_ok(request, max_bytes):
     try:
@@ -318,6 +320,93 @@ def _vnccs_register_endpoint():
                 "landmarks": landmarks_for_frontend,
                 "landmark_indices": landmark_indices_for_frontend
             })
+        except Exception as e:
+            import traceback
+            traceback.print_exc()
+            return web.json_response({"error": str(e)}, status=500)
+
+    @PromptServer.instance.routes.get("/vnccs/character_studio/morph_data.bin")
+    async def vnccs_character_studio_morph_data(request):
+        try:
+            global _VNCCS_MORPH_DATA_BINARY
+            if _VNCCS_MORPH_DATA_BINARY is None:
+                from .nodes.pose_studio import POSE_STUDIO_CACHE, _ensure_data_loaded
+
+                _ensure_data_loaded()
+                base_mesh = POSE_STUDIO_CACHE["base_mesh"]
+                targets = POSE_STUDIO_CACHE["targets"] or []
+
+                buffers = []
+                header = {
+                    "version": 1,
+                    "vertex_count": int(len(base_mesh.vertices)),
+                    "base_vertices": {"offset": 0, "length": int(base_mesh.vertices.size)},
+                    "targets": [],
+                    "joints": {},
+                    "bones": [],
+                }
+
+                offset = 0
+                base_vertices = np.asarray(base_mesh.vertices, dtype="<f4")
+                base_bytes = base_vertices.tobytes(order="C")
+                buffers.append(base_bytes)
+                offset += len(base_bytes)
+
+                for target in targets:
+                    data = target.get("data")
+                    if data is None:
+                        continue
+                    indices, deltas = data
+                    indices = np.asarray(indices, dtype="<u4")
+                    deltas = np.asarray(deltas, dtype="<f4").reshape(-1, 3)
+                    if len(indices) == 0 or len(deltas) != len(indices):
+                        continue
+
+                    indices_bytes = indices.tobytes(order="C")
+                    deltas_bytes = deltas.tobytes(order="C")
+                    target_header = {
+                        "tags": target.get("tags", {}),
+                        "count": int(len(indices)),
+                        "indices": {"offset": offset, "length": int(len(indices))},
+                    }
+                    buffers.append(indices_bytes)
+                    offset += len(indices_bytes)
+                    target_header["deltas"] = {"offset": offset, "length": int(deltas.size)}
+                    buffers.append(deltas_bytes)
+                    offset += len(deltas_bytes)
+                    header["targets"].append(target_header)
+
+                skeleton = POSE_STUDIO_CACHE.get("skeleton")
+                if skeleton:
+                    header["joints"] = {
+                        name: [int(index) for index in indices]
+                        for name, indices in skeleton.joint_pos_idxs.items()
+                    }
+                    header["bones"] = [
+                        {
+                            "name": bone.name,
+                            "parent": bone.parent.name if bone.parent else None,
+                            "head_joint": bone.headJoint,
+                            "tail_joint": bone.tailJoint,
+                        }
+                        for bone in skeleton.getBones()
+                    ]
+
+                header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+                header_padding = b"\0" * ((4 - ((12 + len(header_bytes)) % 4)) % 4)
+                _VNCCS_MORPH_DATA_BINARY = (
+                    b"VNMORPH1"
+                    + struct.pack("<I", len(header_bytes))
+                    + header_bytes
+                    + header_padding
+                    + b"".join(buffers)
+                )
+
+            return web.Response(
+                body=_VNCCS_MORPH_DATA_BINARY,
+                content_type="application/octet-stream",
+                headers={"Cache-Control": "no-store"},
+            )
         except Exception as e:
             import traceback
             traceback.print_exc()

--- a/__init__.py
+++ b/__init__.py
@@ -34,6 +34,7 @@ import json
 import re
 import numpy as np
 import struct
+import asyncio
 
 _SAFE_ID_RE = re.compile(r"[^A-Za-z0-9_-]+")
 _CAPTURE_CACHE_MAX_IMAGES = 16
@@ -41,6 +42,141 @@ _CAPTURE_CACHE_MAX_TOTAL_CHARS = 64 * 1024 * 1024
 _SAM3D_MAX_UPLOAD_BYTES = 32 * 1024 * 1024
 _SAM3D_MAX_PIXELS = 4096 * 4096
 _VNCCS_MORPH_DATA_BINARY = None
+_VNCCS_MORPH_DATA_LOCK = None
+_VNCCS_PREVIEW_LOCK = None
+_VNCCS_DATA_LOAD_LOCK = None
+
+async def _vnccs_async_checkpoint():
+    await asyncio.sleep(0)
+
+async def _vnccs_load_obj_async(file_path, checkpoint_lines=1500):
+    from .CharacterData.obj_loader import Mesh
+
+    vertices = []
+    faces = []
+    face_groups = []
+    current_group = "default"
+    vertex_to_uv = {}
+    texcoords = []
+    line_count = 0
+
+    with open(file_path, "r", encoding="utf-8") as handle:
+        for line in handle:
+            line_count += 1
+            if line.startswith("v "):
+                parts = line.strip().split()
+                vertices.append([float(parts[1]), float(parts[2]), float(parts[3])])
+            elif line.startswith("vt "):
+                parts = line.strip().split()
+                texcoords.append([float(parts[1]), float(parts[2])])
+            elif line.startswith("g "):
+                parts = line.strip().split()
+                current_group = parts[1] if len(parts) > 1 else "default"
+            elif line.startswith("f "):
+                parts = line.strip().split()
+                face_indices = []
+                for item in parts[1:]:
+                    components = item.split("/")
+                    if not components[0]:
+                        continue
+                    vertex_index = int(components[0]) - 1
+                    face_indices.append(vertex_index)
+                    if len(components) > 1 and components[1]:
+                        uv_index = int(components[1]) - 1
+                        if 0 <= uv_index < len(texcoords):
+                            vertex_to_uv[vertex_index] = texcoords[uv_index]
+                faces.append(face_indices)
+                face_groups.append(current_group)
+
+            if line_count % checkpoint_lines == 0:
+                await _vnccs_async_checkpoint()
+
+    vertex_uvs = np.zeros((len(vertices), 2), dtype=np.float32)
+    for vertex_index, uv in vertex_to_uv.items():
+        if vertex_index < len(vertex_uvs):
+            vertex_uvs[vertex_index] = uv
+
+    mesh = Mesh(np.array(vertices, dtype=np.float32), faces, face_groups)
+    mesh.vertex_uvs = vertex_uvs
+    return mesh
+
+async def _vnccs_load_target_data_async(target_entry, checkpoint_lines=1200):
+    if target_entry.get("data") is not None:
+        return target_entry["data"]
+
+    indices = []
+    deltas = []
+    line_count = 0
+
+    try:
+        with open(target_entry["path"], "r", encoding="utf-8") as handle:
+            for line in handle:
+                line_count += 1
+                line = line.strip()
+                if not line or line.startswith("#"):
+                    continue
+
+                parts = line.split()
+                if len(parts) == 4:
+                    try:
+                        indices.append(int(parts[0]))
+                        deltas.append([float(parts[1]), float(parts[2]), float(parts[3])])
+                    except ValueError:
+                        pass
+
+                if line_count % checkpoint_lines == 0:
+                    await _vnccs_async_checkpoint()
+    except Exception as exc:
+        print(f"Error reading {target_entry['path']}: {exc}")
+        return None
+
+    if not indices:
+        return None
+
+    data = (np.array(indices, dtype=np.int32), np.array(deltas, dtype=np.float32))
+    target_entry["data"] = data
+    return data
+
+async def _vnccs_scan_targets_async(parser):
+    base_folders = ["macrodetails", "breast", "genitals"]
+    all_targets = []
+
+    for folder in base_folders:
+        base_path = os.path.join(parser.makehuman_path, "makehuman", "data", "targets", folder)
+        if not os.path.exists(base_path):
+            base_path = os.path.join(parser.makehuman_path, "data", "targets", folder)
+            if not os.path.exists(base_path):
+                continue
+
+        for root, _dirs, files in os.walk(base_path):
+            for file_name in files:
+                if not file_name.endswith(".target"):
+                    continue
+
+                tags = parser._parse_filename(file_name)
+                keep = False
+                if folder == "macrodetails":
+                    keep = len(tags) > 0
+                elif folder == "breast":
+                    keep = "cup" in tags
+                elif folder == "genitals":
+                    keep = any(key.startswith("penis") for key in tags)
+                if not keep:
+                    continue
+
+                target_entry = {
+                    "path": os.path.join(root, file_name),
+                    "tags": tags,
+                    "data": None,
+                    "filename": file_name.replace(".target", ""),
+                }
+                await _vnccs_load_target_data_async(target_entry)
+                all_targets.append(target_entry)
+                if len(all_targets) % 8 == 0:
+                    await _vnccs_async_checkpoint()
+
+    parser.macro_targets = all_targets
+    return all_targets
 
 def _vnccs_content_length_ok(request, max_bytes):
     try:
@@ -75,6 +211,280 @@ def _vnccs_validate_capture_payload(data):
     lighting_prompts = [str(prompt)[:4096] for prompt in lighting_prompts[:_CAPTURE_CACHE_MAX_IMAGES]]
     return captured_images, lighting_prompts
 
+async def _vnccs_ensure_pose_data_loaded_async():
+    from .CharacterData.mh_parser import TargetParser
+    from .CharacterData.mh_skeleton import Skeleton
+    from .nodes.pose_studio import POSE_STUDIO_CACHE, _get_character_data_path
+
+    if POSE_STUDIO_CACHE.get("base_mesh") is not None:
+        return
+
+    global _VNCCS_DATA_LOAD_LOCK
+    if _VNCCS_DATA_LOAD_LOCK is None:
+        _VNCCS_DATA_LOAD_LOCK = asyncio.Lock()
+
+    async with _VNCCS_DATA_LOAD_LOCK:
+        if POSE_STUDIO_CACHE.get("base_mesh") is not None:
+            return
+
+        char_data_path = _get_character_data_path()
+        mh_path = os.path.join(char_data_path, "makehuman")
+        if not os.path.exists(mh_path):
+            raise RuntimeError(f"MakeHuman data not found at: {mh_path}")
+
+        print(f"[VNCCS Pose Studio] Loading MakeHuman data from {mh_path}...")
+
+        base_obj_paths = [
+            os.path.join(mh_path, "makehuman", "data", "3dobjs", "base.obj"),
+            os.path.join(mh_path, "data", "3dobjs", "base.obj"),
+        ]
+        base_path = next((path for path in base_obj_paths if os.path.exists(path)), None)
+        if not base_path:
+            raise RuntimeError("Could not find base.obj inside makehuman data.")
+
+        base_mesh = await _vnccs_load_obj_async(base_path)
+        await _vnccs_async_checkpoint()
+
+        parser = TargetParser(mh_path)
+        targets = await _vnccs_scan_targets_async(parser)
+        print(f"[VNCCS Pose Studio] Loaded {len(targets)} targets.")
+        await _vnccs_async_checkpoint()
+
+        skeleton = None
+        skel_path = os.path.join(mh_path, "makehuman", "data", "rigs", "game_engine.mhskel")
+        if not os.path.exists(skel_path):
+            skel_path = os.path.join(mh_path, "makehuman", "data", "rigs", "default.mhskel")
+
+        if os.path.exists(skel_path):
+            print(f"[VNCCS Pose Studio] Loading skeleton from {skel_path}...")
+            skeleton = Skeleton()
+            await asyncio.to_thread(skeleton.fromFile, skel_path, base_mesh)
+        else:
+            print(f"[VNCCS Pose Studio] Warning: Default skeleton not found at {skel_path}")
+
+        POSE_STUDIO_CACHE.update({
+            "base_mesh": base_mesh,
+            "targets": targets,
+            "parser": parser,
+            "skeleton": skeleton,
+        })
+
+def _vnccs_build_update_preview_payload(data):
+    age = float(data.get('age', 25.0))
+    gender = float(data.get('gender', 0.5))
+    weight = float(data.get('weight', 0.5))
+    muscle = float(data.get('muscle', 0.5))
+    height = float(data.get('height', 0.5))
+    breast_size = float(data.get('breast_size', 0.5))
+    firmness = float(data.get('firmness', 0.5))
+    penis_len = float(data.get('penis_len', 0.5))
+    penis_circ = float(data.get('penis_circ', 0.5))
+    penis_test = float(data.get('penis_test', 0.5))
+
+    from .CharacterData.mh_parser import HumanSolver
+    from .nodes.pose_studio import POSE_STUDIO_CACHE
+
+    mh_age = (age - 1.0) / (90.0 - 1.0)
+    mh_age = max(0.0, min(1.0, mh_age))
+
+    if POSE_STUDIO_CACHE.get("base_mesh") is None:
+        raise RuntimeError("Pose Studio data is not loaded")
+
+    solver = HumanSolver()
+    factors = solver.calculate_factors(mh_age, gender, weight, muscle, height, breast_size, firmness, penis_len, penis_circ, penis_test)
+    new_verts = solver.solve_mesh(POSE_STUDIO_CACHE['base_mesh'], POSE_STUDIO_CACHE['targets'], factors)
+
+    skel = POSE_STUDIO_CACHE.get('skeleton')
+    base_mesh = POSE_STUDIO_CACHE['base_mesh']
+    valid_prefixes = ["body", "helper-r-eye", "helper-l-eye", "helper-upper-teeth", "helper-lower-teeth", "helper-tongue", "helper-genital"]
+
+    valid_faces = []
+    if base_mesh.face_groups:
+        for i, group in enumerate(base_mesh.face_groups):
+            g_clean = group.strip()
+            is_valid = g_clean in valid_prefixes
+            if g_clean.startswith("joint-"): is_valid = False
+            if g_clean in ["helper-skirt", "helper-tights", "helper-hair"]: is_valid = False
+            if g_clean == "helper-genital" and gender < 0.99: is_valid = False
+            if is_valid:
+                valid_faces.append(base_mesh.faces[i])
+
+    tri_indices = []
+    for face in valid_faces:
+        v_indices = []
+        for item in face:
+            if isinstance(item, (list, tuple)):
+                v_indices.append(item[0])
+            else:
+                v_indices.append(item)
+
+        if len(v_indices) == 3:
+            tri_indices.extend([v_indices[0], v_indices[1], v_indices[2]])
+        elif len(v_indices) == 4:
+            tri_indices.extend([v_indices[0], v_indices[1], v_indices[2]])
+            tri_indices.extend([v_indices[0], v_indices[2], v_indices[3]])
+
+    bones_data = []
+    weights_for_frontend = {}
+    landmarks_for_frontend = {}
+    landmark_indices_for_frontend = {}
+
+    def average_vertices(indices):
+        valid = [int(index) for index in indices if 0 <= int(index) < len(new_verts)]
+        if not valid:
+            return None
+        point = new_verts[valid].mean(axis=0)
+        return point.tolist() if hasattr(point, "tolist") else list(point)
+
+    def set_landmark_from_indices(name, indices):
+        valid = sorted({int(index) for index in indices if 0 <= int(index) < len(new_verts)})
+        point = average_vertices(valid)
+        if point is None:
+            return None
+        landmarks_for_frontend[name] = point
+        landmark_indices_for_frontend[name] = valid
+        return point
+
+    def group_vertex_indices(group_names):
+        names = set(group_names if isinstance(group_names, (list, tuple, set)) else [group_names])
+        result = set()
+        if not base_mesh.face_groups:
+            return result
+        for face, group in zip(base_mesh.faces, base_mesh.face_groups):
+            if str(group).strip() not in names:
+                continue
+            for item in face:
+                result.add(int(item[0] if isinstance(item, (list, tuple)) else item))
+        return result
+
+    def set_landmark_from_group(name, group_names):
+        return set_landmark_from_indices(name, group_vertex_indices(group_names))
+
+    def surface_nose_point():
+        body_indices = sorted(group_vertex_indices("body"))
+        if not body_indices:
+            return None
+        points = new_verts[body_indices]
+        if points.size == 0:
+            return None
+
+        left_eye = landmarks_for_frontend.get("left_eye")
+        right_eye = landmarks_for_frontend.get("right_eye")
+        if left_eye and right_eye:
+            eye_mid = (np.asarray(left_eye, dtype=np.float32) + np.asarray(right_eye, dtype=np.float32)) * 0.5
+            eye_span = float(abs(left_eye[0] - right_eye[0]))
+            x_limit = max(0.18, eye_span * 0.45)
+            mask = (
+                (np.abs(points[:, 0] - eye_mid[0]) <= x_limit)
+                & (points[:, 1] >= eye_mid[1] - 0.65)
+                & (points[:, 1] <= eye_mid[1] - 0.03)
+            )
+        else:
+            mask = (
+                (np.abs(points[:, 0]) <= 0.25)
+                & (points[:, 1] >= 6.4)
+                & (points[:, 1] <= 7.4)
+            )
+
+        candidates = points[mask]
+        if len(candidates) == 0:
+            candidates = points[
+                (np.abs(points[:, 0]) <= 0.35)
+                & (points[:, 1] >= 6.4)
+                & (points[:, 1] <= 7.4)
+            ]
+        if len(candidates) == 0:
+            return None
+        selected = candidates[np.argmax(candidates[:, 2])]
+        distances = np.linalg.norm(points - selected, axis=1)
+        nearest_order = np.argsort(distances)[:12]
+        selected_indices = [body_indices[int(i)] for i in nearest_order]
+        return set_landmark_from_indices("nose", selected_indices)
+
+    def average_joint(joints_data, name):
+        indices = joints_data.get(name) if isinstance(joints_data, dict) else None
+        if not indices:
+            return None
+        valid = [int(index) for index in indices if 0 <= int(index) < len(new_verts)]
+        if not valid:
+            return None
+        point = new_verts[valid].mean(axis=0)
+        return point.tolist() if hasattr(point, "tolist") else list(point)
+
+    try:
+        set_landmark_from_group("left_eye", "helper-l-eye")
+        set_landmark_from_group("right_eye", "helper-r-eye")
+        surface_nose_point()
+
+        char_data_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "CharacterData"))
+        mh_path = os.path.join(char_data_path, "makehuman")
+        default_skel_path = os.path.join(mh_path, "makehuman", "data", "rigs", "default.mhskel")
+        if os.path.exists(default_skel_path):
+            with open(default_skel_path, "r", encoding="utf-8") as f:
+                default_skel_data = json.load(f)
+            default_joints = default_skel_data.get("joints", {})
+            landmark_sources = {
+                "left_eye": "eye.L____head",
+                "left_eye_front": "eye.L____tail",
+                "right_eye": "eye.R____head",
+                "right_eye_front": "eye.R____tail",
+                "nose": "special01____tail",
+                "mouth": "oris05____head",
+                "jaw": "jaw____head",
+                "head": "head____tail",
+            }
+            for landmark_name, joint_name in landmark_sources.items():
+                if landmark_name in landmarks_for_frontend:
+                    continue
+                point = average_joint(default_joints, joint_name)
+                if point is not None:
+                    landmarks_for_frontend[landmark_name] = point
+    except Exception as exc:
+        print(f"[VNCCS] Failed to build MH face landmarks: {exc}")
+
+    if skel:
+        class MeshWrapper:
+            def __init__(self, verts):
+                self.vertices = verts
+        mesh_wrapper = MeshWrapper(new_verts)
+        skel.updateJointPositions(mesh_wrapper)
+
+        for bone in skel.getBones():
+            headPos = bone.headPos.tolist() if hasattr(bone.headPos, 'tolist') else list(bone.headPos)
+            tailPos = bone.tailPos.tolist() if hasattr(bone.tailPos, 'tolist') else list(bone.tailPos)
+
+            restMatrix = None
+            if bone.matRestGlobal is not None:
+                restMatrix = bone.matRestGlobal.flatten().tolist()
+
+            bones_data.append({
+                "name": bone.name,
+                "headPos": headPos,
+                "tailPos": tailPos,
+                "parent": bone.parent.name if bone.parent else None,
+                "length": float(bone.length) if hasattr(bone, 'length') else 0.0,
+                "restMatrix": restMatrix
+            })
+
+        if skel.vertexWeights:
+            for bone_name, (indices, w_vals) in skel.vertexWeights.data.items():
+                weights_for_frontend[bone_name] = {
+                    "indices": indices.tolist() if hasattr(indices, 'tolist') else list(indices),
+                    "weights": w_vals.tolist() if hasattr(w_vals, 'tolist') else list(w_vals)
+                }
+
+    return {
+        "status": "success",
+        "vertices": new_verts.flatten().tolist(),
+        "uvs": base_mesh.vertex_uvs.flatten().tolist() if hasattr(base_mesh, 'vertex_uvs') else [],
+        "indices": tri_indices,
+        "normals": [],
+        "bones": bones_data,
+        "weights": weights_for_frontend,
+        "landmarks": landmarks_for_frontend,
+        "landmark_indices": landmark_indices_for_frontend
+    }
+
 def _vnccs_register_endpoint():
     """Lazy registration to avoid import errors in analysis tools."""
     try:
@@ -86,240 +496,15 @@ def _vnccs_register_endpoint():
     @PromptServer.instance.routes.post("/vnccs/character_studio/update_preview")
     async def vnccs_character_studio_update_preview(request):
         try:
+            global _VNCCS_PREVIEW_LOCK
             if not _vnccs_content_length_ok(request, 1024 * 1024):
                 return web.json_response({"error": "Request body is too large"}, status=413)
             data = await request.json()
-            
-            # Extract params
-            age = float(data.get('age', 25.0))
-            gender = float(data.get('gender', 0.5))
-            weight = float(data.get('weight', 0.5))
-            muscle = float(data.get('muscle', 0.5))
-            height = float(data.get('height', 0.5))
-            breast_size = float(data.get('breast_size', 0.5))
-            breast_size = float(data.get('breast_size', 0.5))
-            firmness = float(data.get('firmness', 0.5))
-            penis_len = float(data.get('penis_len', 0.5))
-            penis_circ = float(data.get('penis_circ', 0.5))
-            penis_test = float(data.get('penis_test', 0.5))
-            
-            # Import from CharacterData
-            from .CharacterData.mh_parser import HumanSolver
-            from .CharacterData import matrix
-            from .nodes.pose_studio import POSE_STUDIO_CACHE, _ensure_data_loaded
-            
-            # Normalize age
-            mh_age = (age - 1.0) / (90.0 - 1.0)
-            mh_age = max(0.0, min(1.0, mh_age))
-            
-            # Ensure data loaded
-            _ensure_data_loaded()
-            
-            # Solve mesh
-            solver = HumanSolver()
-            factors = solver.calculate_factors(mh_age, gender, weight, muscle, height, breast_size, firmness, penis_len, penis_circ, penis_test)
-            new_verts = solver.solve_mesh(POSE_STUDIO_CACHE['base_mesh'], POSE_STUDIO_CACHE['targets'], factors)
-            
-            # Get skeleton
-            skel = POSE_STUDIO_CACHE.get('skeleton')
-            
-            # Filter faces and return
-            base_mesh = POSE_STUDIO_CACHE['base_mesh']
-            valid_prefixes = ["body", "helper-r-eye", "helper-l-eye", "helper-upper-teeth", "helper-lower-teeth", "helper-tongue", "helper-genital"]
-            
-            valid_faces = []
-            if base_mesh.face_groups:
-                for i, group in enumerate(base_mesh.face_groups):
-                    g_clean = group.strip()
-                    is_valid = g_clean in valid_prefixes
-                    if g_clean.startswith("joint-"): is_valid = False
-                    if g_clean in ["helper-skirt", "helper-tights", "helper-hair"]: is_valid = False
-                    if g_clean == "helper-genital" and gender < 0.99: is_valid = False
-                    
-                    if is_valid:
-                        valid_faces.append(base_mesh.faces[i])
-            
-            # Convert quads to triangles
-            tri_indices = []
-            for face in valid_faces:
-                v_indices = []
-                for item in face:
-                    if isinstance(item, (list, tuple)):
-                        v_indices.append(item[0])
-                    else:
-                        v_indices.append(item)
-                
-                if len(v_indices) == 3:
-                    tri_indices.extend([v_indices[0], v_indices[1], v_indices[2]])
-                elif len(v_indices) == 4:
-                    tri_indices.extend([v_indices[0], v_indices[1], v_indices[2]])
-                    tri_indices.extend([v_indices[0], v_indices[2], v_indices[3]])
-            
-            # Extract Bones Data
-            bones_data = []
-            weights_for_frontend = {}
-            landmarks_for_frontend = {}
-            landmark_indices_for_frontend = {}
-
-            def average_vertices(indices):
-                valid = [int(index) for index in indices if 0 <= int(index) < len(new_verts)]
-                if not valid:
-                    return None
-                point = new_verts[valid].mean(axis=0)
-                return point.tolist() if hasattr(point, "tolist") else list(point)
-
-            def set_landmark_from_indices(name, indices):
-                valid = sorted({int(index) for index in indices if 0 <= int(index) < len(new_verts)})
-                point = average_vertices(valid)
-                if point is None:
-                    return None
-                landmarks_for_frontend[name] = point
-                landmark_indices_for_frontend[name] = valid
-                return point
-
-            def group_vertex_indices(group_names):
-                names = set(group_names if isinstance(group_names, (list, tuple, set)) else [group_names])
-                result = set()
-                if not base_mesh.face_groups:
-                    return result
-                for face, group in zip(base_mesh.faces, base_mesh.face_groups):
-                    if str(group).strip() not in names:
-                        continue
-                    for item in face:
-                        result.add(int(item[0] if isinstance(item, (list, tuple)) else item))
-                return result
-
-            def average_group(group_names):
-                return average_vertices(group_vertex_indices(group_names))
-
-            def set_landmark_from_group(name, group_names):
-                return set_landmark_from_indices(name, group_vertex_indices(group_names))
-
-            def surface_nose_point():
-                body_indices = sorted(group_vertex_indices("body"))
-                if not body_indices:
-                    return None
-                points = new_verts[body_indices]
-                if points.size == 0:
-                    return None
-
-                left_eye = landmarks_for_frontend.get("left_eye")
-                right_eye = landmarks_for_frontend.get("right_eye")
-                if left_eye and right_eye:
-                    eye_mid = (np.asarray(left_eye, dtype=np.float32) + np.asarray(right_eye, dtype=np.float32)) * 0.5
-                    eye_span = float(abs(left_eye[0] - right_eye[0]))
-                    x_limit = max(0.18, eye_span * 0.45)
-                    mask = (
-                        (np.abs(points[:, 0] - eye_mid[0]) <= x_limit)
-                        & (points[:, 1] >= eye_mid[1] - 0.65)
-                        & (points[:, 1] <= eye_mid[1] - 0.03)
-                    )
-                else:
-                    mask = (
-                        (np.abs(points[:, 0]) <= 0.25)
-                        & (points[:, 1] >= 6.4)
-                        & (points[:, 1] <= 7.4)
-                    )
-
-                candidates = points[mask]
-                if len(candidates) == 0:
-                    candidates = points[
-                        (np.abs(points[:, 0]) <= 0.35)
-                        & (points[:, 1] >= 6.4)
-                        & (points[:, 1] <= 7.4)
-                    ]
-                if len(candidates) == 0:
-                    return None
-                selected = candidates[np.argmax(candidates[:, 2])]
-                distances = np.linalg.norm(points - selected, axis=1)
-                nearest_order = np.argsort(distances)[:12]
-                selected_indices = [body_indices[int(i)] for i in nearest_order]
-                return set_landmark_from_indices("nose", selected_indices)
-
-            def average_joint(joints_data, name):
-                indices = joints_data.get(name) if isinstance(joints_data, dict) else None
-                if not indices:
-                    return None
-                valid = [int(index) for index in indices if 0 <= int(index) < len(new_verts)]
-                if not valid:
-                    return None
-                point = new_verts[valid].mean(axis=0)
-                return point.tolist() if hasattr(point, "tolist") else list(point)
-
-            try:
-                set_landmark_from_group("left_eye", "helper-l-eye")
-                set_landmark_from_group("right_eye", "helper-r-eye")
-                surface_nose_point()
-
-                char_data_path = os.path.abspath(os.path.join(os.path.dirname(__file__), "CharacterData"))
-                mh_path = os.path.join(char_data_path, "makehuman")
-                default_skel_path = os.path.join(mh_path, "makehuman", "data", "rigs", "default.mhskel")
-                if os.path.exists(default_skel_path):
-                    with open(default_skel_path, "r", encoding="utf-8") as f:
-                        default_skel_data = json.load(f)
-                    default_joints = default_skel_data.get("joints", {})
-                    landmark_sources = {
-                        "left_eye": "eye.L____head",
-                        "left_eye_front": "eye.L____tail",
-                        "right_eye": "eye.R____head",
-                        "right_eye_front": "eye.R____tail",
-                        "nose": "special01____tail",
-                        "mouth": "oris05____head",
-                        "jaw": "jaw____head",
-                        "head": "head____tail",
-                    }
-                    for landmark_name, joint_name in landmark_sources.items():
-                        if landmark_name in landmarks_for_frontend:
-                            continue
-                        point = average_joint(default_joints, joint_name)
-                        if point is not None:
-                            landmarks_for_frontend[landmark_name] = point
-            except Exception as exc:
-                print(f"[VNCCS] Failed to build MH face landmarks: {exc}")
-            
-            if skel:
-                class MeshWrapper:
-                    def __init__(self, verts):
-                        self.vertices = verts
-                mesh_wrapper = MeshWrapper(new_verts)
-                skel.updateJointPositions(mesh_wrapper)
-
-                for bone in skel.getBones():
-                    headPos = bone.headPos.tolist() if hasattr(bone.headPos, 'tolist') else list(bone.headPos)
-                    tailPos = bone.tailPos.tolist() if hasattr(bone.tailPos, 'tolist') else list(bone.tailPos)
-                    
-                    restMatrix = None
-                    if bone.matRestGlobal is not None:
-                        restMatrix = bone.matRestGlobal.flatten().tolist()
-                    
-                    bones_data.append({
-                        "name": bone.name,
-                        "headPos": headPos,
-                        "tailPos": tailPos,
-                        "parent": bone.parent.name if bone.parent else None,
-                        "length": float(bone.length) if hasattr(bone, 'length') else 0.0,
-                        "restMatrix": restMatrix
-                    })
-                
-                # Prepare weights for frontend skinning
-                if skel.vertexWeights:
-                    for bone_name, (indices, w_vals) in skel.vertexWeights.data.items():
-                        weights_for_frontend[bone_name] = {
-                            "indices": indices.tolist() if hasattr(indices, 'tolist') else list(indices),
-                            "weights": w_vals.tolist() if hasattr(w_vals, 'tolist') else list(w_vals)
-                        }
-
-            return web.json_response({
-                "status": "success",
-                "vertices": new_verts.flatten().tolist(),
-                "uvs": base_mesh.vertex_uvs.flatten().tolist() if hasattr(base_mesh, 'vertex_uvs') else [],
-                "indices": tri_indices,
-                "normals": [],
-                "bones": bones_data,
-                "weights": weights_for_frontend,
-                "landmarks": landmarks_for_frontend,
-                "landmark_indices": landmark_indices_for_frontend
-            })
+            if _VNCCS_PREVIEW_LOCK is None:
+                _VNCCS_PREVIEW_LOCK = asyncio.Lock()
+            async with _VNCCS_PREVIEW_LOCK:
+                await _vnccs_ensure_pose_data_loaded_async()
+                return web.json_response(await asyncio.to_thread(_vnccs_build_update_preview_payload, data))
         except Exception as e:
             import traceback
             traceback.print_exc()
@@ -328,79 +513,83 @@ def _vnccs_register_endpoint():
     @PromptServer.instance.routes.get("/vnccs/character_studio/morph_data.bin")
     async def vnccs_character_studio_morph_data(request):
         try:
-            global _VNCCS_MORPH_DATA_BINARY
+            global _VNCCS_MORPH_DATA_BINARY, _VNCCS_MORPH_DATA_LOCK
             if _VNCCS_MORPH_DATA_BINARY is None:
-                from .nodes.pose_studio import POSE_STUDIO_CACHE, _ensure_data_loaded
+                if _VNCCS_MORPH_DATA_LOCK is None:
+                    _VNCCS_MORPH_DATA_LOCK = asyncio.Lock()
+                async with _VNCCS_MORPH_DATA_LOCK:
+                    if _VNCCS_MORPH_DATA_BINARY is None:
+                        from .nodes.pose_studio import POSE_STUDIO_CACHE
 
-                _ensure_data_loaded()
-                base_mesh = POSE_STUDIO_CACHE["base_mesh"]
-                targets = POSE_STUDIO_CACHE["targets"] or []
+                        await _vnccs_ensure_pose_data_loaded_async()
+                        base_mesh = POSE_STUDIO_CACHE["base_mesh"]
+                        targets = POSE_STUDIO_CACHE["targets"] or []
 
-                buffers = []
-                header = {
-                    "version": 1,
-                    "vertex_count": int(len(base_mesh.vertices)),
-                    "base_vertices": {"offset": 0, "length": int(base_mesh.vertices.size)},
-                    "targets": [],
-                    "joints": {},
-                    "bones": [],
-                }
-
-                offset = 0
-                base_vertices = np.asarray(base_mesh.vertices, dtype="<f4")
-                base_bytes = base_vertices.tobytes(order="C")
-                buffers.append(base_bytes)
-                offset += len(base_bytes)
-
-                for target in targets:
-                    data = target.get("data")
-                    if data is None:
-                        continue
-                    indices, deltas = data
-                    indices = np.asarray(indices, dtype="<u4")
-                    deltas = np.asarray(deltas, dtype="<f4").reshape(-1, 3)
-                    if len(indices) == 0 or len(deltas) != len(indices):
-                        continue
-
-                    indices_bytes = indices.tobytes(order="C")
-                    deltas_bytes = deltas.tobytes(order="C")
-                    target_header = {
-                        "tags": target.get("tags", {}),
-                        "count": int(len(indices)),
-                        "indices": {"offset": offset, "length": int(len(indices))},
-                    }
-                    buffers.append(indices_bytes)
-                    offset += len(indices_bytes)
-                    target_header["deltas"] = {"offset": offset, "length": int(deltas.size)}
-                    buffers.append(deltas_bytes)
-                    offset += len(deltas_bytes)
-                    header["targets"].append(target_header)
-
-                skeleton = POSE_STUDIO_CACHE.get("skeleton")
-                if skeleton:
-                    header["joints"] = {
-                        name: [int(index) for index in indices]
-                        for name, indices in skeleton.joint_pos_idxs.items()
-                    }
-                    header["bones"] = [
-                        {
-                            "name": bone.name,
-                            "parent": bone.parent.name if bone.parent else None,
-                            "head_joint": bone.headJoint,
-                            "tail_joint": bone.tailJoint,
+                        buffers = []
+                        header = {
+                            "version": 1,
+                            "vertex_count": int(len(base_mesh.vertices)),
+                            "base_vertices": {"offset": 0, "length": int(base_mesh.vertices.size)},
+                            "targets": [],
+                            "joints": {},
+                            "bones": [],
                         }
-                        for bone in skeleton.getBones()
-                    ]
 
-                header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
-                header_padding = b"\0" * ((4 - ((12 + len(header_bytes)) % 4)) % 4)
-                _VNCCS_MORPH_DATA_BINARY = (
-                    b"VNMORPH1"
-                    + struct.pack("<I", len(header_bytes))
-                    + header_bytes
-                    + header_padding
-                    + b"".join(buffers)
-                )
+                        offset = 0
+                        base_vertices = np.asarray(base_mesh.vertices, dtype="<f4")
+                        base_bytes = base_vertices.tobytes(order="C")
+                        buffers.append(base_bytes)
+                        offset += len(base_bytes)
+
+                        for target in targets:
+                            data = target.get("data")
+                            if data is None:
+                                continue
+                            indices, deltas = data
+                            indices = np.asarray(indices, dtype="<u4")
+                            deltas = np.asarray(deltas, dtype="<f4").reshape(-1, 3)
+                            if len(indices) == 0 or len(deltas) != len(indices):
+                                continue
+
+                            indices_bytes = indices.tobytes(order="C")
+                            deltas_bytes = deltas.tobytes(order="C")
+                            target_header = {
+                                "tags": target.get("tags", {}),
+                                "count": int(len(indices)),
+                                "indices": {"offset": offset, "length": int(len(indices))},
+                            }
+                            buffers.append(indices_bytes)
+                            offset += len(indices_bytes)
+                            target_header["deltas"] = {"offset": offset, "length": int(deltas.size)}
+                            buffers.append(deltas_bytes)
+                            offset += len(deltas_bytes)
+                            header["targets"].append(target_header)
+
+                        skeleton = POSE_STUDIO_CACHE.get("skeleton")
+                        if skeleton:
+                            header["joints"] = {
+                                name: [int(index) for index in indices]
+                                for name, indices in skeleton.joint_pos_idxs.items()
+                            }
+                            header["bones"] = [
+                                {
+                                    "name": bone.name,
+                                    "parent": bone.parent.name if bone.parent else None,
+                                    "head_joint": bone.headJoint,
+                                    "tail_joint": bone.tailJoint,
+                                }
+                                for bone in skeleton.getBones()
+                            ]
+
+                        header_bytes = json.dumps(header, separators=(",", ":")).encode("utf-8")
+                        header_padding = b"\0" * ((4 - ((12 + len(header_bytes)) % 4)) % 4)
+                        _VNCCS_MORPH_DATA_BINARY = (
+                            b"VNMORPH1"
+                            + struct.pack("<I", len(header_bytes))
+                            + header_bytes
+                            + header_padding
+                            + b"".join(buffers)
+                        )
 
             return web.Response(
                 body=_VNCCS_MORPH_DATA_BINARY,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs-utils"
 description = "VNCCS - Collection of utility nodes. VNCCS Visual Camera Control for Qwen-Image-Edit-2511-Multiple-Angles LoRa. VNCCS QWEN Detailer - For spot corrections in images of any size. VNCCS Pose Studio - Combined mesh editor and multi-pose generator. "
-version = "0.4.28"
+version = "0.4.29"
 license = {file = "LICENSE"} 
 
 dependencies = [

--- a/web/vnccs_pose_morph_worker.js
+++ b/web/vnccs_pose_morph_worker.js
@@ -209,11 +209,11 @@ function solveMorph(data, params) {
 }
 
 self.onmessage = async (event) => {
-    const { type, seq, params } = event.data || {};
+    const { type, seq, params, clientId } = event.data || {};
     try {
         if (type === "warmup") {
             await loadMorphData();
-            self.postMessage({ type: "ready" });
+            self.postMessage({ type: "ready", clientId });
             return;
         }
         if (type !== "solve") return;
@@ -225,6 +225,7 @@ self.onmessage = async (event) => {
         self.postMessage({
             type: "result",
             seq,
+            clientId,
             vertices: result.vertices,
             bonePositions: result.bonePositions,
         }, transfers);
@@ -232,6 +233,7 @@ self.onmessage = async (event) => {
         self.postMessage({
             type: "error",
             seq,
+            clientId,
             message: error?.message || String(error),
         });
     }

--- a/web/vnccs_pose_morph_worker.js
+++ b/web/vnccs_pose_morph_worker.js
@@ -1,0 +1,238 @@
+const MORPH_URL = "/vnccs/character_studio/morph_data.bin";
+
+let morphDataPromise = null;
+let morphData = null;
+
+function readAscii(bytes, start, length) {
+    let text = "";
+    for (let i = 0; i < length; i++) text += String.fromCharCode(bytes[start + i]);
+    return text;
+}
+
+function factorMax(value) {
+    return Math.max(0.0, value * 2 - 1);
+}
+
+function factorMin(value) {
+    return Math.max(0.0, 1 - value * 2);
+}
+
+function calculateFactors(params) {
+    const ageInput = Number(params.age ?? 25);
+    const age = Math.max(0, Math.min(1, (ageInput - 1.0) / (90.0 - 1.0)));
+    const gender = Number(params.gender ?? 0.5);
+    const weight = Number(params.weight ?? 0.5);
+    const muscle = Number(params.muscle ?? 0.5);
+    const height = Number(params.height ?? 0.5);
+    const breastSize = Number(params.breast_size ?? 0.5);
+    const firmness = Number(params.firmness ?? 0.5);
+    const penisLen = Number(params.penis_len ?? params.genital_size ?? 0.5);
+    const penisCirc = Number(params.penis_circ ?? 0.5);
+    const penisTest = Number(params.penis_test ?? 0.5);
+
+    const factors = {
+        male: gender,
+        female: 1.0 - gender,
+        maxmuscle: factorMax(muscle),
+        minmuscle: factorMin(muscle),
+        maxweight: factorMax(weight),
+        minweight: factorMin(weight),
+        maxheight: factorMax(height),
+        minheight: factorMin(height),
+        african: 0.333,
+        asian: 0.333,
+        caucasian: 0.334,
+        maxcup: factorMax(breastSize),
+        mincup: factorMin(breastSize),
+        maxfirmness: factorMax(firmness),
+        minfirmness: factorMin(firmness),
+        "penis-length-incr": factorMax(penisLen),
+        "penis-length-decr": factorMin(penisLen),
+        "penis-circ-incr": factorMax(penisCirc),
+        "penis-circ-decr": factorMin(penisCirc),
+        "penis-testicles-incr": factorMax(penisTest),
+        "penis-testicles-decr": factorMin(penisTest),
+        universal: 1.0,
+    };
+
+    factors.averagemuscle = 1 - (factors.maxmuscle + factors.minmuscle);
+    factors.averageweight = 1 - (factors.maxweight + factors.minweight);
+    factors.averageheight = 1 - (factors.maxheight + factors.minheight);
+    factors.averagecup = 1 - (factors.maxcup + factors.mincup);
+    factors.averagefirmness = 1 - (factors.maxfirmness + factors.minfirmness);
+
+    if (age < 0.5) {
+        factors.old = 0.0;
+        factors.baby = Math.max(0.0, 1 - age * 5.333);
+        factors.young = Math.max(0.0, (age - 0.1875) * 3.2);
+        factors.child = Math.max(0.0, Math.min(1.0, 5.333 * age) - factors.young);
+    } else {
+        factors.child = 0.0;
+        factors.baby = 0.0;
+        factors.old = Math.max(0.0, age * 2 - 1);
+        factors.young = 1 - factors.old;
+    }
+
+    return factors;
+}
+
+function targetWeight(target, factors) {
+    let weight = 1.0;
+    for (const value of target.factorValues) {
+        weight *= factors[value] ?? 0.0;
+        if (weight < 0.001) return 0.0;
+    }
+    return weight;
+}
+
+async function loadMorphData() {
+    if (morphData) return morphData;
+    if (morphDataPromise) return morphDataPromise;
+
+    morphDataPromise = fetch(MORPH_URL).then(async (response) => {
+        if (!response.ok) throw new Error(`Failed to load morph data: ${response.status}`);
+        const buffer = await response.arrayBuffer();
+        const bytes = new Uint8Array(buffer);
+        const magic = readAscii(bytes, 0, 8);
+        if (magic !== "VNMORPH1") throw new Error("Invalid morph data header");
+
+        const view = new DataView(buffer);
+        const headerLength = view.getUint32(8, true);
+        const headerText = new TextDecoder().decode(bytes.subarray(12, 12 + headerLength));
+        const header = JSON.parse(headerText);
+        const dataOffset = 12 + headerLength + ((4 - ((12 + headerLength) % 4)) % 4);
+
+        const baseInfo = header.base_vertices;
+        const baseVertices = new Float32Array(
+            buffer,
+            dataOffset + baseInfo.offset,
+            baseInfo.length
+        );
+
+        const targets = header.targets.map((target) => {
+            const factorValues = [];
+            for (const tagValue of Object.values(target.tags || {})) {
+                factorValues.push(tagValue === true ? "universal" : String(tagValue));
+            }
+            return {
+                factorValues,
+                count: target.count,
+                indices: new Uint32Array(buffer, dataOffset + target.indices.offset, target.indices.length),
+                deltas: new Float32Array(buffer, dataOffset + target.deltas.offset, target.deltas.length),
+            };
+        });
+
+        const joints = {};
+        for (const [name, indices] of Object.entries(header.joints || {})) {
+            joints[name] = new Uint32Array(indices);
+        }
+
+        morphData = {
+            baseVertices,
+            targets,
+            joints,
+            bones: Array.isArray(header.bones) ? header.bones : [],
+            vertexCount: header.vertex_count,
+        };
+        return morphData;
+    });
+
+    return morphDataPromise;
+}
+
+function averageJoint(vertices, indices, out, outOffset) {
+    if (!indices || indices.length === 0) {
+        out[outOffset] = 0;
+        out[outOffset + 1] = 0;
+        out[outOffset + 2] = 0;
+        return;
+    }
+
+    let x = 0;
+    let y = 0;
+    let z = 0;
+    let count = 0;
+    for (let i = 0; i < indices.length; i++) {
+        const vertexIndex = indices[i] * 3;
+        if (vertexIndex + 2 >= vertices.length) continue;
+        x += vertices[vertexIndex];
+        y += vertices[vertexIndex + 1];
+        z += vertices[vertexIndex + 2];
+        count++;
+    }
+
+    if (count <= 0) {
+        out[outOffset] = 0;
+        out[outOffset + 1] = 0;
+        out[outOffset + 2] = 0;
+        return;
+    }
+
+    out[outOffset] = x / count;
+    out[outOffset + 1] = y / count;
+    out[outOffset + 2] = z / count;
+}
+
+function solveBonePositions(data, vertices) {
+    if (!data.bones.length) return null;
+    const positions = new Float32Array(data.bones.length * 6);
+    for (let i = 0; i < data.bones.length; i++) {
+        const bone = data.bones[i];
+        averageJoint(vertices, data.joints[bone.head_joint], positions, i * 6);
+        averageJoint(vertices, data.joints[bone.tail_joint], positions, i * 6 + 3);
+    }
+    return positions;
+}
+
+function solveMorph(data, params) {
+    const factors = calculateFactors(params);
+    const vertices = new Float32Array(data.baseVertices);
+
+    for (const target of data.targets) {
+        const weight = targetWeight(target, factors);
+        if (weight <= 0) continue;
+        const indices = target.indices;
+        const deltas = target.deltas;
+        for (let i = 0; i < target.count; i++) {
+            const vertexOffset = indices[i] * 3;
+            const deltaOffset = i * 3;
+            vertices[vertexOffset] += deltas[deltaOffset] * weight;
+            vertices[vertexOffset + 1] += deltas[deltaOffset + 1] * weight;
+            vertices[vertexOffset + 2] += deltas[deltaOffset + 2] * weight;
+        }
+    }
+
+    return {
+        vertices,
+        bonePositions: solveBonePositions(data, vertices),
+    };
+}
+
+self.onmessage = async (event) => {
+    const { type, seq, params } = event.data || {};
+    try {
+        if (type === "warmup") {
+            await loadMorphData();
+            self.postMessage({ type: "ready" });
+            return;
+        }
+        if (type !== "solve") return;
+
+        const data = await loadMorphData();
+        const result = solveMorph(data, params || {});
+        const transfers = [result.vertices.buffer];
+        if (result.bonePositions) transfers.push(result.bonePositions.buffer);
+        self.postMessage({
+            type: "result",
+            seq,
+            vertices: result.vertices,
+            bonePositions: result.bonePositions,
+        }, transfers);
+    } catch (error) {
+        self.postMessage({
+            type: "error",
+            seq,
+            message: error?.message || String(error),
+        });
+    }
+};

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -12,6 +12,47 @@ import { importMixamoFBXAsPoses } from "./vnccs_mixamo_import.js";
 import { detectAndParseJSON, extractKeypointsFromImage, convertOpenPoseToPose, roundTripTest } from "./vnccs_openpose_import.js";
 
 const VNCCS_POSE_MORPH_WORKER_URL = new URL("./vnccs_pose_morph_worker.js", import.meta.url);
+let VNCCS_SHARED_MORPH_WORKER = null;
+let VNCCS_SHARED_MORPH_WORKER_FAILED = false;
+let VNCCS_SHARED_MORPH_WORKER_WARMED = false;
+let VNCCS_SHARED_MORPH_CLIENT_ID = 1;
+const VNCCS_SHARED_MORPH_CLIENTS = new Map();
+
+function getVNCCSSharedMorphWorker() {
+    if (VNCCS_SHARED_MORPH_WORKER_FAILED || typeof Worker === "undefined") return null;
+    if (VNCCS_SHARED_MORPH_WORKER) return VNCCS_SHARED_MORPH_WORKER;
+
+    try {
+        const worker = new Worker(VNCCS_POSE_MORPH_WORKER_URL, { type: "module" });
+        worker.onmessage = (event) => {
+            const message = event.data || {};
+            const handler = VNCCS_SHARED_MORPH_CLIENTS.get(message.clientId);
+            if (handler) {
+                handler(message);
+                return;
+            }
+            if (message.type === "error") {
+                for (const callback of VNCCS_SHARED_MORPH_CLIENTS.values()) callback(message);
+            }
+        };
+        worker.onerror = (event) => {
+            VNCCS_SHARED_MORPH_WORKER_FAILED = true;
+            console.warn("[VNCCS PoseStudio] Shared live morph worker error:", event.message || event);
+            for (const callback of VNCCS_SHARED_MORPH_CLIENTS.values()) {
+                callback({ type: "error", message: event.message || String(event) });
+            }
+            try { worker.terminate(); } catch (_) {}
+            VNCCS_SHARED_MORPH_WORKER = null;
+            VNCCS_SHARED_MORPH_WORKER_WARMED = false;
+        };
+        VNCCS_SHARED_MORPH_WORKER = worker;
+    } catch (error) {
+        VNCCS_SHARED_MORPH_WORKER_FAILED = true;
+        console.warn("[VNCCS PoseStudio] Shared live morph worker unavailable:", error);
+    }
+
+    return VNCCS_SHARED_MORPH_WORKER;
+}
 
 // Determine the extension's base URL dynamically to support varied directory names (e.g. ComfyUI_VNCCS_Utils or vnccs-utils)
 const EXTENSION_URL = new URL(".", import.meta.url).toString();
@@ -2751,6 +2792,8 @@ class PoseStudioWidget {
         this._morphSeq = 0;
         this._lastAppliedMorphSeq = 0;
         this._managerPreviewRefreshFrame = null;
+        this._managerPreviewRefreshGeneration = 0;
+        this._managerPreviewRefreshNextIndex = 0;
         this._samCamStoredProjectionFrame = null;
         this._hoveredHandSide = null;
         this._handPopover = null;
@@ -3951,7 +3994,9 @@ class PoseStudioWidget {
         });
         const img = new Image();
         img.onload = () => {
-            const callbacks = this.managerImageMetrics.get(src)?.callbacks || [];
+            const entry = this.managerImageMetrics.get(src);
+            if (!entry) return;
+            const callbacks = entry.callbacks || [];
             const metrics = {
                 width: img.naturalWidth || 1,
                 height: img.naturalHeight || 1,
@@ -3962,13 +4007,29 @@ class PoseStudioWidget {
             callbacks.forEach(callback => callback?.());
         };
         img.onerror = () => {
-            const callbacks = this.managerImageMetrics.get(src)?.callbacks || [];
+            const entry = this.managerImageMetrics.get(src);
+            if (!entry) return;
+            const callbacks = entry.callbacks || [];
             const metrics = fallback || { width: 1, height: 1, loading: false };
             this.managerImageMetrics.set(src, { ...metrics, loading: false });
             if (index >= 0) this.managerPoseMetrics[index] = metrics;
             callbacks.forEach(callback => callback?.());
         };
         img.src = src;
+    }
+
+    forgetPoseManagerImageMetrics(src) {
+        if (!src || !this.managerImageMetrics) return;
+        this.managerImageMetrics.delete(src);
+    }
+
+    setPoseCapture(index, capture) {
+        if (!this.poseCaptures) this.poseCaptures = [];
+        const previousCapture = this.poseCaptures[index];
+        if (previousCapture && previousCapture !== capture) {
+            this.forgetPoseManagerImageMetrics(previousCapture);
+        }
+        this.poseCaptures[index] = capture;
     }
 
     layoutPoseManager() {
@@ -4074,17 +4135,26 @@ class PoseStudioWidget {
         if (this.interfaceMode !== "manager" && this.interfaceMode !== "managerDetail") return;
         if (!this.viewer?.isInitialized?.()) return;
         if (!this.poses?.length) return;
-        if (this._managerPreviewRefreshFrame) return;
+        const isMidRefresh = Boolean(this._managerPreviewRefreshFrame) || (this._managerPreviewRefreshNextIndex || 0) > 0;
+        this._managerPreviewRefreshGeneration = (this._managerPreviewRefreshGeneration || 0) + 1;
+        this._managerPreviewRefreshNextIndex = isMidRefresh
+            ? (this._managerPreviewRefreshNextIndex || 0) % this.poses.length
+            : 0;
+        if (this._managerPreviewRefreshFrame) {
+            cancelAnimationFrame(this._managerPreviewRefreshFrame);
+        }
 
+        const generation = this._managerPreviewRefreshGeneration;
         this._managerPreviewRefreshFrame = requestAnimationFrame(() => {
             this._managerPreviewRefreshFrame = null;
-            this.refreshAllManagerPreviews();
+            this.refreshAllManagerPreviews(generation);
         });
     }
 
-    refreshAllManagerPreviews() {
+    refreshAllManagerPreviews(generation = this._managerPreviewRefreshGeneration) {
         if (this.interfaceMode !== "manager" && this.interfaceMode !== "managerDetail") return;
         if (!this.viewer?.isInitialized?.()) return;
+        if (generation !== this._managerPreviewRefreshGeneration) return;
 
         const originalPose = this.viewer.getPose();
         const originalLights = JSON.parse(JSON.stringify(this.lightParams || []));
@@ -4098,7 +4168,10 @@ class PoseStudioWidget {
         this.ensurePosePrompts();
 
         try {
-            for (let i = 0; i < this.poses.length; i++) {
+            const capturesPerFrame = 2;
+            const startIndex = Math.max(0, Math.min(this._managerPreviewRefreshNextIndex || 0, this.poses.length));
+            const endIndex = Math.min(this.poses.length, startIndex + capturesPerFrame);
+            for (let i = startIndex; i < endIndex; i++) {
                 const pose = this.poses[i] || {};
                 this.viewer.setPose(pose, true);
 
@@ -4115,16 +4188,28 @@ class PoseStudioWidget {
                     this.viewer.updateLights(this.lightParams);
                 }
 
-                this.poseCaptures[i] = this.viewer.capture(w, h, z, bg, oX, oY, yaw, pitch);
+                const nextCapture = this.viewer.capture(w, h, z, bg, oX, oY, yaw, pitch);
+                this.setPoseCapture(i, nextCapture);
                 this.lightingPrompts[i] = this.generatePromptFromLights(
                     isOriginalLighting ? [] : this.lightParams,
                     this.getPosePrompt(i)
                 );
                 this.updatePoseManagerPreviewImage(i);
             }
+            this._managerPreviewRefreshNextIndex = endIndex;
         } finally {
             this.viewer.setPose(originalPose, true);
             this.viewer.updateLights(originalLights);
+        }
+
+        if (generation !== this._managerPreviewRefreshGeneration) return;
+        if (this._managerPreviewRefreshNextIndex < this.poses.length) {
+            this._managerPreviewRefreshFrame = requestAnimationFrame(() => {
+                this._managerPreviewRefreshFrame = null;
+                this.refreshAllManagerPreviews(generation);
+            });
+        } else {
+            this._managerPreviewRefreshNextIndex = 0;
         }
     }
 
@@ -5664,7 +5749,11 @@ class PoseStudioWidget {
 
         // Remove capture
         if (this.poseCaptures && this.poseCaptures.length > idx) {
-            this.poseCaptures.splice(idx, 1);
+            const [removedCapture] = this.poseCaptures.splice(idx, 1);
+            this.forgetPoseManagerImageMetrics(removedCapture);
+        }
+        if (this.managerPoseMetrics && this.managerPoseMetrics.length > idx) {
+            this.managerPoseMetrics.splice(idx, 1);
         }
 
         this.poses.splice(idx, 1);
@@ -8044,36 +8133,33 @@ class PoseStudioWidget {
 
     ensureMorphWorker() {
         if (this._morphWorker || this._morphWorkerFailed) return this._morphWorker;
-        if (typeof Worker === "undefined") return null;
-
-        try {
-            const worker = new Worker(VNCCS_POSE_MORPH_WORKER_URL, { type: "module" });
-            worker.onmessage = (event) => {
-                const message = event.data || {};
-                if (message.type === "error") {
-                    console.warn("[VNCCS PoseStudio] Live morph worker failed:", message.message);
-                    this._morphWorkerFailed = true;
-                    return;
-                }
-                if (message.type !== "result") return;
-                if (message.seq < this._morphSeq || message.seq < this._lastAppliedMorphSeq) return;
-                if (!this.viewer?.updateBodyVertices?.(message.vertices, message.bonePositions)) return;
-                this._lastAppliedMorphSeq = message.seq;
-                this.scheduleAllManagerPreviewRefresh();
-            };
-            worker.onerror = (event) => {
-                console.warn("[VNCCS PoseStudio] Live morph worker error:", event.message || event);
-                this._morphWorkerFailed = true;
-                try { worker.terminate(); } catch (_) {}
-                if (this._morphWorker === worker) this._morphWorker = null;
-            };
-            worker.postMessage({ type: "warmup" });
-            this._morphWorker = worker;
-        } catch (error) {
-            console.warn("[VNCCS PoseStudio] Live morph worker unavailable:", error);
+        const worker = getVNCCSSharedMorphWorker();
+        if (!worker) {
             this._morphWorkerFailed = true;
+            return null;
         }
+
+        if (!this._morphClientId) this._morphClientId = VNCCS_SHARED_MORPH_CLIENT_ID++;
+        VNCCS_SHARED_MORPH_CLIENTS.set(this._morphClientId, (message) => this.handleMorphWorkerMessage(message));
+        if (!VNCCS_SHARED_MORPH_WORKER_WARMED) {
+            VNCCS_SHARED_MORPH_WORKER_WARMED = true;
+            worker.postMessage({ type: "warmup", clientId: this._morphClientId });
+        }
+        this._morphWorker = worker;
         return this._morphWorker;
+    }
+
+    handleMorphWorkerMessage(message) {
+        if (message.type === "error") {
+            console.warn("[VNCCS PoseStudio] Live morph worker failed:", message.message);
+            this._morphWorkerFailed = true;
+            return;
+        }
+        if (message.type !== "result") return;
+        if (message.seq < this._morphSeq || message.seq < this._lastAppliedMorphSeq) return;
+        if (!this.viewer?.updateBodyVertices?.(message.vertices, message.bonePositions)) return;
+        this._lastAppliedMorphSeq = message.seq;
+        this.scheduleAllManagerPreviewRefresh();
     }
 
     requestLiveMorph(changedKey = null) {
@@ -8084,6 +8170,7 @@ class PoseStudioWidget {
         worker.postMessage({
             type: "solve",
             seq,
+            clientId: this._morphClientId,
             params: { ...this.meshParams },
         });
         return true;
@@ -8914,7 +9001,7 @@ class PoseStudioWidget {
                         }
 
                         // Capture
-                        this.poseCaptures[i] = this.viewer.capture(w, h, debugParams.zoom, debugParams.bgColor, debugParams.offsetX, debugParams.offsetY);
+                        this.setPoseCapture(i, this.viewer.capture(w, h, debugParams.zoom, debugParams.bgColor, debugParams.offsetX, debugParams.offsetY));
 
                         // Prompt
                         const promptLights = isOriginalLighting ? [{ type: 'ambient', color: '#ffffff', intensity: 1.0 }] : (debugParams.lights || originalLights);
@@ -8936,7 +9023,7 @@ class PoseStudioWidget {
                             this.viewer.updateLights(this.lightParams);
                         }
 
-                        this.poseCaptures[i] = this.viewer.capture(w, h, z, bg, oX, oY, yaw, pitch);
+                        this.setPoseCapture(i, this.viewer.capture(w, h, z, bg, oX, oY, yaw, pitch));
                         this.lightingPrompts[i] = this.generatePromptFromLights(isOriginalLighting ? [] : this.lightParams, this.getPosePrompt(i));
                     }
                 }
@@ -8969,7 +9056,7 @@ class PoseStudioWidget {
                         this.viewer.updateLights(debugParams.lights);
                     }
 
-                    this.poseCaptures[this.activeTab] = this.viewer.capture(w, h, debugParams.zoom, debugParams.bgColor, debugParams.offsetX, debugParams.offsetY, 0, 0);
+                    this.setPoseCapture(this.activeTab, this.viewer.capture(w, h, debugParams.zoom, debugParams.bgColor, debugParams.offsetX, debugParams.offsetY, 0, 0));
 
                     const promptLights = isOriginalLighting ? [{ type: 'ambient', color: '#ffffff', intensity: 1.0 }] : (debugParams.lights || userLights);
                     this.lightingPrompts[this.activeTab] = this.generatePromptFromLights(promptLights, this.getPosePrompt(this.activeTab));
@@ -8996,7 +9083,7 @@ class PoseStudioWidget {
                         this.viewer.updateLights(this.lightParams);
                     }
 
-                    this.poseCaptures[this.activeTab] = this.viewer.capture(w, h, z, bg, oX, oY, yaw, pitch);
+                    this.setPoseCapture(this.activeTab, this.viewer.capture(w, h, z, bg, oX, oY, yaw, pitch));
                     this.lightingPrompts[this.activeTab] = this.generatePromptFromLights(isOriginalLighting ? [] : this.lightParams, this.getPosePrompt(this.activeTab));
 
                     if (isOriginalLighting) {
@@ -9589,7 +9676,14 @@ app.registerExtension({
                     cancelAnimationFrame(this.studioWidget._resizeRaf);
                 }
                 if (this.studioWidget._morphWorker) {
-                    try { this.studioWidget._morphWorker.terminate(); } catch (_) {}
+                    if (this.studioWidget._morphClientId) {
+                        VNCCS_SHARED_MORPH_CLIENTS.delete(this.studioWidget._morphClientId);
+                    }
+                    if (VNCCS_SHARED_MORPH_CLIENTS.size === 0 && VNCCS_SHARED_MORPH_WORKER) {
+                        try { VNCCS_SHARED_MORPH_WORKER.terminate(); } catch (_) {}
+                        VNCCS_SHARED_MORPH_WORKER = null;
+                        VNCCS_SHARED_MORPH_WORKER_WARMED = false;
+                    }
                     this.studioWidget._morphWorker = null;
                 }
                 if (this.studioWidget.viewer) {

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -11,6 +11,8 @@ import { HAND_PRESETS } from "./vnccs_hand_presets.js";
 import { importMixamoFBXAsPoses } from "./vnccs_mixamo_import.js";
 import { detectAndParseJSON, extractKeypointsFromImage, convertOpenPoseToPose, roundTripTest } from "./vnccs_openpose_import.js";
 
+const VNCCS_POSE_MORPH_WORKER_URL = new URL("./vnccs_pose_morph_worker.js", import.meta.url);
+
 // Determine the extension's base URL dynamically to support varied directory names (e.g. ComfyUI_VNCCS_Utils or vnccs-utils)
 const EXTENSION_URL = new URL(".", import.meta.url).toString();
 
@@ -2728,6 +2730,7 @@ class PoseStudioWidget {
         this.managerResizeObserver = null;
         this.managerBackBtn = null;
         this.managerImageMetrics = new Map();
+        this.managerPoseMetrics = [];
         this.managerLayoutFrame = null;
         this._defaultHandPresets = HAND_PRESETS;
         this._handSliderValues = { spread: 0, grasp: 0, thumb: 0, index: 0, middle: 0, ring: 0, pinky: 0 };
@@ -2743,6 +2746,11 @@ class PoseStudioWidget {
         this._samCamDisplayActive = true;
         this._samCamPreParams = null;
         this._samCamStoredParams = null;
+        this._morphWorker = null;
+        this._morphWorkerFailed = false;
+        this._morphSeq = 0;
+        this._lastAppliedMorphSeq = 0;
+        this._managerPreviewRefreshFrame = null;
         this._samCamStoredProjectionFrame = null;
         this._hoveredHandSide = null;
         this._handPopover = null;
@@ -2921,7 +2929,13 @@ class PoseStudioWidget {
         slider.addEventListener("input", () => {
             const next = this.normalizeManagerNumber(slider.value, def);
             slider.value = next;
-            this.applyManagerMeshValue(def.key, next);
+            this.applyManagerMeshValue(def.key, next, { liveOnly: this.isLiveMorphKey?.(def.key) === true });
+        });
+
+        slider.addEventListener("change", () => {
+            const next = this.normalizeManagerNumber(slider.value, def);
+            slider.value = next;
+            this.applyManagerMeshValue(def.key, next, { finalize: true });
         });
 
         labelRow.appendChild(label);
@@ -2978,7 +2992,7 @@ class PoseStudioWidget {
             : Number(value || 0).toFixed(2);
     }
 
-    applyManagerMeshValue(key, value) {
+    applyManagerMeshValue(key, value, options = {}) {
         this.meshParams[key] = value;
         const main = this.sliders?.[key];
         if (main) {
@@ -2986,6 +3000,10 @@ class PoseStudioWidget {
             main.label.innerText = this.formatManagerValue(key, value);
         }
         this.refreshPoseManagerControls();
+        if (options.liveOnly && this.isLiveMorphKey?.(key)) {
+            this.onMeshParamsChanged(key, { liveOnly: true });
+            return;
+        }
         this.onMeshParamsChanged(key);
         this.syncToNode(false, { skipCapture: true });
     }
@@ -3794,10 +3812,41 @@ class PoseStudioWidget {
         this.setInterfaceMode("managerDetail");
     }
 
+    updateExistingPoseManagerCards() {
+        if (!this.managerGrid || !this.poses.length) return false;
+        const cards = Array.from(this.managerGrid.children).filter(card => card.classList?.contains("vnccs-ps-pose-card"));
+        if (cards.length !== this.poses.length || cards.length !== this.managerGrid.children.length) return false;
+
+        for (let i = 0; i < cards.length; i++) {
+            const card = cards[i];
+            card.classList.toggle("active", i === this.activeTab);
+            card.dataset.poseIndex = String(i);
+            card.title = `Open Pose ${i + 1}`;
+
+            const name = card.querySelector(".vnccs-ps-pose-card-name");
+            if (name) name.textContent = `Pose ${i + 1}`;
+
+            const del = card.querySelector(".vnccs-ps-pose-card-delete");
+            if (del) {
+                del.title = `Delete Pose ${i + 1}`;
+                del.disabled = this.poses.length <= 1;
+            }
+
+            this.updatePoseManagerPreviewImage(i);
+        }
+        return true;
+    }
+
     renderPoseManager() {
         if (!this.managerGrid) return;
         this.refreshPoseManagerControls();
         this.ensurePosePrompts();
+
+        if (this.updateExistingPoseManagerCards()) {
+            this.schedulePoseManagerGridLayout();
+            return;
+        }
+
         this.managerGrid.innerHTML = "";
 
         if (!this.poses.length) {
@@ -3811,6 +3860,7 @@ class PoseStudioWidget {
         for (let i = 0; i < this.poses.length; i++) {
             const card = document.createElement("div");
             card.className = "vnccs-ps-pose-card" + (i === this.activeTab ? " active" : "");
+            card.dataset.poseIndex = String(i);
             card.tabIndex = 0;
             card.role = "button";
             card.title = `Open Pose ${i + 1}`;
@@ -3871,12 +3921,20 @@ class PoseStudioWidget {
             this.managerLayoutFrame = null;
             this.layoutPoseManager();
         });
-        for (const capture of this.poseCaptures || []) {
-            if (capture) this.ensurePoseManagerImageMetrics(capture, () => this.layoutPoseManager());
+        for (let i = 0; i < (this.poseCaptures || []).length; i++) {
+            const capture = this.poseCaptures[i];
+            const stableMetrics = this.managerPoseMetrics?.[i];
+            if (capture) {
+                this.ensurePoseManagerImageMetrics(
+                    capture,
+                    stableMetrics?.width && stableMetrics?.height ? null : () => this.layoutPoseManager(),
+                    i
+                );
+            }
         }
     }
 
-    ensurePoseManagerImageMetrics(src, onReady) {
+    ensurePoseManagerImageMetrics(src, onReady, index = -1) {
         const existing = this.managerImageMetrics.get(src);
         if (existing) {
             if (existing.loading && onReady) existing.callbacks.push(onReady);
@@ -3884,20 +3942,30 @@ class PoseStudioWidget {
             return;
         }
 
-        this.managerImageMetrics.set(src, { width: 1, height: 1, loading: true, callbacks: onReady ? [onReady] : [] });
+        const fallback = index >= 0 ? this.managerPoseMetrics?.[index] : null;
+        this.managerImageMetrics.set(src, {
+            width: fallback?.width || 0,
+            height: fallback?.height || 0,
+            loading: true,
+            callbacks: onReady ? [onReady] : [],
+        });
         const img = new Image();
         img.onload = () => {
             const callbacks = this.managerImageMetrics.get(src)?.callbacks || [];
-            this.managerImageMetrics.set(src, {
+            const metrics = {
                 width: img.naturalWidth || 1,
                 height: img.naturalHeight || 1,
                 loading: false,
-            });
+            };
+            this.managerImageMetrics.set(src, metrics);
+            if (index >= 0) this.managerPoseMetrics[index] = metrics;
             callbacks.forEach(callback => callback?.());
         };
         img.onerror = () => {
             const callbacks = this.managerImageMetrics.get(src)?.callbacks || [];
-            this.managerImageMetrics.set(src, { width: 1, height: 1, loading: false });
+            const metrics = fallback || { width: 1, height: 1, loading: false };
+            this.managerImageMetrics.set(src, { ...metrics, loading: false });
+            if (index >= 0) this.managerPoseMetrics[index] = metrics;
             callbacks.forEach(callback => callback?.());
         };
         img.src = src;
@@ -3916,7 +3984,8 @@ class PoseStudioWidget {
         const aspects = Array.from({ length: count }, (_, index) => {
             const capture = this.poseCaptures?.[index];
             const metrics = capture ? this.managerImageMetrics.get(capture) : null;
-            return Math.max(0.05, Math.min(20, (metrics?.width && metrics?.height) ? metrics.width / metrics.height : fallbackAspect));
+            const stableMetrics = (metrics?.width && metrics?.height) ? metrics : this.managerPoseMetrics?.[index];
+            return Math.max(0.05, Math.min(20, (stableMetrics?.width && stableMetrics?.height) ? stableMetrics.width / stableMetrics.height : fallbackAspect));
         });
         let best = null;
 
@@ -3964,15 +4033,145 @@ class PoseStudioWidget {
         });
     }
 
+    updatePoseManagerPreviewImage(index) {
+        const capture = this.poseCaptures?.[index];
+        if (capture) this.ensurePoseManagerImageMetrics(capture, null, index);
+
+        const updateCard = (card, previewSelector) => {
+            if (!card) return;
+            const preview = card.querySelector(previewSelector);
+            if (!preview) return;
+            if (!capture) {
+                if (!preview.querySelector(".vnccs-ps-pose-preview-empty")) {
+                    preview.innerHTML = "";
+                    const placeholder = document.createElement("div");
+                    placeholder.className = "vnccs-ps-pose-preview-empty";
+                    preview.appendChild(placeholder);
+                }
+                return;
+            }
+            let img = preview.querySelector("img");
+            if (!img) {
+                preview.innerHTML = "";
+                img = document.createElement("img");
+                img.alt = `Pose ${index + 1}`;
+                preview.appendChild(img);
+            }
+            img.src = capture;
+        };
+
+        updateCard(
+            this.managerGrid?.querySelector(`.vnccs-ps-pose-card[data-pose-index="${index}"]`),
+            ".vnccs-ps-pose-preview"
+        );
+        updateCard(
+            this.managerDetailStrip?.querySelector(`.vnccs-ps-detail-card[data-pose-index="${index}"]`),
+            ".vnccs-ps-detail-card-preview"
+        );
+    }
+
+    scheduleAllManagerPreviewRefresh() {
+        if (this.interfaceMode !== "manager" && this.interfaceMode !== "managerDetail") return;
+        if (!this.viewer?.isInitialized?.()) return;
+        if (!this.poses?.length) return;
+        if (this._managerPreviewRefreshFrame) return;
+
+        this._managerPreviewRefreshFrame = requestAnimationFrame(() => {
+            this._managerPreviewRefreshFrame = null;
+            this.refreshAllManagerPreviews();
+        });
+    }
+
+    refreshAllManagerPreviews() {
+        if (this.interfaceMode !== "manager" && this.interfaceMode !== "managerDetail") return;
+        if (!this.viewer?.isInitialized?.()) return;
+
+        const originalPose = this.viewer.getPose();
+        const originalLights = JSON.parse(JSON.stringify(this.lightParams || []));
+        const w = this.exportParams.view_width || 1024;
+        const h = this.exportParams.view_height || 1024;
+        const bg = this.exportParams.bg_color || [40, 40, 40];
+        const isOriginalLighting = this.exportParams.keepOriginalLighting;
+
+        if (!this.poseCaptures) this.poseCaptures = [];
+        if (!this.lightingPrompts) this.lightingPrompts = [];
+        this.ensurePosePrompts();
+
+        try {
+            for (let i = 0; i < this.poses.length; i++) {
+                const pose = this.poses[i] || {};
+                this.viewer.setPose(pose, true);
+
+                const poseCam = pose.cameraParams || {};
+                const z = poseCam.zoom || this.exportParams.cam_zoom || 1.0;
+                const oX = (poseCam.offset_x !== undefined ? poseCam.offset_x : this.exportParams.cam_offset_x) || 0;
+                const oY = (poseCam.offset_y !== undefined ? poseCam.offset_y : this.exportParams.cam_offset_y) || 0;
+                const yaw = (poseCam.yaw_deg !== undefined ? poseCam.yaw_deg : this.exportParams.cam_yaw_deg) || 0;
+                const pitch = (poseCam.pitch_deg !== undefined ? poseCam.pitch_deg : this.exportParams.cam_pitch_deg) || 0;
+
+                if (isOriginalLighting) {
+                    this.viewer.updateLights([{ type: 'ambient', color: '#ffffff', intensity: 1.0 }]);
+                } else {
+                    this.viewer.updateLights(this.lightParams);
+                }
+
+                this.poseCaptures[i] = this.viewer.capture(w, h, z, bg, oX, oY, yaw, pitch);
+                this.lightingPrompts[i] = this.generatePromptFromLights(
+                    isOriginalLighting ? [] : this.lightParams,
+                    this.getPosePrompt(i)
+                );
+                this.updatePoseManagerPreviewImage(i);
+            }
+        } finally {
+            this.viewer.setPose(originalPose, true);
+            this.viewer.updateLights(originalLights);
+        }
+    }
+
+    updateExistingPoseManagerDetailCards() {
+        if (!this.managerDetailStrip || this.interfaceMode !== "managerDetail" || !this.poses.length) return false;
+        const cards = Array.from(this.managerDetailStrip.children).filter(card => card.classList?.contains("vnccs-ps-detail-card"));
+        if (cards.length !== this.poses.length || cards.length !== this.managerDetailStrip.children.length) return false;
+
+        for (let i = 0; i < cards.length; i++) {
+            const card = cards[i];
+            card.classList.toggle("active", i === this.activeTab);
+            card.dataset.poseIndex = String(i);
+            card.title = `Open Pose ${i + 1}`;
+
+            const name = card.querySelector(".vnccs-ps-detail-card-name");
+            if (name) name.textContent = `Pose ${i + 1}`;
+
+            const del = card.querySelector(".vnccs-ps-detail-card-delete");
+            if (del) {
+                del.title = `Delete Pose ${i + 1}`;
+                del.disabled = this.poses.length <= 1;
+            }
+
+            this.updatePoseManagerPreviewImage(i);
+        }
+        return true;
+    }
+
     renderPoseManagerDetailStrip() {
         if (!this.managerDetailStrip) return;
         if (this.interfaceMode !== "managerDetail") return;
         this.ensurePosePrompts();
+
+        if (this.updateExistingPoseManagerDetailCards()) {
+            requestAnimationFrame(() => {
+                const active = this.managerDetailStrip?.querySelector(".vnccs-ps-detail-card.active");
+                active?.scrollIntoView({ behavior: "smooth", block: "nearest", inline: "nearest" });
+            });
+            return;
+        }
+
         this.managerDetailStrip.innerHTML = "";
 
         for (let i = 0; i < this.poses.length; i++) {
             const card = document.createElement("div");
             card.className = "vnccs-ps-detail-card" + (i === this.activeTab ? " active" : "");
+            card.dataset.poseIndex = String(i);
             card.tabIndex = 0;
             card.role = "button";
             card.title = `Open Pose ${i + 1}`;
@@ -4237,6 +4436,7 @@ class PoseStudioWidget {
         slider.step = step;
         slider.value = value;
         slider._vnccsValueSpan = valueSpan;
+        const isLiveMorphSlider = !isExport && this.isLiveMorphKey?.(key);
 
         // Reset logic
         resetBtn.onclick = (e) => {
@@ -4285,7 +4485,7 @@ class PoseStudioWidget {
                 } else {
                     // Directly update meshParams and trigger mesh rebuild
                     this.meshParams[key] = val;
-                    this.onMeshParamsChanged(key);
+                    this.onMeshParamsChanged(key, isLiveMorphSlider ? { liveOnly: true } : {});
                 }
             }
         });
@@ -4294,6 +4494,8 @@ class PoseStudioWidget {
             if (isExport) {
                 const needsFull = ['view_width', 'view_height', 'cam_zoom', 'bg_color', 'cam_offset_x', 'cam_offset_y', 'cam_yaw_deg', 'cam_pitch_deg'].includes(key);
                 this.syncToNode(needsFull);
+            } else if (isLiveMorphSlider) {
+                this.queueFullMeshUpdate(key);
             }
         });
 
@@ -7797,6 +7999,7 @@ class PoseStudioWidget {
                 // Reload mesh data without implicit camera math; if we need a reset,
                 // do the same explicit snap the Preview button uses.
                 this.viewer.loadData(d, true);
+                this.ensureMorphWorker();
 
                 // Apply lighting configuration
                 this.viewer.updateLights(this.lightParams);
@@ -7828,6 +8031,92 @@ class PoseStudioWidget {
             }
         }).finally(() => {
             if (this.loadingOverlay) this.loadingOverlay.style.display = "none";
+        });
+    }
+
+    isLiveMorphKey(key) {
+        return [
+            "age", "gender", "weight", "muscle", "height",
+            "breast_size", "firmness",
+            "penis_len", "penis_circ", "penis_test",
+        ].includes(key);
+    }
+
+    ensureMorphWorker() {
+        if (this._morphWorker || this._morphWorkerFailed) return this._morphWorker;
+        if (typeof Worker === "undefined") return null;
+
+        try {
+            const worker = new Worker(VNCCS_POSE_MORPH_WORKER_URL, { type: "module" });
+            worker.onmessage = (event) => {
+                const message = event.data || {};
+                if (message.type === "error") {
+                    console.warn("[VNCCS PoseStudio] Live morph worker failed:", message.message);
+                    this._morphWorkerFailed = true;
+                    return;
+                }
+                if (message.type !== "result") return;
+                if (message.seq < this._morphSeq || message.seq < this._lastAppliedMorphSeq) return;
+                if (!this.viewer?.updateBodyVertices?.(message.vertices, message.bonePositions)) return;
+                this._lastAppliedMorphSeq = message.seq;
+                this.scheduleAllManagerPreviewRefresh();
+            };
+            worker.onerror = (event) => {
+                console.warn("[VNCCS PoseStudio] Live morph worker error:", event.message || event);
+                this._morphWorkerFailed = true;
+                try { worker.terminate(); } catch (_) {}
+                if (this._morphWorker === worker) this._morphWorker = null;
+            };
+            worker.postMessage({ type: "warmup" });
+            this._morphWorker = worker;
+        } catch (error) {
+            console.warn("[VNCCS PoseStudio] Live morph worker unavailable:", error);
+            this._morphWorkerFailed = true;
+        }
+        return this._morphWorker;
+    }
+
+    requestLiveMorph(changedKey = null) {
+        if (changedKey && !this.isLiveMorphKey(changedKey)) return false;
+        const worker = this.ensureMorphWorker();
+        if (!worker || !this.viewer?.isInitialized?.()) return false;
+        const seq = ++this._morphSeq;
+        worker.postMessage({
+            type: "solve",
+            seq,
+            params: { ...this.meshParams },
+        });
+        return true;
+    }
+
+    queueFullMeshUpdate(changedKey = null) {
+        if (changedKey === "age") {
+            this.pendingAgeCameraFit = true;
+        }
+
+        this.pendingMeshUpdate = true;
+
+        if (this.isMeshUpdating) return;
+        this.isMeshUpdating = true;
+        this.pendingMeshUpdate = false;
+
+        this.loadModel(false).finally(() => {
+            const hasPendingMeshUpdate = this.pendingMeshUpdate;
+            this.isMeshUpdating = false;
+            if (hasPendingMeshUpdate) {
+                this.queueFullMeshUpdate();
+                return;
+            }
+            if (this.pendingAgeCameraFit) {
+                this.pendingAgeCameraFit = false;
+                const suppressAgeFitSync = this._suppressNextAgeFitSync === true;
+                this._suppressNextAgeFitSync = false;
+                if (this.applyAgeCameraFit()) {
+                    if (!suppressAgeFitSync) {
+                        this.syncToNode(this.interfaceMode !== "studio");
+                    }
+                }
+            }
         });
     }
 
@@ -8119,11 +8408,7 @@ class PoseStudioWidget {
         this.genderBtns.female.classList.toggle("active", isFemale);
     }
 
-    onMeshParamsChanged(changedKey = null) {
-        if (changedKey === "age") {
-            this.pendingAgeCameraFit = true;
-        }
-
+    onMeshParamsChanged(changedKey = null, options = {}) {
         // Update node widgets
         for (const [key, value] of Object.entries(this.meshParams)) {
             const widget = this.node.widgets?.find(w => w.name === key);
@@ -8132,31 +8417,12 @@ class PoseStudioWidget {
             }
         }
 
-        // Async Queue update
-        this.pendingMeshUpdate = true;
+        const liveRequested = this.requestLiveMorph(changedKey);
+        if (options.liveOnly && liveRequested) {
+            return;
+        }
 
-        if (this.isMeshUpdating) return;
-        this.isMeshUpdating = true;
-        this.pendingMeshUpdate = false;
-
-        this.loadModel(false).finally(() => {
-            const hasPendingMeshUpdate = this.pendingMeshUpdate;
-            this.isMeshUpdating = false;
-            if (hasPendingMeshUpdate) {
-                this.onMeshParamsChanged();
-                return;
-            }
-            if (this.pendingAgeCameraFit) {
-                this.pendingAgeCameraFit = false;
-                const suppressAgeFitSync = this._suppressNextAgeFitSync === true;
-                this._suppressNextAgeFitSync = false;
-                if (this.applyAgeCameraFit()) {
-                    if (!suppressAgeFitSync) {
-                        this.syncToNode(this.interfaceMode !== "studio");
-                    }
-                }
-            }
-        });
+        this.queueFullMeshUpdate(changedKey);
     }
 
     resize() {
@@ -9315,8 +9581,16 @@ app.registerExtension({
                     cancelAnimationFrame(this.studioWidget.managerLayoutFrame);
                     this.studioWidget.managerLayoutFrame = null;
                 }
+                if (this.studioWidget._managerPreviewRefreshFrame) {
+                    cancelAnimationFrame(this.studioWidget._managerPreviewRefreshFrame);
+                    this.studioWidget._managerPreviewRefreshFrame = null;
+                }
                 if (this.studioWidget._resizeRaf) {
                     cancelAnimationFrame(this.studioWidget._resizeRaf);
+                }
+                if (this.studioWidget._morphWorker) {
+                    try { this.studioWidget._morphWorker.terminate(); } catch (_) {}
+                    this.studioWidget._morphWorker = null;
                 }
                 if (this.studioWidget.viewer) {
                     this.studioWidget.viewer.dispose();

--- a/web/vnccs_pose_studio_core.js
+++ b/web/vnccs_pose_studio_core.js
@@ -2500,6 +2500,87 @@ export class PoseViewerCore {
         return { geometry, vertices, indices };
     }
 
+    updateBodyVertices(vertices, bonePositions = null) {
+        if (!this.initialized || !this.skinnedMesh || !this.skinnedMesh.geometry || !vertices) return false;
+        const geometry = this.skinnedMesh.geometry;
+        const position = geometry.getAttribute('position');
+        if (!position || position.array.length !== vertices.length) return false;
+
+        const savedRotations = new Map();
+        let savedMeshRotation = null;
+        if (bonePositions && this.boneList?.length && bonePositions.length >= this.boneList.length * 6) {
+            for (const bone of this.boneList) {
+                savedRotations.set(bone.name, bone.rotation.clone());
+                bone.rotation.set(0, 0, 0);
+            }
+            savedMeshRotation = this.skinnedMesh.rotation.clone();
+            this.skinnedMesh.rotation.set(0, 0, 0);
+        }
+
+        position.array.set(vertices);
+        position.needsUpdate = true;
+        geometry.computeVertexNormals();
+        geometry.computeBoundingBox();
+        geometry.computeBoundingSphere();
+        if (geometry.boundingBox && this.THREE) {
+            if (!this.meshCenter) this.meshCenter = new this.THREE.Vector3();
+            geometry.boundingBox.getCenter(this.meshCenter);
+        }
+
+        if (bonePositions && this.boneList?.length && bonePositions.length >= this.boneList.length * 6) {
+            for (let i = 0; i < this.boneList.length; i++) {
+                const bone = this.boneList[i];
+                const offset = i * 6;
+                const head = [
+                    bonePositions[offset],
+                    bonePositions[offset + 1],
+                    bonePositions[offset + 2],
+                ];
+                const tail = [
+                    bonePositions[offset + 3],
+                    bonePositions[offset + 4],
+                    bonePositions[offset + 5],
+                ];
+                bone.userData.headPos = head;
+                bone.userData.tailPos = tail;
+
+                const parentName = bone.userData.parentName;
+                const parent = parentName ? this.bones?.[parentName] : null;
+                if (parent?.userData?.headPos) {
+                    const parentHead = parent.userData.headPos;
+                    bone.position.set(
+                        head[0] - parentHead[0],
+                        head[1] - parentHead[1],
+                        head[2] - parentHead[2]
+                    );
+                } else {
+                    bone.position.set(head[0], head[1], head[2]);
+                }
+
+                if (this.initialBoneStates?.[bone.name]) {
+                    this.initialBoneStates[bone.name].position.copy(bone.position);
+                }
+            }
+
+            this.skinnedMesh.updateMatrixWorld(true);
+            for (const bone of this.boneList) bone.updateMatrixWorld(true);
+            if (this.skeleton?.calculateInverses) {
+                this.skeleton.calculateInverses();
+            }
+
+            for (const bone of this.boneList) {
+                const rotation = savedRotations.get(bone.name);
+                if (rotation) bone.rotation.copy(rotation);
+            }
+            if (savedMeshRotation) this.skinnedMesh.rotation.copy(savedMeshRotation);
+            if (this.skeleton) this.skeleton.update();
+            this.updateIKEffectorPositions?.();
+        }
+
+        this.requestRender();
+        return true;
+    }
+
     _initSkeleton(data, geometry, vertices) {
         const THREE = this.THREE;
         this.bones = {};


### PR DESCRIPTION
# Version 0.4.29
## Pose Studio Live Morph Performance and Pose Manager Stability

### Improvements

*   **Pose Studio live morphing moved to the browser**: Added a dedicated browser-side morph data pipeline for realtime body-parameter previews.
    *   MakeHuman base vertices, morph targets, joint data, and skeleton metadata are exposed through a compact binary endpoint for the live worker.
    *   Age, Gender, Weight, Muscle, Height, breast, firmness, and genital morph parameters can now update the visible mesh without a full Python preview rebuild on every slider input.
    *   A shared morph worker is reused across Pose Studio widgets so multiple active nodes do not each create their own heavy morph worker and duplicate morph-data downloads.
    *   Worker messages are routed by client id so concurrent Pose Studio widgets receive only their own live morph results.

*   **Pose Manager realtime preview updates**: Reworked manager-mode body-slider updates so all pose cards refresh during live morph changes.
    *   Pose Manager now updates every visible pose preview during realtime Age/Weight/Muscle/Height edits instead of waiting for a final Python sync.
    *   Preview refresh work is chunked across animation frames to keep the UI responsive while multiple cards are being recaptured.
    *   Stale worker results are ignored by sequence id so quick slider movement cannot apply older mesh states over newer ones.

*   **Non-blocking Pose Studio startup load**: Reworked the MakeHuman preload path used by the preview API to cooperate with ComfyUI's async server loop.
    *   Startup model loading still happens when the Pose Studio widget opens, but OBJ and target-file reads now yield between chunks instead of monopolizing the server handler.
    *   Preview payload building runs off the aiohttp request path after the shared Pose Studio data cache is loaded.
    *   Cache loading remains serialized so parallel widget startup does not create partially initialized shared MakeHuman state.

### Fixes

*   **Age and Height live skinning**: Fixed live Age/Height morph updates that could temporarily detach the mesh from the skeleton while dragging.
    *   Live morph results now include updated bone/joint positions so the frontend can keep skinned geometry aligned during realtime body-size changes.
    *   The final Python sync remains available for full authoritative mesh rebuilds after dragging, without hammering the server on every input event.

*   **Pose Manager card flicker**: Reduced manager-card flicker after final body-scale recalculation.
    *   Pose cards preserve measured preview dimensions while captures are refreshed.
    *   Capture replacement updates existing card images instead of forcing avoidable full-grid layout churn.
    *   Deleted/reordered poses keep their card metrics aligned with the correct pose index during subsequent live morph refreshes.

*   **Pose Manager lighting restore**: Fixed Pose Manager reloads that could show black/unlit model previews until any parameter was changed.
    *   Lighting is now applied when model data is loaded so restored cards match the configured light state immediately.

*   **Preview API cleanup**: Removed obsolete unreachable preview-generation code left behind during the live morph refactor.
    *   Removed the rejected subprocess preload experiment and all related helper code.
    *   Removed the remaining synchronous data-load fallback from the new preview payload path.