### PR TITLE
Fix Mixamo FBX head bone import failure

### DIFF
--- a/web/vnccs_mixamo_import.js
+++ b/web/vnccs_mixamo_import.js
@@ -163,7 +163,12 @@ let loaderPromise = null;
 function normalizeBoneName(name) {
     if (!name) return '';
     const shortName = name.includes(':') ? name.split(':').pop() : name;
-    return shortName.replace(/[^a-z0-9]/gi, '').toLowerCase();
+    // Strip Blender-style duplicate-name suffixes (e.g. "Head.001") before
+    // stripping non-alphanumeric chars, so they normalize the same as the
+    // unsuffixed name. Only a dot followed by digits at the end qualifies -
+    // this must not touch legitimate trailing digits like "Spine1".
+    const dedupedName = shortName.replace(/\.\d+$/, '');
+    return dedupedName.replace(/[^a-z0-9]/gi, '').toLowerCase();
 }
 
 async function loadMixamoModules() {
@@ -241,8 +246,7 @@ function buildFrameRotationMap(sourceBones, targetTHREE) {
             }
         }
         if (!sourceBone) {
-            // debug: log which candidates were tried for this bone name
-            // console.debug(`[vnccs_mixamo_import] no source bone for ${mixamoName}, tried:`, candidates);
+            console.warn(`[vnccs_mixamo_import] no source bone found for ${mixamoName}, tried:`, candidates);
         }
         if (!sourceBone) continue;
 
@@ -288,6 +292,16 @@ function findSourceBone(sourceBones, mixamoName) {
 
     for (const normalizedName of normalizedCandidates) {
         if (sourceBones?.normalizedBones?.[normalizedName]) return sourceBones.normalizedBones[normalizedName];
+    }
+
+    // Fallback: some source names collide with other objects and get suffixed
+    // in ways normalizeBoneName can't predict. Look for a normalized bone name
+    // that contains the target as a substring, but only if exactly one match
+    // exists - otherwise this is too ambiguous to trust.
+    const target = normalizeBoneName(mixamoName);
+    if (target && sourceBones?.normalizedBones) {
+        const matches = Object.keys(sourceBones.normalizedBones).filter((n) => n.includes(target));
+        if (matches.length === 1) return sourceBones.normalizedBones[matches[0]];
     }
 
     return null;

--- a/web/vnccs_pose_studio_core.js
+++ b/web/vnccs_pose_studio_core.js
@@ -6717,11 +6717,12 @@ export class PoseViewerCore {
         return true;
     }
 
-    fitMannequinToHMR2(shoulderYOffset = 0) {
+    fitMannequinToHMR2(shoulderYOffset = 0, options = {}) {
         if (!this._hmr2WorldKps || !this.bones || !this.ikController || !this.skinnedMesh) return;
 
         const THREE = this.THREE;
         const worldKps = this._hmr2WorldKps;
+        const includeHead = options.includeHead !== false;
 
         this.recordState();
         for (const bone of this.boneList) {


### PR DESCRIPTION
## Summary
- Fix `normalizeBoneName()` in `web/vnccs_mixamo_import.js` so it strips Blender-style duplicate-name suffixes (e.g. `Head.001`) before normalizing. Previously trailing digits were kept, so a suffixed bone normalized to `head001` instead of `head` and silently failed to match. `Head` collides with other Mixamo/Blender-scene names more often than bones like `Hips`/`Spine`, so this bug mostly manifested as a missing head bone on import.
- Add an unambiguous substring-match fallback in `findSourceBone()` for source bone names that still don't match after the exact/normalized candidate list is exhausted (only applied when there is exactly one match, to avoid mismatching e.g. `HeadTop_End`).
- Surface unmatched bones via `console.warn` instead of a silent no-op, to make future mapping gaps visible during import instead of silently failing.
- Fix a `ReferenceError: includeHead is not defined` in `fitMannequinToHMR2()` (`web/vnccs_pose_studio_core.js`) — the function referenced `includeHead` without ever declaring it, which threw and aborted the entire FBX import whenever the keypoint-fitting (HMR2) retarget path was used, before bone-name matching even had a chance to run. Added the missing `options` parameter and default, mirroring the sibling function `_applyImportPelvisAndTorso` which already had this pattern.

## Test plan
- [x] `node --check` on both modified files
- [x] Import a Mixamo FBX (e.g. a clip re-exported through Blender with a `Head.001`-style duplicate bone name) into a `VNCCS_PoseStudio` node and confirm the head now rotates/tracks correctly instead of staying static or throwing an error in the console.