### PR TITLE
0.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,16 @@
 
 *   **Persistent 3D scenes and object editing**: Added host-backed scene management and multi-object composition.
     *   Scenes can be created, reopened, renamed, and deleted; their references, objects, generation settings, transforms, visibility, camera, render settings, lighting, skydome, and exports are retained.
+    *   Existing Gaussian PLY files can be imported from the Factory UI, validated and normalized into persistent scene objects, then selected and framed in the live viewport.
     *   The layer list supports drag-and-drop ordering, visibility, inline rename, duplication, deletion, grouping, ungrouping, and group transforms.
     *   Viewport selection and gizmos provide object and group translation, rotation, and uniform scaling.
+    *   A new left-panel Camera block provides graphical first-person yaw/pitch and roll controls, plus one Cameras group for up to 32 saved scene viewpoints.
+    *   Selecting a saved camera switches the viewport to its view; clearing that selection restores the previous editor camera.
 
 *   **Native Gaussian viewport and scene output**: Added a bundled SparkJS/Three.js viewport that renders multiple Gaussian objects together.
     *   Supports orbit, pan, detailed zoom, adaptive clipping, selection bounds, an optional grid, and quality LOD.
-    *   The node returns a clean `preview` image of the complete scene without editor overlays.
+    *   The node returns `preview` as an ordered `IMAGE` LIST: current viewport first, then every saved scene camera, all without editor overlays and at the shared Scene Export dimensions.
+    *   Execution captures are committed atomically so current and saved-camera images cannot be mixed across scene revisions.
     *   Canonical PLY assets are converted lazily into a shared, bounded, content-addressed SPLAT cache for viewport rendering.
 
 *   **3D Factory lighting and environments**: Added persistent realtime lighting presets and custom scene lighting.
@@ -25,9 +29,10 @@
 
 *   **Gaussian PLY export and model library**: Added reusable object and scene assets.
     *   Object and combined-scene PLY exports bake position, rotation, and uniform scale into Gaussian centers and covariance while preserving opacity, color, and available spherical-harmonic data.
-    *   Scene export includes persistent dimensions, aspect presets, FOV, camera metadata, and an optional camera-frame overlay.
+    *   Scene export includes persistent dimensions, aspect presets, FOV, current and saved-camera metadata, and an optional camera-frame overlay.
     *   The local and Hugging Face-backed library stores objects, complete `.vnccs3d` scenes, and skydomes with generated previews.
-    *   Scene packages preserve layer order, groups, visibility, transforms, camera, render settings, lighting, and environment data; remote entries load as independent scene copies.
+    *   Skydome library previews temporarily remove every Gaussian object from the Spark scene, render only the environment, and restore the complete viewport state afterward.
+    *   Scene packages preserve layer order, groups, visibility, transforms, current and saved cameras, render settings, lighting, and environment data; remote entries load as independent scene copies.
 
 *   **Pose Studio Animation mode**: Added a complete keyframe editor alongside the existing Image mode.
     *   Provides a dope-sheet timeline with FPS and duration controls, playback, looping, playhead scrubbing, Auto-Key, snapping, per-bone tracks, model-rotation tracks, and anatomical track groups.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,55 @@
+# Version 0.6.1
+## 3D Factory Cameras, Gaussian PLY Import, and Per-Pose Framing
+
+### New Features
+
+*   **Gaussian PLY import for 3D Factory**: Existing Gaussian models can now be added directly to the active scene from the Factory UI.
+    *   Binary little-endian Gaussian PLY files up to 2 GiB are streamed to temporary storage, fully inspected, and validated before the scene is changed; invalid, oversized, empty, and polygon-mesh payloads are rejected without leaving partial objects behind.
+    *   Imported coordinates are normalized into Factory's canonical source convention so the live SPLAT viewport and later object export preserve the model's expected world orientation.
+    *   Each import becomes a persistent visible layer with source metadata, checksums, validation statistics, a generated card thumbnail, and the same transform, duplication, library, cache, and PLY export support as generated objects.
+    *   A successful import immediately loads, selects, and frames the new object in the live viewport.
+
+*   **Saved scene cameras in 3D Factory**: Added a dedicated Camera block and one persistent Cameras group for up to 32 viewpoints.
+    *   The graphical look pad and keyboard arrows rotate yaw and pitch in place while preserving camera position, target distance, vertical FOV, and a normalized up vector.
+    *   Cameras can be added from the current view, selected for exact viewport inspection, adjusted with the look pad, and deleted.
+    *   Leaving a saved-camera view by selecting it again, clicking empty viewport space, or selecting a scene object, group, or skydome restores the previous editor camera.
+    *   Current and saved cameras persist in scene manifests and workflow snapshots; scene-list summaries now expose the saved-camera count.
+
+*   **Multi-camera 3D Factory output**: Changed `preview` to an ordered ComfyUI `IMAGE` LIST.
+    *   Item 0 is the current viewport, followed by every saved camera in Cameras-group order.
+    *   Every frame is a clean PNG at the shared Scene Export dimensions, without the editor grid, selection bounds, or transform gizmos, while retaining its camera's own position, orientation, up vector, and FOV.
+    *   Scenes containing only an environment or saved cameras can participate in the same capture path; scenes with no renderable content still return one empty image.
+
+### Improvements
+
+*   **Atomic execution capture sets**: Current-view and saved-camera renders are now uploaded and committed as one token-, scene-revision-, render-revision-, dimension-, and camera-order-bound set.
+    *   The backend validates every frame before publishing any of them and rejects captures if the scene, export frame, or camera list changed during rendering.
+    *   Node execution waits for the complete requested set, reports viewport failures explicitly, and can reuse only a complete saved set that still matches the current scene revision.
+    *   Old capture directories are pruned after a successful atomic replacement, while internal capture manifests are omitted from public scene payloads and library packages.
+
+*   **Camera-aware PLY export and scene packages**: Updated Gaussian scene metadata to `vnccs-3d-factory-gaussian-scene/v2`.
+    *   Scene PLY headers now include the current camera plus every saved camera's stable ID, name, position, target, normalized up vector, and vertical FOV, alongside shared render dimensions and aspect metadata.
+    *   `.vnccs3d` scene packages preserve current and saved cameras; loaded copies receive fresh camera IDs so they remain independent of the source scene.
+
+*   **Pose Studio per-pose framing**: Image-mode pose tabs now retain independent camera framing.
+    *   Each character stores its own X/Y position and zoom for every pose, while yaw and pitch remain shared across all characters on that pose tab.
+    *   Switching, adding, deleting, resetting, copying, pasting, importing, exporting, saving to the library, loading a scene, and reopening a workflow now preserve the appropriate pose camera values.
+    *   Full-scene and active-pose captures apply the correct framing for each pose and restore the active tab's camera afterward; Animation mode continues to use animated character transforms and its shared capture camera.
+    *   Legacy poses without camera data are migrated from their character transform and existing camera settings.
+
+*   **Skydome library previews**: Skydome capture now temporarily removes every Gaussian root from the Spark scene, renders the environment alone, and restores object parents, order, visibility, selection, camera, and viewport state afterward.
+
+### Fixes
+
+*   **3D Factory FPV camera stability**: Reworked look-pad rotation around world-up yaw and a clamped local pitch axis so repeated adjustments cannot accumulate unintended roll or flip at the poles.
+*   **Pose Studio preview camera restoration**: Temporary Pose Manager fitting and batch captures now restore the active pose's camera instead of leaking preview framing into Studio or saved library poses.
+
+### Packaging and Documentation
+
+*   Bumped the package version to `0.6.1` and advanced the 3D Factory scene, export, workflow-state, frontend, and viewer schema/build revisions.
+*   Updated the README and 3D Factory guide for PLY import, saved cameras, camera-aware PLY/library persistence, and ordered multi-camera node output.
+*   Expanded backend, node, frontend, library, Pose Studio bootstrap, character-scene, and widget-hardening regression coverage for the new workflows.
+
 # Version 0.6.0
 ## VNCCS 3D Factory, Pose Studio Animation, and Multi-Character Scenes
 
@@ -11,16 +63,12 @@
 
 *   **Persistent 3D scenes and object editing**: Added host-backed scene management and multi-object composition.
     *   Scenes can be created, reopened, renamed, and deleted; their references, objects, generation settings, transforms, visibility, camera, render settings, lighting, skydome, and exports are retained.
-    *   Existing Gaussian PLY files can be imported from the Factory UI, validated and normalized into persistent scene objects, then selected and framed in the live viewport.
     *   The layer list supports drag-and-drop ordering, visibility, inline rename, duplication, deletion, grouping, ungrouping, and group transforms.
     *   Viewport selection and gizmos provide object and group translation, rotation, and uniform scaling.
-    *   A new left-panel Camera block provides graphical first-person yaw/pitch and roll controls, plus one Cameras group for up to 32 saved scene viewpoints.
-    *   Selecting a saved camera switches the viewport to its view; clearing that selection restores the previous editor camera.
 
 *   **Native Gaussian viewport and scene output**: Added a bundled SparkJS/Three.js viewport that renders multiple Gaussian objects together.
     *   Supports orbit, pan, detailed zoom, adaptive clipping, selection bounds, an optional grid, and quality LOD.
-    *   The node returns `preview` as an ordered `IMAGE` LIST: current viewport first, then every saved scene camera, all without editor overlays and at the shared Scene Export dimensions.
-    *   Execution captures are committed atomically so current and saved-camera images cannot be mixed across scene revisions.
+    *   The node returns a clean `preview` image of the complete scene without editor overlays.
     *   Canonical PLY assets are converted lazily into a shared, bounded, content-addressed SPLAT cache for viewport rendering.
 
 *   **3D Factory lighting and environments**: Added persistent realtime lighting presets and custom scene lighting.
@@ -29,10 +77,9 @@
 
 *   **Gaussian PLY export and model library**: Added reusable object and scene assets.
     *   Object and combined-scene PLY exports bake position, rotation, and uniform scale into Gaussian centers and covariance while preserving opacity, color, and available spherical-harmonic data.
-    *   Scene export includes persistent dimensions, aspect presets, FOV, current and saved-camera metadata, and an optional camera-frame overlay.
+    *   Scene export includes persistent dimensions, aspect presets, FOV, camera metadata, and an optional camera-frame overlay.
     *   The local and Hugging Face-backed library stores objects, complete `.vnccs3d` scenes, and skydomes with generated previews.
-    *   Skydome library previews temporarily remove every Gaussian object from the Spark scene, render only the environment, and restore the complete viewport state afterward.
-    *   Scene packages preserve layer order, groups, visibility, transforms, current and saved cameras, render settings, lighting, and environment data; remote entries load as independent scene copies.
+    *   Scene packages preserve layer order, groups, visibility, transforms, camera, render settings, lighting, and environment data; remote entries load as independent scene copies.
 
 *   **Pose Studio Animation mode**: Added a complete keyframe editor alongside the existing Image mode.
     *   Provides a dope-sheet timeline with FPS and duration controls, playback, looping, playhead scrubbing, Auto-Key, snapping, per-bone tracks, model-rotation tracks, and anatomical track groups.

--- a/README.md
+++ b/README.md
@@ -41,16 +41,23 @@ assets through the bundled SparkJS viewport.
   beside every model.
 * **Scene Manager**: Create and reopen scenes; generated objects, names,
   transforms, generation settings, and exports persist on the ComfyUI host.
+* **Gaussian PLY Import**: Add an existing validated Gaussian PLY to the active
+  scene; it appears immediately in the object list and live viewport.
 * **Interactive Transforms**: Click objects in the viewport and move, rotate,
   or uniformly scale them with visible viewport gizmos. Exact numeric fields
   remain available in a collapsed precision panel.
+* **Saved Scene Cameras**: A graphical FPV look pad and roll control rotate the
+  camera in place without changing normal viewport orbit behavior. Add up to
+  32 named scene cameras, click one to inspect its exact view, and receive the
+  current view followed by every saved camera as an ordered ComfyUI `IMAGE`
+  LIST at the shared Scene Export resolution.
 * **Local TripoSplat Pipeline**: The official pipeline runs in process with
   ComfyUI's PyTorch device. Model setup and weight download are graphical.
 * **Object and Scene PLY Export**: Export every transformed object separately
   or combine the visible scene as an editable Gaussian PLY. The export bakes
   transforms into the actual Gaussian centers and covariance, preserves
-  opacity and spherical-harmonic color data, and embeds the saved scene camera
-  without lossy triangle reconstruction.
+  opacity and spherical-harmonic color data, and embeds the current camera plus
+  every saved scene camera without lossy triangle reconstruction.
 * **Gaussian Library**: Save individual objects or complete scenes with
   automatic 3D previews. `.vnccs3d` packages keep only canonical PLY assets,
   then synchronize or publish manifest-driven model repositories on Hugging
@@ -60,9 +67,9 @@ assets through the bundled SparkJS viewport.
   Every stage is printed to the ComfyUI console and retained in a downloadable
   per-job log.
 * **Persistent Widget State**: Scene selection, generation controls, source
-  reference, object transforms and selection, camera, grid, and transform mode
-  are saved with the workflow. Reference images are persisted on the ComfyUI
-  host rather than temporary browser file URLs.
+  reference, object transforms and selection, current and saved cameras, grid,
+  and transform mode are saved with the workflow. Reference images are
+  persisted on the ComfyUI host rather than temporary browser file URLs.
 
 👉 **[Setup and workflow guide](docs/VNCCS_3D_FACTORY.md)**
 

--- a/api/factory3d.py
+++ b/api/factory3d.py
@@ -16,9 +16,9 @@ import threading
 import time
 import traceback
 from pathlib import Path
-from typing import Any, Callable
+from typing import Any, BinaryIO, Callable
 
-from PIL import Image, ImageOps
+from PIL import Image, ImageDraw, ImageOps
 
 from .gaussian_scene import (
     export_gaussian_scene,
@@ -32,12 +32,14 @@ from .gaussian_scene import (
 
 LOGGER = logging.getLogger("vnccs.3d_factory")
 API_BASE = "/vnccs/3d-factory"
-SCHEMA_VERSION = 6
-EXPORT_FORMAT_VERSION = 7
+SCHEMA_VERSION = 7
+EXPORT_FORMAT_VERSION = 8
 UPSTREAM_REPOSITORY = "VAST-AI/TripoSplat"
 UPSTREAM_COMMIT = "a78fa12d06dbf1381ca548bfac32bb68cb8c451d"
 MAX_UPLOAD_BYTES = 32 * 1024 * 1024
+MAX_PLY_UPLOAD_BYTES = 2 * 1024 * 1024 * 1024
 MAX_PREVIEW_BYTES = 64 * 1024 * 1024
+MAX_SCENE_CAMERAS = 32
 MAX_IMAGE_PIXELS = 4096 * 4096
 MAX_SKYDOME_BYTES = 64 * 1024 * 1024
 MAX_SKYDOME_PIXELS = 8192 * 4096
@@ -66,6 +68,7 @@ _DEFAULT_RENDER_SETTINGS = {
 _DEFAULT_CAMERA = {
     "position": [2.8, 2.1, 4.2],
     "target": [0.0, 0.0, 0.0],
+    "up": [0.0, 1.0, 0.0],
     "fov": 42.0,
 }
 _LIGHTING_PRESETS = {"off", "day", "night", "dawn", "sunset", "custom"}
@@ -234,11 +237,83 @@ def _normalize_camera(value: Any) -> dict[str, Any]:
         fov = _DEFAULT_CAMERA["fov"]
     if not math.isfinite(fov):
         fov = _DEFAULT_CAMERA["fov"]
+    position = vector("position")
+    target = vector("target")
+    up = vector("up")
+    forward = [target[index] - position[index] for index in range(3)]
+    forward_length = math.sqrt(sum(component * component for component in forward))
+    if forward_length < 1e-7:
+        target = [position[0], position[1], position[2] - 1.0]
+        forward = [0.0, 0.0, -1.0]
+        forward_length = 1.0
+    forward = [component / forward_length for component in forward]
+    up_length = math.sqrt(sum(component * component for component in up))
+    if up_length < 1e-7:
+        up = list(_DEFAULT_CAMERA["up"])
+        up_length = 1.0
+    up = [component / up_length for component in up]
+    alignment = abs(sum(forward[index] * up[index] for index in range(3)))
+    if alignment > 0.999:
+        up = [0.0, 1.0, 0.0]
+        if abs(sum(forward[index] * up[index] for index in range(3))) > 0.999:
+            up = [0.0, 0.0, 1.0]
     return {
-        "position": vector("position"),
-        "target": vector("target"),
+        "position": position,
+        "target": target,
+        "up": up,
         "fov": max(5.0, min(120.0, fov)),
     }
+
+
+def _normalize_scene_cameras(
+    value: Any,
+    *,
+    strict: bool = False,
+) -> list[dict[str, Any]]:
+    if value is None:
+        return []
+    if not isinstance(value, list):
+        if strict:
+            raise ValueError("scene cameras must be a list")
+        return []
+    if len(value) > MAX_SCENE_CAMERAS:
+        if strict:
+            raise ValueError(f"a scene can contain at most {MAX_SCENE_CAMERAS} cameras")
+        value = value[:MAX_SCENE_CAMERAS]
+    output: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(value):
+        if not isinstance(raw, dict):
+            if strict:
+                raise ValueError("scene camera entries must be objects")
+            continue
+        try:
+            camera_id = _validate_id(raw.get("camera_id"), "camera id")
+        except ValueError:
+            if strict:
+                raise
+            camera_id = _new_id()
+        if camera_id in seen:
+            if strict:
+                raise ValueError("scene camera ids must be unique")
+            camera_id = _new_id()
+        seen.add(camera_id)
+        camera = _normalize_camera(raw)
+        try:
+            created_at = float(raw.get("created_at", 0.0))
+        except (TypeError, ValueError):
+            created_at = 0.0
+        if not math.isfinite(created_at) or created_at < 0:
+            created_at = 0.0
+        output.append(
+            {
+                "camera_id": camera_id,
+                "name": _clean_name(raw.get("name"), f"Camera {index + 1}", 80),
+                "created_at": created_at,
+                **camera,
+            }
+        )
+    return output
 
 
 def _normalize_lighting(value: Any) -> dict[str, Any]:
@@ -615,6 +690,7 @@ def load_scene(scene_id: str) -> dict[str, Any]:
     value["layers"] = _normalize_scene_layers(value)
     value["render"] = _normalize_render_settings(value.get("render"))
     value["camera"] = _normalize_camera(value.get("camera"))
+    value["cameras"] = _normalize_scene_cameras(value.get("cameras"))
     value["lighting"] = _normalize_lighting(value.get("lighting"))
     skydome = _normalize_scene_skydome(value.get("skydome"))
     if skydome is None:
@@ -659,8 +735,10 @@ def create_scene(name: Any = "") -> dict[str, Any]:
         "camera": {
             "position": list(_DEFAULT_CAMERA["position"]),
             "target": list(_DEFAULT_CAMERA["target"]),
+            "up": list(_DEFAULT_CAMERA["up"]),
             "fov": _DEFAULT_CAMERA["fov"],
         },
+        "cameras": [],
         "lighting": dict(_DEFAULT_LIGHTING),
         "exports": {},
     }
@@ -688,6 +766,7 @@ def list_scenes(limit: int = 100) -> list[dict[str, Any]]:
                     "created_at": float(scene.get("created_at", 0)),
                     "revision": int(scene.get("revision", 0)),
                     "object_count": len(scene.get("objects", [])),
+                    "camera_count": len(scene.get("cameras", [])),
                 }
             )
         except (OSError, ValueError, json.JSONDecodeError):
@@ -794,6 +873,130 @@ def duplicate_object(scene_id: str, object_id: str) -> dict[str, Any]:
             shutil.rmtree(duplicate_root)
         except OSError:
             pass
+        raise
+
+
+def _write_imported_object_thumbnail(target: Path) -> None:
+    """Create a stable card thumbnail for an object without a source image."""
+    size = OBJECT_THUMBNAIL_SIZE
+    image = Image.new("RGB", size, "#12101a")
+    draw = ImageDraw.Draw(image)
+    draw.rounded_rectangle(
+        (18, 18, size[0] - 18, size[1] - 18),
+        radius=28,
+        fill="#1d1929",
+        outline="#5b486a",
+        width=3,
+    )
+    colors = ("#ff8fa3", "#b8a9e8", "#ffc1cf")
+    points = (
+        (74, 82, 12),
+        (111, 62, 9),
+        (148, 86, 13),
+        (177, 118, 8),
+        (145, 143, 11),
+        (101, 137, 9),
+        (72, 117, 7),
+    )
+    for index, (x, y, radius) in enumerate(points):
+        color = colors[index % len(colors)]
+        draw.ellipse((x - radius, y - radius, x + radius, y + radius), fill=color)
+    draw.text((105, 177), "PLY", fill="#e9e8f1")
+    image.save(target, format="PNG", optimize=True)
+
+
+def import_ply_object(
+    scene_id: str,
+    source: BinaryIO,
+    file_name: Any = "model.ply",
+    object_name: Any = "",
+) -> dict[str, Any]:
+    """Validate and commit an uploaded Gaussian PLY as a scene object."""
+    safe_scene_id = _validate_id(scene_id, "scene id")
+    raw_file_name = str(file_name or "model.ply").replace("\\", "/")
+    safe_file_name = _clean_name(Path(raw_file_name).name, "model.ply", 160)
+    fallback_name = Path(safe_file_name).stem or "Imported PLY"
+    name = _clean_name(object_name, fallback_name, 80)
+    object_id = _new_id()
+    scene_root = resolve_scene_dir(safe_scene_id)
+    object_root = scene_root / "objects" / object_id
+    temporary = object_root / f".model.{secrets.token_hex(6)}.tmp"
+    target = object_root / "model.ply"
+    try:
+        with _STATE_LOCK:
+            load_scene(safe_scene_id)
+            object_root.mkdir(parents=True, exist_ok=False)
+        total = 0
+        with temporary.open("wb") as output:
+            while True:
+                block = source.read(4 * 1024 * 1024)
+                if not block:
+                    break
+                total += len(block)
+                if total > MAX_PLY_UPLOAD_BYTES:
+                    raise ValueError("PLY upload is too large")
+                output.write(block)
+            output.flush()
+            os.fsync(output.fileno())
+        if total <= 0:
+            raise ValueError("PLY upload is empty")
+
+        inspect_ply(temporary)
+        validate_ply_payload(temporary)
+        # Uploaded PLY coordinates describe the appearance the user expects
+        # to see. Factory's internal source convention is pre-canonical
+        # TripoSplat space, so normalize the upload once here; the viewport
+        # canonical matrix and a later object export then restore its original
+        # world orientation instead of rotating it unexpectedly.
+        normalized = export_gaussian_scene(
+            [(temporary, normalize_transform({}))],
+            target,
+        )
+        temporary.unlink(missing_ok=True)
+        validation = normalized["ply"]["validation"]
+        ply_hash = _sha256_file(target)
+        _remember_ply_sha256(target, ply_hash)
+        _write_imported_object_thumbnail(object_root / "thumbnail.png")
+
+        relative_root = Path("objects") / object_id
+        item = {
+            "object_id": object_id,
+            "name": name,
+            "created_at": _now(),
+            "visible": True,
+            "transform": normalize_transform({}),
+            "gaussians": int(normalized["ply"]["gaussians"]),
+            "source": {
+                "type": "ply_import",
+                "filename": safe_file_name,
+                "size": total,
+            },
+            "checksums": {
+                "ply_sha256": ply_hash,
+            },
+            "validation": {
+                "ply": {
+                    "invalid_values": validation["invalid_values"],
+                    "invalid_scales": validation["invalid_scales"],
+                    "invalid_quaternions": validation["invalid_quaternions"],
+                },
+            },
+            "settings": {
+                "source": "ply_import",
+            },
+            "files": {
+                "ply": str(relative_root / "model.ply"),
+            },
+        }
+        with _STATE_LOCK:
+            scene = load_scene(safe_scene_id)
+            scene["objects"].append(item)
+            scene["layers"].append({"type": "object", "object_id": object_id})
+            scene["exports"] = {}
+            _save_scene(scene)
+        return {"scene": scene, "object_id": object_id}
+    except Exception:
+        shutil.rmtree(object_root, ignore_errors=True)
         raise
 
 
@@ -924,9 +1127,18 @@ def _ensure_scene_skydome_viewport(scene: dict[str, Any]) -> Path:
 
 
 def _ensure_object_thumbnail(scene_id: str, item: dict[str, Any]) -> Path:
-    source = _object_file(scene_id, item, "prepared")
-    for target in sorted(source.parent.glob("thumbnail.*")):
+    ply = _object_file(scene_id, item, "ply")
+    for target in sorted(ply.parent.glob("thumbnail.*")):
         if target.is_file():
+            return target
+    try:
+        source = _object_file(scene_id, item, "prepared")
+    except FileNotFoundError:
+        try:
+            source = _object_file(scene_id, item, "reference")
+        except FileNotFoundError:
+            target = ply.parent / "thumbnail.png"
+            _write_imported_object_thumbnail(target)
             return target
     with Image.open(source) as image:
         image.load()
@@ -967,6 +1179,60 @@ def _scene_preview_file(
     if root not in target.parents or not target.is_file():
         raise FileNotFoundError("scene 3D preview is missing")
     return target
+
+
+def _scene_capture_files(
+    scene: dict[str, Any],
+    expected_capture_token: str = "",
+) -> list[Path]:
+    capture_set = scene.get("capture_set")
+    if not isinstance(capture_set, dict):
+        raise FileNotFoundError("scene has no saved camera capture set")
+    if (
+        expected_capture_token
+        and capture_set.get("capture_token") != expected_capture_token
+    ):
+        raise FileNotFoundError("scene camera captures have not completed this execution")
+    if int(capture_set.get("revision", -1)) != int(scene.get("revision", 0)):
+        raise FileNotFoundError("scene camera captures are stale")
+    if int(capture_set.get("render_revision", -1)) != int(
+        scene.get("render_revision", scene.get("revision", 0))
+    ):
+        raise FileNotFoundError("scene camera captures use stale render settings")
+    render = _normalize_render_settings(scene.get("render"))
+    if (
+        int(capture_set.get("width", 0)) != render["width"]
+        or int(capture_set.get("height", 0)) != render["height"]
+    ):
+        raise FileNotFoundError("scene camera capture dimensions do not match Scene Export")
+    camera_entries = capture_set.get("cameras")
+    if not isinstance(camera_entries, list):
+        raise FileNotFoundError("scene camera capture manifest is invalid")
+    expected_ids = [
+        camera["camera_id"] for camera in _normalize_scene_cameras(scene.get("cameras"))
+    ]
+    captured_ids = [
+        str(entry.get("camera_id", ""))
+        for entry in camera_entries
+        if isinstance(entry, dict)
+    ]
+    if captured_ids != expected_ids or len(camera_entries) != len(expected_ids):
+        raise FileNotFoundError("scene camera capture set does not match the saved cameras")
+
+    root = resolve_scene_dir(scene["scene_id"])
+
+    def capture_path(entry: Any) -> Path:
+        relative = entry.get("file") if isinstance(entry, dict) else None
+        if not isinstance(relative, str) or not relative:
+            raise FileNotFoundError("scene camera capture path is missing")
+        target = (root / relative).resolve()
+        if root not in target.parents or not target.is_file():
+            raise FileNotFoundError("scene camera capture file is missing")
+        return target
+
+    paths = [capture_path(capture_set.get("current"))]
+    paths.extend(capture_path(entry) for entry in camera_entries)
+    return paths
 
 
 def store_scene_reference(
@@ -1209,6 +1475,163 @@ def store_scene_preview(
         return scene
 
 
+def store_scene_capture_set(
+    scene_id: str,
+    current_image_bytes: Any,
+    camera_images: dict[str, Any],
+    camera_ids: Any,
+    expected_revision: Any,
+    expected_render_revision: Any,
+    capture_token: Any,
+) -> dict[str, Any]:
+    """Atomically persist the execution frame followed by every saved camera."""
+    normalized_capture_token = str(capture_token or "")
+    if not _ID_RE.fullmatch(normalized_capture_token):
+        raise ValueError("scene camera capture token is invalid")
+    if not isinstance(camera_ids, list) or len(camera_ids) > MAX_SCENE_CAMERAS:
+        raise ValueError("scene camera capture ids are invalid")
+    normalized_ids = [
+        _validate_id(camera_id, "camera id") for camera_id in camera_ids
+    ]
+    if len(set(normalized_ids)) != len(normalized_ids):
+        raise ValueError("scene camera capture ids must be unique")
+    if set(camera_images) != set(normalized_ids):
+        raise ValueError("scene camera capture images do not match their ids")
+    try:
+        revision = int(expected_revision)
+        render_revision = int(expected_render_revision)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("scene camera capture revision is invalid") from exc
+
+    with _STATE_LOCK:
+        initial_scene = load_scene(scene_id)
+        initial_ids = [
+            camera["camera_id"]
+            for camera in _normalize_scene_cameras(initial_scene.get("cameras"))
+        ]
+        if revision != int(initial_scene.get("revision", 0)):
+            raise ValueError("scene changed while its cameras were being rendered")
+        if render_revision != int(
+            initial_scene.get("render_revision", initial_scene.get("revision", 0))
+        ):
+            raise ValueError(
+                "scene camera or export frame changed while cameras were being rendered"
+            )
+        if normalized_ids != initial_ids:
+            raise ValueError("saved cameras changed while they were being rendered")
+        render = _normalize_render_settings(initial_scene.get("render"))
+
+    root = resolve_scene_dir(scene_id)
+    captures_root = root / "preview" / "captures"
+    captures_root.mkdir(parents=True, exist_ok=True)
+    temporary_root = captures_root / (
+        f".{normalized_capture_token}.{secrets.token_hex(6)}.tmp"
+    )
+    final_root = captures_root / normalized_capture_token
+    temporary_root.mkdir(parents=False, exist_ok=False)
+
+    def save_capture(source: Any, target: Path) -> None:
+        if hasattr(source, "read"):
+            try:
+                source.seek(0)
+            except (OSError, AttributeError):
+                pass
+            image_bytes = source.read(MAX_PREVIEW_BYTES + 1)
+        else:
+            image_bytes = bytes(source or b"")
+        image = _decode_image(image_bytes, max_bytes=MAX_PREVIEW_BYTES).convert("RGB")
+        if (image.width, image.height) != (render["width"], render["height"]):
+            raise ValueError(
+                f"scene camera capture is {image.width}x{image.height}; "
+                f"Scene Export is {render['width']}x{render['height']}"
+            )
+        image.save(target, format="PNG")
+
+    try:
+        save_capture(current_image_bytes, temporary_root / "current.png")
+        for camera_id in normalized_ids:
+            save_capture(camera_images[camera_id], temporary_root / f"{camera_id}.png")
+
+        with _STATE_LOCK:
+            scene = load_scene(scene_id)
+            current_ids = [
+                camera["camera_id"]
+                for camera in _normalize_scene_cameras(scene.get("cameras"))
+            ]
+            if revision != int(scene.get("revision", 0)):
+                raise ValueError("scene changed while its cameras were being rendered")
+            if render_revision != int(
+                scene.get("render_revision", scene.get("revision", 0))
+            ):
+                raise ValueError(
+                    "scene camera or export frame changed while cameras were being rendered"
+                )
+            if normalized_ids != current_ids:
+                raise ValueError("saved cameras changed while they were being rendered")
+
+            if final_root.is_dir():
+                shutil.rmtree(final_root)
+            os.replace(temporary_root, final_root)
+            canonical_target = root / "preview" / "scene.png"
+            canonical_temporary = root / "preview" / (
+                f".scene.{secrets.token_hex(6)}.tmp"
+            )
+            try:
+                shutil.copyfile(final_root / "current.png", canonical_temporary)
+                os.replace(canonical_temporary, canonical_target)
+            finally:
+                canonical_temporary.unlink(missing_ok=True)
+
+            current_relative = str((final_root / "current.png").relative_to(root))
+            camera_entries = [
+                {
+                    "camera_id": camera_id,
+                    "file": str((final_root / f"{camera_id}.png").relative_to(root)),
+                }
+                for camera_id in normalized_ids
+            ]
+            timestamp = _now()
+            scene["capture_set"] = {
+                "capture_token": normalized_capture_token,
+                "revision": revision,
+                "render_revision": render_revision,
+                "width": render["width"],
+                "height": render["height"],
+                "current": {"file": current_relative},
+                "cameras": camera_entries,
+                "updated_at": timestamp,
+            }
+            scene["preview"] = {
+                "file": str(canonical_target.relative_to(root)),
+                "mime": "image/png",
+                "width": render["width"],
+                "height": render["height"],
+                "size": canonical_target.stat().st_size,
+                "revision": revision,
+                "render_revision": render_revision,
+                "capture_token": normalized_capture_token,
+                "updated_at": timestamp,
+            }
+            scene["preview_sync"] = {
+                "capture_token": normalized_capture_token,
+                "status": "completed",
+                "error": "",
+                "camera_count": len(normalized_ids),
+                "updated_at": timestamp,
+            }
+            _save_scene(scene, bump_revision=False)
+
+        for candidate in captures_root.iterdir():
+            if candidate == final_root or candidate.name.startswith("."):
+                continue
+            if candidate.is_dir():
+                shutil.rmtree(candidate, ignore_errors=True)
+        return scene
+    except Exception:
+        shutil.rmtree(temporary_root, ignore_errors=True)
+        raise
+
+
 def store_scene_preview_error(
     scene_id: str,
     capture_token: Any,
@@ -1329,6 +1752,7 @@ def capabilities() -> dict[str, Any]:
         "scene_render": {
             "min_side": 64,
             "max_side": 4096,
+            "max_cameras": MAX_SCENE_CAMERAS,
             "aspect_presets": sorted(_ASPECT_PRESETS),
             "defaults": dict(_DEFAULT_RENDER_SETTINGS),
         },
@@ -2219,6 +2643,7 @@ def _generate_object(
 
 def _public_scene(scene: dict[str, Any]) -> dict[str, Any]:
     value = json.loads(json.dumps(scene))
+    value.pop("capture_set", None)
     scene_id = value["scene_id"]
     reference = value.get("reference")
     if isinstance(reference, dict):
@@ -2336,6 +2761,12 @@ def update_scene(scene_id: str, payload: Any) -> dict[str, Any]:
                 scene["camera"] = camera
                 changed = True
                 preview_changed = True
+        if "cameras" in payload:
+            cameras = _normalize_scene_cameras(payload["cameras"], strict=True)
+            if cameras != _normalize_scene_cameras(scene.get("cameras")):
+                scene["cameras"] = cameras
+                changed = True
+                preview_changed = True
         if "lighting" in payload:
             lighting = _normalize_lighting(payload["lighting"])
             if lighting != _normalize_lighting(scene.get("lighting")):
@@ -2395,21 +2826,34 @@ def _scene_camera_metadata(
     render_revision: int,
 ) -> dict[str, Any]:
     camera = _normalize_camera(scene.get("camera"))
+    saved_cameras = _normalize_scene_cameras(scene.get("cameras"))
     render = _normalize_render_settings(scene.get("render"))
+
+    def camera_entry(value: dict[str, Any]) -> dict[str, Any]:
+        return {
+            "projection": "perspective",
+            "position": value["position"],
+            "target": value["target"],
+            "up": value["up"],
+            "fov": value["fov"],
+            "fov_axis": "vertical-degrees",
+        }
+
     return {
-        "schema": "vnccs-3d-factory-gaussian-scene/v1",
+        "schema": "vnccs-3d-factory-gaussian-scene/v2",
         "scene_id": scene["scene_id"],
         "scene_revision": revision,
         "render_revision": render_revision,
         "coordinate_system": "right-handed-y-up",
-        "camera": {
-            "projection": "perspective",
-            "position": camera["position"],
-            "target": camera["target"],
-            "up": [0.0, 1.0, 0.0],
-            "fov": camera["fov"],
-            "fov_axis": "vertical-degrees",
-        },
+        "camera": camera_entry(camera),
+        "cameras": [
+            {
+                "camera_id": saved["camera_id"],
+                "name": saved["name"],
+                **camera_entry(saved),
+            }
+            for saved in saved_cameras
+        ],
         "render": {
             "width": render["width"],
             "height": render["height"],
@@ -2785,6 +3229,60 @@ def register_routes(routes: Any) -> None:
         except Exception as exc:
             return _json_error(web, exc)
 
+    @routes.post(f"{API_BASE}/scenes/{{scene_id}}/capture-set")
+    async def factory_scene_capture_set_upload(request: Any) -> Any:
+        try:
+            maximum = (MAX_SCENE_CAMERAS + 1) * MAX_PREVIEW_BYTES + 2 * 1024 * 1024
+            if not _content_length_ok(request, maximum):
+                return web.json_response(
+                    {"error": "camera capture set upload is too large"},
+                    status=413,
+                )
+            scene_id = _validate_id(request.match_info["scene_id"], "scene id")
+            load_scene(scene_id)
+            post = await request.post()
+            current_field = post.get("current")
+            if current_field is None or not hasattr(current_field, "file"):
+                raise ValueError("missing current viewport capture")
+            try:
+                camera_ids = json.loads(str(post.get("camera_ids", "[]")))
+            except json.JSONDecodeError as exc:
+                raise ValueError("scene camera capture ids are invalid") from exc
+            if not isinstance(camera_ids, list):
+                raise ValueError("scene camera capture ids are invalid")
+            normalized_ids = [
+                _validate_id(camera_id, "camera id") for camera_id in camera_ids
+            ]
+            camera_images: dict[str, Any] = {}
+            for camera_id in normalized_ids:
+                image_field = post.get(f"camera_{camera_id}")
+                if image_field is None or not hasattr(image_field, "file"):
+                    raise ValueError(f"missing capture for camera {camera_id}")
+                camera_images[camera_id] = image_field.file
+            scene = await asyncio.to_thread(
+                store_scene_capture_set,
+                scene_id,
+                current_field.file,
+                camera_images,
+                normalized_ids,
+                post.get("revision"),
+                post.get("render_revision"),
+                post.get("capture_token"),
+            )
+            public_scene = _public_scene(scene)
+            return web.json_response(
+                {
+                    "preview": public_scene.get("preview"),
+                    "camera_count": len(normalized_ids),
+                    "capture_token": scene["preview_sync"]["capture_token"],
+                },
+                status=201,
+            )
+        except FileNotFoundError as exc:
+            return _json_error(web, exc, 404)
+        except Exception as exc:
+            return _json_error(web, exc)
+
     @routes.get(f"{API_BASE}/scenes/{{scene_id}}/preview")
     async def factory_scene_preview_get(request: Any) -> Any:
         try:
@@ -2930,6 +3428,36 @@ def register_routes(routes: Any) -> None:
             return web.FileResponse(
                 path,
                 headers={"Cache-Control": "private, max-age=31536000, immutable"},
+            )
+        except FileNotFoundError as exc:
+            return _json_error(web, exc, 404)
+        except Exception as exc:
+            return _json_error(web, exc)
+
+    @routes.post(f"{API_BASE}/scenes/{{scene_id}}/objects/import")
+    async def factory_object_import(request: Any) -> Any:
+        try:
+            if not _content_length_ok(request, MAX_PLY_UPLOAD_BYTES + 1024 * 1024):
+                return web.json_response({"error": "PLY upload is too large"}, status=413)
+            scene_id = _validate_id(request.match_info["scene_id"], "scene id")
+            load_scene(scene_id)
+            post = await request.post()
+            ply_field = post.get("ply")
+            if ply_field is None or not hasattr(ply_field, "file"):
+                raise ValueError("missing PLY file")
+            result = await asyncio.to_thread(
+                import_ply_object,
+                scene_id,
+                ply_field.file,
+                getattr(ply_field, "filename", "model.ply"),
+                post.get("name"),
+            )
+            return web.json_response(
+                {
+                    "scene": _public_scene(result["scene"]),
+                    "object_id": result["object_id"],
+                },
+                status=201,
             )
         except FileNotFoundError as exc:
             return _json_error(web, exc, 404)

--- a/api/factory3d_library.py
+++ b/api/factory3d_library.py
@@ -300,6 +300,8 @@ def _build_package(
                 snapshot = json.loads(json.dumps(scene))
                 snapshot["objects"] = stored_objects
                 snapshot.pop("preview", None)
+                snapshot.pop("capture_set", None)
+                snapshot.pop("preview_sync", None)
                 snapshot["exports"] = {}
                 if isinstance(snapshot.get("skydome"), dict):
                     snapshot["skydome"] = _skydome_payload(
@@ -796,6 +798,17 @@ def load_asset(
                             scene["layers"].append(copied)
                 scene["render"] = factory._normalize_render_settings(stored_scene.get("render"))
                 scene["camera"] = factory._normalize_camera(stored_scene.get("camera"))
+                scene["cameras"] = factory._normalize_scene_cameras(
+                    [
+                        {
+                            **stored_camera,
+                            "camera_id": factory._new_id(),
+                        }
+                        for stored_camera in stored_scene.get("cameras", [])
+                        if isinstance(stored_camera, dict)
+                    ],
+                    strict=True,
+                )
                 scene["lighting"] = factory._normalize_lighting(stored_scene.get("lighting"))
                 stored_skydome = stored_scene.get("skydome")
                 if isinstance(stored_skydome, dict):

--- a/docs/VNCCS_3D_FACTORY.md
+++ b/docs/VNCCS_3D_FACTORY.md
@@ -69,9 +69,29 @@ then:
 - duplicate it as an independently transformable scene object;
 - remove it from its object card after a graphical confirmation.
 
-Scene selection, generation settings, camera position, transform mode, grid,
-and selected object are stored in the workflow. Scene data and Gaussian assets
-remain under `ComfyUI/output/vnccs_3d_factory/scenes/`.
+Choose **Import PLY** above the scene-object list to add an existing Gaussian
+PLY directly to the active scene. Factory validates the complete payload,
+normalizes its coordinate convention, stores it as a persistent scene object,
+and immediately loads its derived SPLAT into the viewport. The imported object
+is selected and framed automatically. This accepts binary little-endian
+Gaussian PLY files with position, DC color, opacity, scale, and quaternion
+fields; polygon-mesh PLY files are rejected with an explicit error.
+
+The **Camera** block below TripoSplat provides first-person camera rotation
+without changing the viewport's normal orbit controls. Drag the graphical pad
+to look left/right/up/down from the current camera position, or use its
+keyboard arrows. The graphical roll slider rotates the horizon and returns to
+center after each adjustment; there are no numeric camera fields.
+
+Choose **Add camera** to store the current position, target, up vector, and FOV.
+Saved entries live in one **Cameras** group. Selecting one shows the viewport
+from that camera. Selecting it again, clicking empty viewport space, or
+selecting a scene object restores the editor camera that was active before the
+saved camera was opened. A scene supports up to 32 saved cameras.
+
+Scene selection, generation settings, current and saved cameras, transform
+mode, grid, and selected object are stored in the workflow. Scene data and
+Gaussian assets remain under `ComfyUI/output/vnccs_3d_factory/scenes/`.
 
 The selected reference image is copied into the active scene as soon as it is
 chosen. The workflow stores its scene URL and metadata rather than a temporary
@@ -90,18 +110,20 @@ scale into one Gaussian model. The file contains real Gaussian centers,
 covariance transforms, colors, spherical-harmonic data, and opacity—not a
 triangle mesh or a renamed placeholder file.
 
-The scene PLY header also embeds the exact perspective camera used by Scene
-Export: position, target, Y-up vector, vertical FOV, output dimensions, and
-aspect ratio. PLY is the only public object and scene export format.
+The scene PLY header also embeds the current perspective camera and every entry
+in the **Cameras** group: stable camera ID, name, position, target, up vector,
+and vertical FOV. The shared Scene Export dimensions and aspect ratio are
+included once in the same metadata. PLY is the only public object and scene
+export format.
 
 ## Gaussian model library
 
 The **Library** button in the scene header opens the persistent 3D Factory
 library. An individual object is stored with its canonical Gaussian PLY and
 metadata. A scene package additionally keeps every object, layer group,
-visibility flag, transform, render size, camera, and lighting setup. SPLAT is
-a disposable internal viewport derivative and is not duplicated inside
-`.vnccs3d` packages.
+visibility flag, transform, render size, current and saved cameras, and
+lighting setup. SPLAT is a disposable internal viewport derivative and is not
+duplicated inside `.vnccs3d` packages.
 
 Preview images are rendered automatically from the 3D viewport. Object previews
 temporarily isolate and frame only the selected object, then restore the editor
@@ -115,10 +137,13 @@ read-only; loading one always creates an independent Factory object or scene.
 
 ## ComfyUI outputs
 
-When the graph executes, the node exposes only `preview`: a clean render of the
-complete 3D scene from the current viewport camera, without the editor grid,
-selection bounds, or transform gizmo. Internal PLY/SPLAT asset paths and the
-scene manifest are not exposed as graph outputs.
+When the graph executes, `preview` is an `IMAGE` LIST. Item 0 is a clean render
+from the current visible viewport camera. The remaining items follow the
+**Cameras** group in manager order. Every item uses the same width, height, and
+PNG capture format configured by **Scene Export**, while retaining its saved
+camera's own position, orientation, and FOV. Editor grid, selection bounds,
+and transform gizmos are excluded. Internal PLY/SPLAT asset paths and the scene
+manifest are not exposed as graph outputs.
 
 PLY is the only permanent Gaussian source asset. The browser-facing 32-byte
 SPLAT representation is generated from PLY on first use and shared by SHA-256
@@ -128,6 +153,8 @@ least-recently-used and capped at 8 GiB by default; set
 `VNCCS_3D_FACTORY_SPLAT_CACHE_GB` before starting ComfyUI to change the cap.
 Deleting the cache is always safe because every entry is reproducible from PLY.
 
-The browser viewport capture is saved with the scene and bound to its revision.
-If a current capture cannot be obtained, execution fails explicitly rather
-than silently substituting an input/reference image or an outdated 3D render.
+The browser uploads the current view and all saved-camera images as one
+revision-bound capture set. The backend publishes it only after every frame
+has passed Scene Export dimension validation. If a complete current set cannot
+be obtained, execution fails explicitly rather than silently mixing revisions
+or substituting an input/reference image or outdated 3D render.

--- a/nodes/factory3d.py
+++ b/nodes/factory3d.py
@@ -16,9 +16,10 @@ import torch
 from PIL import Image
 
 
-_EMPTY_STATE = '{"schema_version":4,"scene_id":"","selected_object_id":"","selected_group_id":"","selected_object_ids":[]}'
+_EMPTY_STATE = '{"schema_version":10,"scene_id":"","selected_object_id":"","selected_group_id":"","selected_object_ids":[]}'
 _MAX_STATE_CHARS = 2 * 1024 * 1024
 _MAX_PREVIEW_PIXELS = 4096 * 4096
+_MAX_SCENE_CAMERAS = 32
 _ID_RE = re.compile(r"^[a-f0-9]{32}$")
 
 
@@ -130,12 +131,13 @@ def _parse_state(factory_data: Any) -> dict[str, Any]:
                 raise ValueError("3D Factory scene snapshot has an invalid aspect preset")
             if "show_camera_frame" in render and not isinstance(render["show_camera_frame"], bool):
                 raise ValueError("3D Factory scene snapshot has invalid camera-frame visibility")
-        camera = snapshot.get("camera")
-        if camera is not None:
+        def validate_camera(camera: Any, label: str) -> None:
             if not isinstance(camera, dict):
-                raise ValueError("3D Factory scene snapshot has invalid camera settings")
-            for key in ("position", "target"):
+                raise ValueError(f"3D Factory scene snapshot has invalid {label}")
+            for key in ("position", "target", "up"):
                 vector = camera.get(key)
+                if key == "up" and vector is None:
+                    continue
                 if (
                     not isinstance(vector, list)
                     or len(vector) != 3
@@ -146,7 +148,9 @@ def _parse_state(factory_data: Any) -> dict[str, Any]:
                         for item in vector
                     )
                 ):
-                    raise ValueError("3D Factory scene snapshot has an invalid camera vector")
+                    raise ValueError(
+                        f"3D Factory scene snapshot has an invalid {label} vector"
+                    )
             fov = camera.get("fov")
             if (
                 not isinstance(fov, (int, float))
@@ -154,7 +158,35 @@ def _parse_state(factory_data: Any) -> dict[str, Any]:
                 or not math.isfinite(float(fov))
                 or not 5 <= float(fov) <= 120
             ):
-                raise ValueError("3D Factory scene snapshot has an invalid camera FOV")
+                raise ValueError(f"3D Factory scene snapshot has an invalid {label} FOV")
+
+        camera = snapshot.get("camera")
+        if camera is not None:
+            validate_camera(camera, "camera")
+        cameras = snapshot.get("cameras", [])
+        if not isinstance(cameras, list) or len(cameras) > _MAX_SCENE_CAMERAS:
+            raise ValueError("3D Factory scene snapshot has an invalid saved camera list")
+        camera_ids: set[str] = set()
+        for saved_camera in cameras:
+            camera_id = (
+                saved_camera.get("camera_id")
+                if isinstance(saved_camera, dict)
+                else None
+            )
+            if (
+                not isinstance(camera_id, str)
+                or not _ID_RE.fullmatch(camera_id)
+                or camera_id in camera_ids
+            ):
+                raise ValueError(
+                    "3D Factory scene snapshot contains an invalid saved camera id"
+                )
+            if "name" in saved_camera and not isinstance(saved_camera["name"], str):
+                raise ValueError(
+                    "3D Factory scene snapshot contains an invalid saved camera name"
+                )
+            validate_camera(saved_camera, "saved camera")
+            camera_ids.add(camera_id)
     return value
 
 
@@ -260,6 +292,57 @@ def _wait_for_scene_preview(
     ) from last_error
 
 
+def _wait_for_scene_capture_set(
+    backend: Any,
+    scene_id: str,
+    timeout: float = 60.0,
+    capture_token: str = "",
+) -> list[Path]:
+    """Wait for the current view and all saved-camera renders as one revision."""
+    deadline = time.monotonic() + max(0.0, float(timeout))
+    last_error: Exception | None = None
+    saved_capture_set: list[Path] | None = None
+    while True:
+        scene = backend.load_scene(scene_id)
+        if capture_token:
+            sync = scene.get("preview_sync")
+            if (
+                isinstance(sync, dict)
+                and sync.get("capture_token") == capture_token
+                and sync.get("status") == "failed"
+            ):
+                raise RuntimeError(
+                    "3D Factory execution camera capture failed in the viewport: "
+                    f"{sync.get('error') or 'unknown capture error'}"
+                )
+        try:
+            if capture_token:
+                return backend._scene_capture_files(scene, capture_token)
+            return backend._scene_capture_files(scene)
+        except FileNotFoundError as exc:
+            last_error = exc
+            if capture_token:
+                try:
+                    saved_capture_set = backend._scene_capture_files(scene)
+                except FileNotFoundError:
+                    saved_capture_set = None
+        if time.monotonic() >= deadline:
+            break
+        time.sleep(0.1)
+    if saved_capture_set is not None:
+        print(
+            "[VNCCS 3D Factory] Fresh camera capture timed out; using the "
+            "revision-matched saved capture set.",
+            flush=True,
+        )
+        return saved_capture_set
+    raise RuntimeError(
+        "3D Factory could not obtain the current view and saved-camera images. "
+        "Keep the 3D Factory widget open for execution and save the scene after "
+        f"camera changes. Last capture check: {last_error}"
+    ) from last_error
+
+
 def _backend():
     from ..api import factory3d
 
@@ -271,6 +354,7 @@ class VNCCS_3DFactory:
 
     RETURN_TYPES = ("IMAGE",)
     RETURN_NAMES = ("preview",)
+    OUTPUT_IS_LIST = (True,)
     FUNCTION = "load_scene"
     CATEGORY = "VNCCS/3D"
     OUTPUT_NODE = True
@@ -320,7 +404,7 @@ class VNCCS_3DFactory:
         state = _parse_state(factory_data)
         scene_id = str(state.get("scene_id") or "")
         if not scene_id:
-            return (_empty_image(),)
+            return ([_empty_image()],)
 
         backend = _backend()
         try:
@@ -331,15 +415,31 @@ class VNCCS_3DFactory:
         except (FileNotFoundError, ValueError) as exc:
             raise RuntimeError(f"3D Factory scene {scene_id} could not be loaded: {exc}") from exc
 
-        if scene.get("objects"):
+        has_renderable_scene = bool(
+            scene.get("objects") or scene.get("skydome") or scene.get("cameras")
+        )
+        if has_renderable_scene:
             capture_token = uuid.uuid4().hex if unique_id is not None else ""
             requested = _request_scene_preview(unique_id, scene, capture_token)
-            preview_path = _wait_for_scene_preview(
-                backend,
-                scene_id,
-                capture_token=capture_token if requested else "",
-            )
-            preview = _preview_tensor(preview_path)
+            if requested:
+                capture_paths = _wait_for_scene_capture_set(
+                    backend,
+                    scene_id,
+                    capture_token=capture_token,
+                )
+            else:
+                try:
+                    capture_paths = backend._scene_capture_files(scene)
+                except FileNotFoundError:
+                    if scene.get("cameras"):
+                        raise RuntimeError(
+                            "3D Factory has saved cameras but no matching camera "
+                            "capture set. Open the node widget and run it again."
+                        )
+                    capture_paths = [
+                        _wait_for_scene_preview(backend, scene_id, timeout=0.0)
+                    ]
+            previews = [_preview_tensor(path) for path in capture_paths]
         else:
-            preview = _empty_image()
-        return (preview,)
+            previews = [_empty_image()]
+        return (previews,)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs-utils"
 description = "VNCCS utility nodes: Pose Studio, UniCanvas, and 3D Factory."
-version = "0.6.0"
+version = "0.6.1"
 license = {file = "LICENSE"} 
 
 dependencies = [

--- a/tests/test_factory3d_backend.py
+++ b/tests/test_factory3d_backend.py
@@ -93,6 +93,8 @@ class FactoryBackendTests(unittest.TestCase):
             },
         )
         self.assertEqual(scene["camera"]["fov"], 42.0)
+        self.assertEqual(scene["camera"]["up"], [0.0, 1.0, 0.0])
+        self.assertEqual(scene["cameras"], [])
         self.assertEqual(scene["lighting"]["preset"], "day")
         self.assertEqual(scene["lighting"]["color"], "#fff1d6")
         self.assertEqual(self.factory.list_scenes()[0]["name"], "First scene")
@@ -103,6 +105,34 @@ class FactoryBackendTests(unittest.TestCase):
         self.assertEqual(self.factory.load_scene(scene["scene_id"])["name"], "Renamed")
         unchanged = self.factory.update_scene(scene["scene_id"], {"name": "Renamed", "objects": []})
         self.assertEqual(unchanged["revision"], 0)
+
+    def test_saved_cameras_are_normalized_and_invalidate_capture_revision(self):
+        scene = self.factory.create_scene("Camera scene")
+        camera_id = "c" * 32
+        updated = self.factory.update_scene(
+            scene["scene_id"],
+            {
+                "cameras": [{
+                    "camera_id": camera_id,
+                    "name": "Hero camera",
+                    "created_at": 10,
+                    "position": [4, 3, 2],
+                    "target": [0, 0, 0],
+                    "up": [0, 2, 0],
+                    "fov": 56,
+                }],
+            },
+        )
+        self.assertEqual(updated["revision"], 0)
+        self.assertEqual(updated["render_revision"], 1)
+        self.assertEqual(updated["cameras"][0]["camera_id"], camera_id)
+        self.assertEqual(updated["cameras"][0]["up"], [0.0, 1.0, 0.0])
+        self.assertEqual(self.factory.list_scenes()[0]["camera_count"], 1)
+        with self.assertRaisesRegex(ValueError, "unique"):
+            self.factory.update_scene(
+                scene["scene_id"],
+                {"cameras": [updated["cameras"][0], updated["cameras"][0]]},
+            )
 
     def test_scenes_are_deleted_recursively_but_not_during_active_generation(self):
         scene = self.factory.create_scene("Delete me")
@@ -201,6 +231,7 @@ class FactoryBackendTests(unittest.TestCase):
         self.assertEqual(capabilities["splat_cache"]["used_bytes"], 0)
         self.assertEqual(capabilities["scene_render"]["min_side"], 64)
         self.assertEqual(capabilities["scene_render"]["max_side"], 4096)
+        self.assertEqual(capabilities["scene_render"]["max_cameras"], 32)
         self.assertIn("16:9", capabilities["scene_render"]["aspect_presets"])
         settings = self.factory._generation_settings({"num_gaussians": "524288"})
         self.assertEqual(settings["num_gaussians"], 524288)
@@ -601,6 +632,115 @@ class FactoryBackendTests(unittest.TestCase):
         self.assertEqual(group["group_id"], group_id)
         self.assertEqual(group["children"], [object_id, result["object_id"]])
 
+    def test_gaussian_ply_import_is_committed_to_scene_and_builds_viewport_asset(self):
+        scene = self.factory.create_scene("Imported models")
+        source_path = self.root / "ready-model.ply"
+        self._write_valid_ply(source_path, count=3)
+        source_info = self.gaussian.inspect_ply(source_path)
+        source_records = np.memmap(
+            source_path,
+            mode="r+",
+            dtype=source_info.dtype,
+            offset=source_info.data_offset,
+            shape=(source_info.vertex_count,),
+        )
+        source_records["x"] = 1.0
+        source_records["y"] = 2.0
+        source_records["z"] = 3.0
+        source_records.flush()
+        del source_records
+        source_bytes = source_path.read_bytes()
+
+        result = self.factory.import_ply_object(
+            scene["scene_id"],
+            io.BytesIO(source_bytes),
+            "..\\Ready Model.PLY",
+        )
+
+        restored = self.factory.load_scene(scene["scene_id"])
+        imported = self.factory._object_by_id(restored, result["object_id"])
+        self.assertEqual(imported["name"], "Ready Model")
+        self.assertEqual(imported["gaussians"], 3)
+        self.assertTrue(imported["visible"])
+        self.assertEqual(imported["source"]["type"], "ply_import")
+        self.assertEqual(imported["source"]["filename"], "Ready Model.PLY")
+        self.assertEqual(imported["source"]["size"], len(source_bytes))
+        self.assertEqual(imported["settings"]["source"], "ply_import")
+        self.assertEqual(
+            restored["layers"][-1],
+            {"type": "object", "object_id": result["object_id"]},
+        )
+        stored_ply = self.factory._object_file(scene["scene_id"], imported, "ply")
+        self.assertNotEqual(stored_ply.read_bytes(), source_bytes)
+        stored_info = self.gaussian.inspect_ply(stored_ply)
+        stored_records = np.memmap(
+            stored_ply,
+            mode="r",
+            dtype=stored_info.dtype,
+            offset=stored_info.data_offset,
+            shape=(stored_info.vertex_count,),
+        )
+        np.testing.assert_allclose(stored_records["x"], 3.0)
+        np.testing.assert_allclose(stored_records["y"], -2.0)
+        np.testing.assert_allclose(stored_records["z"], 1.0)
+        del stored_records
+        self.assertEqual(
+            imported["checksums"]["ply_sha256"],
+            self.factory._sha256_file(stored_ply),
+        )
+        thumbnail = self.factory._ensure_object_thumbnail(
+            scene["scene_id"],
+            imported,
+        )
+        self.assertTrue(thumbnail.is_file())
+        exported_ply = self.factory._ensure_object_ply_export(
+            scene["scene_id"],
+            imported["object_id"],
+        )
+        exported_info = self.gaussian.inspect_ply(exported_ply)
+        exported_records = np.memmap(
+            exported_ply,
+            mode="r",
+            dtype=exported_info.dtype,
+            offset=exported_info.data_offset,
+            shape=(exported_info.vertex_count,),
+        )
+        np.testing.assert_allclose(exported_records["x"], 1.0)
+        np.testing.assert_allclose(exported_records["y"], 2.0)
+        np.testing.assert_allclose(exported_records["z"], 3.0)
+        del exported_records
+        viewport = self.factory._ensure_object_splat(
+            scene["scene_id"],
+            imported["object_id"],
+        )
+        self.assertEqual(viewport.stat().st_size, 3 * 32)
+        public = self.factory._public_scene(restored)
+        public_item = self.factory._object_by_id(public, imported["object_id"])
+        self.assertIn("/asset/splat", public_item["urls"]["splat"])
+        self.assertIn("/asset/thumbnail", public_item["urls"]["thumbnail"])
+
+    def test_invalid_or_oversized_ply_import_does_not_add_partial_object(self):
+        scene = self.factory.create_scene("Reject imports")
+
+        with self.assertRaisesRegex(ValueError, "PLY header|not a PLY file"):
+            self.factory.import_ply_object(
+                scene["scene_id"],
+                io.BytesIO(b"not a PLY"),
+                "broken.ply",
+            )
+        self.assertEqual(self.factory.load_scene(scene["scene_id"])["objects"], [])
+
+        with mock.patch.object(self.factory, "MAX_PLY_UPLOAD_BYTES", 4):
+            with self.assertRaisesRegex(ValueError, "too large"):
+                self.factory.import_ply_object(
+                    scene["scene_id"],
+                    io.BytesIO(b"12345"),
+                    "oversized.ply",
+                )
+        self.assertEqual(self.factory.load_scene(scene["scene_id"])["objects"], [])
+        object_root = self.factory.resolve_scene_dir(scene["scene_id"]) / "objects"
+        self.assertEqual(list(object_root.iterdir()), [])
+
     def test_scene_layers_preserve_order_groups_visibility_and_render_revision(self):
         scene = self.factory.create_scene("Layered")
         object_ids = [self.factory._new_id() for _ in range(3)]
@@ -734,6 +874,20 @@ class FactoryBackendTests(unittest.TestCase):
             },
         }
         self.factory._save_scene(scene, bump_revision=False)
+        saved_camera_id = "f" * 32
+        self.factory.update_scene(
+            scene["scene_id"],
+            {
+                "cameras": [{
+                    "camera_id": saved_camera_id,
+                    "name": "Camera 1",
+                    "position": [6, 5, 4],
+                    "target": [1, 0, 0],
+                    "up": [0, 1, 0],
+                    "fov": 50,
+                }],
+            },
+        )
 
         captured_metadata = {}
 
@@ -758,6 +912,9 @@ class FactoryBackendTests(unittest.TestCase):
         self.assertEqual(captured_metadata["camera"]["position"], [2.8, 2.1, 4.2])
         self.assertEqual(captured_metadata["camera"]["target"], [0.0, 0.0, 0.0])
         self.assertEqual(captured_metadata["camera"]["fov"], 42.0)
+        self.assertEqual(captured_metadata["schema"], "vnccs-3d-factory-gaussian-scene/v2")
+        self.assertEqual(captured_metadata["cameras"][0]["camera_id"], saved_camera_id)
+        self.assertEqual(captured_metadata["cameras"][0]["position"], [6.0, 5.0, 4.0])
         self.assertEqual(captured_metadata["render"]["width"], 1024)
         saved = self.factory.load_scene(scene["scene_id"])
         self.assertEqual(saved["exports"]["format_version"], self.factory.EXPORT_FORMAT_VERSION)
@@ -964,6 +1121,77 @@ class FactoryBackendTests(unittest.TestCase):
         )
         with self.assertRaisesRegex(FileNotFoundError, "stale"):
             self.factory._scene_preview_file(changed)
+
+    def test_execution_capture_set_is_atomic_ordered_and_scene_export_sized(self):
+        scene = self.factory.create_scene("Camera captures")
+        camera_ids = ["a" * 32, "b" * 32]
+        scene = self.factory.update_scene(
+            scene["scene_id"],
+            {
+                "render": {
+                    "width": 320,
+                    "height": 180,
+                    "aspect": "16:9",
+                    "show_camera_frame": False,
+                },
+                "cameras": [
+                    {
+                        "camera_id": camera_id,
+                        "name": f"Camera {index + 1}",
+                        "position": [index + 1, 2, 3],
+                        "target": [0, 0, 0],
+                        "up": [0, 1, 0],
+                        "fov": 42 + index,
+                    }
+                    for index, camera_id in enumerate(camera_ids)
+                ],
+            },
+        )
+
+        def png(color):
+            stream = io.BytesIO()
+            Image.new("RGB", (320, 180), color).save(stream, format="PNG")
+            return stream.getvalue()
+
+        token = "c" * 32
+        saved = self.factory.store_scene_capture_set(
+            scene["scene_id"],
+            png((10, 20, 30)),
+            {
+                camera_ids[0]: png((40, 50, 60)),
+                camera_ids[1]: png((70, 80, 90)),
+            },
+            camera_ids,
+            scene["revision"],
+            scene["render_revision"],
+            token,
+        )
+        paths = self.factory._scene_capture_files(saved, token)
+        self.assertEqual(len(paths), 3)
+        self.assertEqual(paths[0].name, "current.png")
+        self.assertEqual([path.stem for path in paths[1:]], camera_ids)
+        self.assertEqual(saved["preview_sync"]["camera_count"], 2)
+        self.assertNotIn("capture_set", self.factory._public_scene(saved))
+
+        changed = self.factory.update_scene(
+            scene["scene_id"],
+            {"cameras": [scene["cameras"][1]]},
+        )
+        with self.assertRaisesRegex(FileNotFoundError, "stale"):
+            self.factory._scene_capture_files(changed)
+
+        wrong = io.BytesIO()
+        Image.new("RGB", (321, 180), (1, 2, 3)).save(wrong, format="PNG")
+        with self.assertRaisesRegex(ValueError, "Scene Export"):
+            self.factory.store_scene_capture_set(
+                scene["scene_id"],
+                wrong.getvalue(),
+                {camera_ids[1]: png((1, 2, 3))},
+                [camera_ids[1]],
+                changed["revision"],
+                changed["render_revision"],
+                "d" * 32,
+            )
 
     def test_scene_render_dimensions_and_camera_invalidate_only_the_preview(self):
         scene = self.factory.create_scene("Camera")

--- a/tests/test_factory3d_frontend.mjs
+++ b/tests/test_factory3d_frontend.mjs
@@ -17,7 +17,7 @@ test("Factory widget registers the renamed node and persists opaque state", () =
     assert.match(studio, /selected_object_id/);
     assert.match(studio, /scene_snapshot/);
     assert.match(studio, /source: this\.sourceAsset/);
-    assert.match(studio, /FRONTEND_BUILD = "20260726\.3"/);
+    assert.match(studio, /FRONTEND_BUILD = "20260726\.4"/);
     assert.doesNotMatch(studio, /vnccs-i3s__brand/);
     assert.doesNotMatch(studio, /Image to Gaussian scene/);
     assert.match(studio, /<option value="524288">524K · Experimental<\/option>/);
@@ -415,18 +415,26 @@ test("Camera block provides graphical FPV control, one Cameras group, and LIST c
     )?.[0] || "";
     assert.match(cameraBlock, />Camera</);
     assert.match(cameraBlock, /vnccs-i3s__camera-look/);
-    assert.match(cameraBlock, /type="range"[\s\S]*?aria-label="Roll camera"/);
+    assert.doesNotMatch(cameraBlock, /camera-roll|Roll camera|slider to roll/);
     assert.match(cameraBlock, />Add camera</);
     assert.match(cameraBlock, /<strong>Cameras<\/strong>/);
     assert.doesNotMatch(cameraBlock, /type="text"/);
     assert.doesNotMatch(cameraBlock, /type="number"/);
+    const cameraControls = studio.match(
+        /_bindCameraControls\(\) \{[\s\S]*?\n    \}\n\n    async addCamera/,
+    )?.[0] || "";
+    assert.match(cameraControls, /setPointerCapture\?\.\(event\.pointerId\)/);
+    assert.match(cameraControls, /rotate\(\{ yaw: -deltaX \* 0\.18, pitch: -deltaY \* 0\.18 \}\)/);
+    assert.doesNotMatch(cameraControls, /cameraRoll|roll\s*:/);
     assert.match(studio, /async addCamera\(\)/);
     assert.match(studio, /_selectCamera\(cameraId\)/);
     assert.match(studio, /_exitCameraView\(\{ restore = true \}/);
     assert.match(studio, /this\._cameraReturnState = this\._normalizeCameraState/);
     assert.match(studio, /cameras: this\._normalizeSceneCameras/);
     assert.match(viewer, /rotateCameraFPV/);
-    assert.match(viewer, /this\.camera\.quaternion\.multiply\(delta\)/);
+    assert.match(viewer, /this\.camera\.up\.copy\(worldUp\)/);
+    assert.match(viewer, /this\.camera\.lookAt\(this\.controls\.target\)/);
+    assert.doesNotMatch(viewer, /new THREE\.Euler\(pitchRadians, yawRadians, rollRadians/);
     assert.match(viewer, /cameraState = null/);
     assert.match(studio, /captureSet: sceneId =>/);
     assert.match(studio, /form\.append\("current", current, "current\.png"\)/);
@@ -601,7 +609,7 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
     assert.equal(typeof module.validateSplatBuffer, "function");
     assert.equal(typeof module.prepareSplatBuffer, "function");
     assert.equal(typeof module.prepareSplatBufferAsync, "function");
-    assert.equal(module.FACTORY_VIEWER_BUILD, "20260726.17");
+    assert.equal(module.FACTORY_VIEWER_BUILD, "20260726.18");
     const fpvViewer = Object.create(module.Factory3DViewer.prototype);
     fpvViewer.camera = new THREE.PerspectiveCamera(42, 1, 0.01, 1000);
     fpvViewer.camera.position.set(1, 2, 3);
@@ -615,15 +623,32 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
     fpvViewer.invalidate = () => {};
     fpvViewer.options = { onStateChange() {} };
     const fpvPosition = fpvViewer.camera.position.clone();
-    fpvViewer.rotateCameraFPV(
-        { yaw: 18, pitch: -7, roll: 11 },
-        { emit: false },
-    );
+    for (const delta of [
+        { yaw: 18, pitch: -7 },
+        { yaw: -9, pitch: 4 },
+        { yaw: 13, pitch: -3 },
+        { yaw: -5, pitch: 6 },
+    ]) {
+        fpvViewer.rotateCameraFPV(delta, { emit: false });
+    }
     assert.deepEqual(fpvViewer.camera.position.toArray(), fpvPosition.toArray());
     assert.ok(
         Math.abs(fpvViewer.camera.position.distanceTo(fpvViewer.controls.target) - 1) < 1e-9,
     );
-    assert.notDeepEqual(fpvViewer.camera.up.toArray(), [0, 1, 0]);
+    assert.deepEqual(fpvViewer.camera.up.toArray(), [0, 1, 0]);
+    const fpvForward = fpvViewer.controls.target.clone()
+        .sub(fpvViewer.camera.position)
+        .normalize();
+    const expectedScreenUp = new THREE.Vector3(0, 1, 0)
+        .addScaledVector(fpvForward, -fpvForward.y)
+        .normalize();
+    const actualScreenUp = new THREE.Vector3(0, 1, 0)
+        .applyQuaternion(fpvViewer.camera.quaternion)
+        .normalize();
+    assert.ok(
+        actualScreenUp.distanceTo(expectedScreenUp) < 1e-9,
+        "yaw/pitch look input must not accumulate camera roll",
+    );
     assert.deepEqual(fpvViewer.getCameraState().position, [1, 2, 3]);
     const modifierState = module.createDirectionalLightingModifier();
     assert.equal(typeof modifierState.modifier.apply, "function");

--- a/tests/test_factory3d_frontend.mjs
+++ b/tests/test_factory3d_frontend.mjs
@@ -17,7 +17,7 @@ test("Factory widget registers the renamed node and persists opaque state", () =
     assert.match(studio, /selected_object_id/);
     assert.match(studio, /scene_snapshot/);
     assert.match(studio, /source: this\.sourceAsset/);
-    assert.match(studio, /FRONTEND_BUILD = "20260725\.20"/);
+    assert.match(studio, /FRONTEND_BUILD = "20260726\.3"/);
     assert.doesNotMatch(studio, /vnccs-i3s__brand/);
     assert.doesNotMatch(studio, /Image to Gaussian scene/);
     assert.match(studio, /<option value="524288">524K · Experimental<\/option>/);
@@ -54,6 +54,8 @@ test("Factory provides a native Gaussian object and scene library with HF reposi
     assert.match(studio, /libraryRepositoryPublish/);
     assert.match(studio, /libraryRepositoryRefresh/);
     assert.match(viewer, /captureObjectPreview/);
+    assert.match(viewer, /captureSkydomePreview/);
+    assert.match(studio, /this\.viewer\.captureSkydomePreview/);
     assert.match(viewer, /canonicalObjectPreviewCamera/);
     assert.match(viewer, /entry\.mesh\.position\.set\(0, 0, 0\)/);
     assert.match(viewer, /entry\.mesh\.quaternion\.identity\(\)/);
@@ -83,6 +85,25 @@ test("Factory exposes scenes, generation, transforms, and PLY export", () => {
     assert.match(studio, /item\?\.urls\?\.export_ply/);
     assert.match(studio, /exportScene\(\)/);
     assert.match(studio, /download\(scene\.exports\.urls\.ply\)/);
+});
+
+test("Factory imports an existing Gaussian PLY into the scene and viewport", () => {
+    assert.match(studio, />Import PLY</);
+    assert.match(studio, /accept="\.ply,application\/octet-stream"/);
+    assert.match(
+        studio,
+        /importObject: sceneId => `\$\{API_BASE\}\/scenes\/\$\{encodeURIComponent\(sceneId\)\}\/objects\/import`/,
+    );
+    const importMethod = studio.match(
+        /async importPly\(file\) \{[\s\S]*?\n    \}\n\n    async _monitorJob/,
+    );
+    assert.ok(importMethod, "PLY import method not found");
+    assert.match(importMethod[0], /form\.append\("ply", file/);
+    assert.match(importMethod[0], /await this\._applyScene\(result\.scene, \{ preserveSource: true \}\)/);
+    assert.match(importMethod[0], /this\._selectObject\(result\.object_id\)/);
+    assert.match(importMethod[0], /this\.viewer\.fit\(result\.object_id\)/);
+    assert.match(importMethod[0], /this\._scheduleScenePreview\(120\)/);
+    assert.match(styles, /\.vnccs-i3s__ply-import/);
 });
 
 test("Factory provides persistent realtime lighting for Gaussian scenes", () => {
@@ -388,6 +409,34 @@ test("Preview output is captured from the clean 3D viewport and persisted per sc
     assert.doesNotMatch(viewer, /maxSide/);
 });
 
+test("Camera block provides graphical FPV control, one Cameras group, and LIST capture order", () => {
+    const cameraBlock = studio.match(
+        /<section class="vnccs-i3s__section vnccs-i3s__camera-section">[\s\S]*?<\/section>/,
+    )?.[0] || "";
+    assert.match(cameraBlock, />Camera</);
+    assert.match(cameraBlock, /vnccs-i3s__camera-look/);
+    assert.match(cameraBlock, /type="range"[\s\S]*?aria-label="Roll camera"/);
+    assert.match(cameraBlock, />Add camera</);
+    assert.match(cameraBlock, /<strong>Cameras<\/strong>/);
+    assert.doesNotMatch(cameraBlock, /type="text"/);
+    assert.doesNotMatch(cameraBlock, /type="number"/);
+    assert.match(studio, /async addCamera\(\)/);
+    assert.match(studio, /_selectCamera\(cameraId\)/);
+    assert.match(studio, /_exitCameraView\(\{ restore = true \}/);
+    assert.match(studio, /this\._cameraReturnState = this\._normalizeCameraState/);
+    assert.match(studio, /cameras: this\._normalizeSceneCameras/);
+    assert.match(viewer, /rotateCameraFPV/);
+    assert.match(viewer, /this\.camera\.quaternion\.multiply\(delta\)/);
+    assert.match(viewer, /cameraState = null/);
+    assert.match(studio, /captureSet: sceneId =>/);
+    assert.match(studio, /form\.append\("current", current, "current\.png"\)/);
+    assert.match(studio, /for \(const camera of cameras\)/);
+    assert.match(studio, /camera_\$\{camera\.camera_id\}/);
+    assert.match(studio, /_saveExecutionCaptureSet\(captureToken\)/);
+    assert.match(styles, /vnccs-i3s__camera-look-reticle/);
+    assert.match(styles, /vnccs-i3s__camera-item\.is-selected/);
+});
+
 test("Scene export exposes persistent dimensions, aspect presets, and an exact camera frame", () => {
     assert.match(studio, /Aspect ratio/);
     assert.match(studio, /16:9 · Widescreen/);
@@ -552,7 +601,30 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
     assert.equal(typeof module.validateSplatBuffer, "function");
     assert.equal(typeof module.prepareSplatBuffer, "function");
     assert.equal(typeof module.prepareSplatBufferAsync, "function");
-    assert.equal(module.FACTORY_VIEWER_BUILD, "20260725.15");
+    assert.equal(module.FACTORY_VIEWER_BUILD, "20260726.17");
+    const fpvViewer = Object.create(module.Factory3DViewer.prototype);
+    fpvViewer.camera = new THREE.PerspectiveCamera(42, 1, 0.01, 1000);
+    fpvViewer.camera.position.set(1, 2, 3);
+    fpvViewer.controls = {
+        target: new THREE.Vector3(1, 2, 2),
+        update() {},
+    };
+    fpvViewer.camera.lookAt(fpvViewer.controls.target);
+    fpvViewer.captureFov = 42;
+    fpvViewer._disposed = false;
+    fpvViewer.invalidate = () => {};
+    fpvViewer.options = { onStateChange() {} };
+    const fpvPosition = fpvViewer.camera.position.clone();
+    fpvViewer.rotateCameraFPV(
+        { yaw: 18, pitch: -7, roll: 11 },
+        { emit: false },
+    );
+    assert.deepEqual(fpvViewer.camera.position.toArray(), fpvPosition.toArray());
+    assert.ok(
+        Math.abs(fpvViewer.camera.position.distanceTo(fpvViewer.controls.target) - 1) < 1e-9,
+    );
+    assert.notDeepEqual(fpvViewer.camera.up.toArray(), [0, 1, 0]);
+    assert.deepEqual(fpvViewer.getCameraState().position, [1, 2, 3]);
     const modifierState = module.createDirectionalLightingModifier();
     assert.equal(typeof modifierState.modifier.apply, "function");
     assert.deepEqual(modifierState.objectCenter.value.toArray(), [0, 0, 0]);
@@ -776,6 +848,33 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
             );
         },
     };
+    previewViewer.invalidate = () => {};
+    previewViewer.skydome = { visible: false };
+    previewViewer.skydomeTexture = {};
+    previewViewer._applySkydomeSettings = () => {};
+    selectedPreviewEntry.mesh.visible = false;
+    selectedPreviewEntry.splat.visible = false;
+    let skydomeCaptureIds = null;
+    let skydomeWasVisible = false;
+    previewViewer.capturePreview = async () => {
+        skydomeCaptureIds = previewViewer.scene.children
+            .map(child => child.userData?.factoryObjectId)
+            .filter(Boolean);
+        skydomeWasVisible = previewViewer.skydome.visible;
+        return "skydome-preview";
+    };
+    const skydomePreview = await previewViewer.captureSkydomePreview();
+    assert.equal(skydomePreview, "skydome-preview");
+    assert.deepEqual(skydomeCaptureIds, []);
+    assert.equal(skydomeWasVisible, true);
+    assert.equal(previewViewer.skydome.visible, false);
+    assert.equal(firstPreviewEntry.mesh.parent, previewViewer.scene);
+    assert.equal(selectedPreviewEntry.mesh.parent, previewViewer.scene);
+    assert.equal(firstPreviewEntry.mesh.visible, true);
+    assert.equal(selectedPreviewEntry.mesh.visible, false);
+    assert.equal(selectedPreviewEntry.splat.visible, false);
+    mappingSnapshots.length = 0;
+
     let capturedIds = [];
     let capturedTransform = null;
     previewViewer.capturePreview = async () => {

--- a/tests/test_factory3d_library.py
+++ b/tests/test_factory3d_library.py
@@ -173,7 +173,21 @@ class FactoryLibraryTests(unittest.TestCase):
         )
         scene = self.factory.load_scene(scene["scene_id"])
         scene["skydome"].update({"yaw": 72, "pitch": -4, "exposure": 0.6})
-        scene["camera"] = {"position": [8, 7, 6], "target": [1, 2, 3], "fov": 55}
+        scene["camera"] = {
+            "position": [8, 7, 6],
+            "target": [1, 2, 3],
+            "up": [0, 1, 0],
+            "fov": 55,
+        }
+        saved_camera_id = self.factory._new_id()
+        scene["cameras"] = [{
+            "camera_id": saved_camera_id,
+            "name": "Detail camera",
+            "position": [3, 2, 1],
+            "target": [0, 0, 0],
+            "up": [0, 1, 0],
+            "fov": 48,
+        }]
         scene["render"] = {
             "width": 1600,
             "height": 900,
@@ -215,6 +229,9 @@ class FactoryLibraryTests(unittest.TestCase):
         self.assertTrue(result["created_scene"])
         restored = self.factory.load_scene(result["scene"]["scene_id"])
         self.assertEqual(restored["camera"]["position"], [8.0, 7.0, 6.0])
+        self.assertEqual(len(restored["cameras"]), 1)
+        self.assertNotEqual(restored["cameras"][0]["camera_id"], saved_camera_id)
+        self.assertEqual(restored["cameras"][0]["position"], [3.0, 2.0, 1.0])
         self.assertEqual(restored["render"]["width"], 1600)
         self.assertEqual(restored["lighting"]["preset"], "sunset")
         self.assertEqual(restored["layers"][0]["type"], "group")

--- a/tests/test_factory3d_node.py
+++ b/tests/test_factory3d_node.py
@@ -32,10 +32,11 @@ class FactoryNodeTests(unittest.TestCase):
     def setUpClass(cls):
         cls.module = load_node_module()
 
-    def test_node_contract_exposes_only_the_scene_render(self):
+    def test_node_contract_exposes_current_and_saved_camera_renders_as_a_list(self):
         node = self.module.VNCCS_3DFactory
         self.assertEqual(node.RETURN_TYPES, ("IMAGE",))
         self.assertEqual(node.RETURN_NAMES, ("preview",))
+        self.assertEqual(node.OUTPUT_IS_LIST, (True,))
         self.assertIn("factory_data", node.INPUT_TYPES()["required"])
         self.assertEqual(node.CATEGORY, "VNCCS/3D")
 
@@ -59,8 +60,17 @@ class FactoryNodeTests(unittest.TestCase):
                     "camera": {
                         "position": [2.0, 3.0, 4.0],
                         "target": [0.0, 0.0, 0.0],
+                        "up": [0.0, 1.0, 0.0],
                         "fov": 42.0,
                     },
+                    "cameras": [{
+                        "camera_id": "e" * 32,
+                        "name": "Camera 1",
+                        "position": [1.0, 2.0, 3.0],
+                        "target": [0.0, 0.0, 0.0],
+                        "up": [0.0, 1.0, 0.0],
+                        "fov": 48.0,
+                    }],
                     "objects": [
                         {"object_id": "b" * 32, "transform": {}, "visible": True},
                         {"object_id": "c" * 32, "transform": {}, "visible": False},
@@ -181,6 +191,7 @@ class FactoryNodeTests(unittest.TestCase):
                 }],
             },
             _scene_preview_file=lambda _scene: preview_path,
+            _scene_capture_files=mock.Mock(side_effect=FileNotFoundError("no set")),
             resolve_scene_dir=lambda _scene_id: ROOT,
         )
         state = json.dumps({"schema_version": 2, "scene_id": scene_id})
@@ -190,7 +201,7 @@ class FactoryNodeTests(unittest.TestCase):
         ):
             result = self.module.VNCCS_3DFactory().load_scene(state)
         render.assert_called_once_with(preview_path)
-        self.assertEqual(result[0], "3d-scene-render")
+        self.assertEqual(result[0], ["3d-scene-render"])
 
     def test_nonempty_scene_without_current_preview_fails_instead_of_returning_black_square(self):
         scene_id = "a" * 32
@@ -202,6 +213,7 @@ class FactoryNodeTests(unittest.TestCase):
             load_scene=lambda _scene_id: scene,
             update_scene=lambda _scene_id, _snapshot: scene,
             _scene_preview_file=mock.Mock(side_effect=FileNotFoundError("stale")),
+            _scene_capture_files=mock.Mock(side_effect=FileNotFoundError("stale")),
             resolve_scene_dir=lambda _scene_id: ROOT,
         )
         state = json.dumps({"schema_version": 2, "scene_id": scene_id})
@@ -221,30 +233,40 @@ class FactoryNodeTests(unittest.TestCase):
         scene_id = "a" * 32
         capture_token = "c" * 32
         preview_path = ROOT / "preview" / "scene.png"
+        camera_path = ROOT / "preview" / "camera.png"
+        camera_id = "d" * 32
         scene = {
             "scene_id": scene_id,
             "revision": 4,
             "render_revision": 7,
             "objects": [{"object_id": "b" * 32}],
-            "preview": {},
+            "cameras": [{
+                "camera_id": camera_id,
+                "name": "Camera 1",
+                "position": [1, 2, 3],
+                "target": [0, 0, 0],
+                "up": [0, 1, 0],
+                "fov": 42,
+            }],
+            "capture_set": {},
         }
         events = []
 
         def send_sync(name, payload):
             events.append((name, payload))
-            scene["preview"]["capture_token"] = payload["capture_token"]
+            scene["capture_set"]["capture_token"] = payload["capture_token"]
 
-        def preview_file(value, expected_capture_token=""):
+        def capture_files(value, expected_capture_token=""):
             if (
                 expected_capture_token
-                and value["preview"].get("capture_token") != expected_capture_token
+                and value["capture_set"].get("capture_token") != expected_capture_token
             ):
                 raise FileNotFoundError("capture pending")
-            return preview_path
+            return [preview_path, camera_path]
 
         backend = types.SimpleNamespace(
             load_scene=lambda _scene_id: scene,
-            _scene_preview_file=preview_file,
+            _scene_capture_files=capture_files,
             resolve_scene_dir=lambda _scene_id: ROOT,
         )
         server = types.ModuleType("server")
@@ -257,11 +279,17 @@ class FactoryNodeTests(unittest.TestCase):
             mock.patch.dict(sys.modules, {"server": server}),
             mock.patch.object(self.module.uuid, "uuid4", return_value=token_value),
             mock.patch.object(self.module, "_backend", return_value=backend),
-            mock.patch.object(self.module, "_preview_tensor", return_value="fresh-preview"),
+            mock.patch.object(
+                self.module,
+                "_preview_tensor",
+                side_effect=lambda path: (
+                    "fresh-current" if path == preview_path else "fresh-camera"
+                ),
+            ),
         ):
             result = self.module.VNCCS_3DFactory().load_scene(state, unique_id="17")
 
-        self.assertEqual(result[0], "fresh-preview")
+        self.assertEqual(result[0], ["fresh-current", "fresh-camera"])
         self.assertEqual(events[0][0], "vnccs_req_3d_factory_preview")
         self.assertEqual(events[0][1]["node_id"], "17")
         self.assertEqual(events[0][1]["capture_token"], capture_token)

--- a/tests/test_pose_character_regressions.mjs
+++ b/tests/test_pose_character_regressions.mjs
@@ -103,8 +103,8 @@ test("per-character position and zoom are evaluated for playback and full captur
         "updateCharacterScene({ frame = null, poseIndex = this.activeTab, rebuildMissing = true } = {})",
         "\n    syncCharacterEditorControls()",
     );
-    assert.match(sceneMethod, /const activeTransform = this\.characterTransformForScene\(active, \{ frame \}\)/);
-    assert.match(sceneMethod, /const transform = this\.characterTransformForScene\(character, \{ frame \}\)/);
+    assert.match(sceneMethod, /const activeTransform = this\.characterTransformForScene\(active, \{ frame, poseIndex \}\)/);
+    assert.match(sceneMethod, /const transform = this\.characterTransformForScene\(character, \{ frame, poseIndex \}\)/);
     assert.match(sceneMethod, /this\.viewer\.setPassiveCharacterState\(character\.id,[\s\S]*transform,/);
 
     const persistMethod = methodSource(
@@ -115,6 +115,62 @@ test("per-character position and zoom are evaluated for playback and full captur
     assert.match(
         persistMethod,
         /this\.captureAnimationTransformEdits\(previousTransform, nextTransform\)/,
+    );
+});
+
+test("image pose tabs keep independent camera framing", () => {
+    const persistMethod = methodSource(
+        poseStudioSource,
+        "persistActivePoseCameraParams()",
+        "\n    currentCameraParams()",
+    );
+    assert.match(
+        persistMethod,
+        /pose\.cameraParams = \{ \.\.\.cameraParams \}/,
+    );
+    assert.match(persistMethod, /this\.poses\[this\.activeTab\] = pose/);
+
+    const switchMethod = methodSource(
+        poseStudioSource,
+        "switchTab(index)",
+        "\n    addTab(",
+    );
+    const saveCamera = switchMethod.indexOf(
+        "savedPose.cameraParams = this.currentCameraParams()",
+    );
+    const changeTab = switchMethod.indexOf("this.activeTab = index");
+    const restoreCamera = switchMethod.indexOf(
+        "this.restoreActivePoseCameraParams({ updateViewer: false })",
+    );
+    assert.ok(saveCamera >= 0 && saveCamera < changeTab);
+    assert.ok(restoreCamera > changeTab);
+
+    const transformMethod = methodSource(
+        poseStudioSource,
+        "characterTransformForScene(character, { frame = null, poseIndex = this.activeTab } = {})",
+        "\n    updateCharacterScene(",
+    );
+    assert.match(
+        transformMethod,
+        /this\.cameraParamsForPose\(\s*character\.poses\[poseIndex\]/,
+    );
+
+    const syncMethod = methodSource(
+        poseStudioSource,
+        "syncToNode(fullCapture = false, options = {})",
+        "\n    loadFromNode()",
+    );
+    assert.match(
+        syncMethod,
+        /syncPose\.cameraParams = this\.currentCameraParams\(\)/,
+    );
+    assert.match(
+        syncMethod,
+        /const poseCamera = resolveCaptureCameraParams\(\s*capturePoses\[i\]\?\.cameraParams/,
+    );
+    assert.doesNotMatch(
+        syncMethod,
+        /serialized\.poses = serialized\.poses\.map\(pose => this\.stripSceneCameraFromPose\(pose\)\)/,
     );
 });
 

--- a/tests/test_pose_widget_bootstrap.mjs
+++ b/tests/test_pose_widget_bootstrap.mjs
@@ -288,4 +288,56 @@ test("Pose Studio constructs its DOM widget and hides pose_data during node boot
     assert.equal(poseWidget.hidden, true);
     assert.equal(poseWidget.computeSize()[0], 0);
     assert.equal(poseWidget.computeSize()[1], -4);
+
+    const studio = node.studioWidget;
+    studio.exportParams.editor_mode = "image";
+    studio.poses = [
+        {
+            cameraParams: {
+                offset_x: -2,
+                offset_y: 1,
+                zoom: 1.25,
+                yaw_deg: -20,
+                pitch_deg: 5,
+            },
+        },
+        {
+            cameraParams: {
+                offset_x: 4,
+                offset_y: -3,
+                zoom: 2.5,
+                yaw_deg: 35,
+                pitch_deg: -10,
+            },
+        },
+    ];
+    studio.characters[0].poses = studio.poses;
+
+    studio.activeTab = 0;
+    studio.restoreActivePoseCameraParams({ updateViewer: false });
+    assert.deepEqual(
+        [
+            studio.exportParams.cam_offset_x,
+            studio.exportParams.cam_offset_y,
+            studio.exportParams.cam_zoom,
+            studio.exportParams.cam_yaw_deg,
+            studio.exportParams.cam_pitch_deg,
+        ],
+        [-2, 1, 1.25, -20, 5],
+    );
+
+    studio.activeTab = 1;
+    studio.restoreActivePoseCameraParams({ updateViewer: false });
+    studio.exportParams.cam_zoom = 3;
+    studio.persistActivePoseCameraParams();
+    assert.equal(studio.poses[0].cameraParams.zoom, 1.25);
+    assert.equal(studio.poses[1].cameraParams.zoom, 3);
+
+    studio.syncToNode(false, {
+        skipCapture: true,
+        skipCaptureUpload: true,
+    });
+    const savedState = JSON.parse(poseWidget.value);
+    assert.equal(savedState.characters[0].poses[0].cameraParams.zoom, 1.25);
+    assert.equal(savedState.characters[0].poses[1].cameraParams.zoom, 3);
 });

--- a/tests/test_widget_hardening.mjs
+++ b/tests/test_widget_hardening.mjs
@@ -148,7 +148,7 @@ test("Pose Manager independently fits and centers every deformed pose preview", 
     );
     assert.match(
         refreshMethod,
-        /finally \{[\s\S]*viewer\.updateCaptureCamera\?\.\(w, h, 1, 0, 0, yaw, pitch\);/,
+        /finally \{[\s\S]*viewer\.updateCaptureCamera\?\.\([\s\S]*activeCamera\.yaw_deg,[\s\S]*activeCamera\.pitch_deg/,
         "manager preview fitting must not leak its temporary camera into Studio or library poses",
     );
 
@@ -245,9 +245,10 @@ test("the original camera positioning widget controls the selected character", (
     const persistStart = characterEnd;
     const persistEnd = poseStudioSource.indexOf("\n    currentCameraParams()", persistStart);
     const persistMethod = poseStudioSource.slice(persistStart, persistEnd);
-    assert.match(persistMethod, /x:\s*this\.exportParams\.cam_offset_x/);
-    assert.match(persistMethod, /y:\s*this\.exportParams\.cam_offset_y/);
-    assert.match(persistMethod, /zoom:\s*this\.exportParams\.cam_zoom/);
+    assert.match(persistMethod, /const cameraParams = this\.currentCameraParams\(\)/);
+    assert.match(persistMethod, /x:\s*cameraParams\.offset_x/);
+    assert.match(persistMethod, /y:\s*cameraParams\.offset_y/);
+    assert.match(persistMethod, /zoom:\s*cameraParams\.zoom/);
 
     const radarStart = poseStudioSource.indexOf("createCameraRadar(section)");
     const radarEnd = poseStudioSource.indexOf("\n    createLightRadar", radarStart);

--- a/web/vnccs_3d_factory.css
+++ b/web/vnccs_3d_factory.css
@@ -73,8 +73,19 @@
     pointer-events: auto;
     user-select: none;
 }
-.vnccs-i3s__library-launcher-wrap { padding-bottom: 5px; }
-.vnccs-i3s__library-launcher-wrap .vnccs-ps-btn { width: 100%; padding: 10px; }
+.vnccs-i3s__library-launcher-wrap {
+    display: grid;
+    grid-template-columns: minmax(0,1.2fr) minmax(0,1fr);
+    gap: 7px;
+    padding-bottom: 5px;
+}
+.vnccs-i3s__library-launcher-wrap .vnccs-ps-btn,
+.vnccs-i3s__library-launcher-wrap .vnccs-i3s__ply-import {
+    width: 100%;
+    min-width: 0;
+    padding: 10px 8px;
+}
+.vnccs-i3s__ply-import svg { width: 15px; height: 15px; }
 .vnccs-i3s *, .vnccs-i3s *::before, .vnccs-i3s *::after { box-sizing: border-box; }
 .vnccs-i3s [hidden] { display: none !important; }
 .vnccs-i3s button, .vnccs-i3s input, .vnccs-i3s textarea, .vnccs-i3s select { font: inherit; }
@@ -156,6 +167,193 @@
 .vnccs-i3s__seed-dice svg { width: 17px; height: 17px; }
 .vnccs-i3s__seed-dice svg .fill { fill: currentColor; stroke: none; }
 .vnccs-i3s__seed-dice.active { border-color: rgba(255,143,163,.7); background: rgba(255,143,163,.18); color: #ffdce5; box-shadow: 0 0 0 1px rgba(255,143,163,.14) inset; }
+
+.vnccs-i3s__camera-section {
+    border-color: rgba(184,169,232,.16);
+    background: linear-gradient(155deg,rgba(184,169,232,.035),rgba(255,143,163,.018));
+}
+.vnccs-i3s__camera-count,
+.vnccs-i3s__camera-group-count {
+    flex: none;
+    min-width: 21px;
+    padding: 1px 6px;
+    border: 1px solid rgba(184,169,232,.2);
+    border-radius: 99px;
+    background: rgba(184,169,232,.07);
+    color: var(--i3-lavender);
+    font: 700 .88em var(--i3-mono);
+    text-align: center;
+}
+.vnccs-i3s__camera-look {
+    position: relative;
+    height: calc(92px * var(--i3-scale));
+    min-height: 76px;
+    overflow: hidden;
+    border: 1px solid rgba(184,169,232,.2);
+    border-radius: 12px;
+    background:
+        radial-gradient(circle at 50% 50%,rgba(255,143,163,.1),transparent 15%),
+        radial-gradient(circle at 50% 50%,rgba(184,169,232,.075),transparent 64%),
+        #0a0910;
+    color: var(--i3-muted);
+    cursor: grab;
+    touch-action: none;
+}
+.vnccs-i3s__camera-look:hover {
+    border-color: rgba(255,143,163,.38);
+    color: var(--i3-pink-hi);
+}
+.vnccs-i3s__camera-look.is-active {
+    cursor: grabbing;
+    border-color: rgba(255,143,163,.62);
+    box-shadow: inset 0 0 28px rgba(255,143,163,.065),0 0 0 3px rgba(255,143,163,.035);
+}
+.vnccs-i3s__camera-look-axis {
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    background: rgba(184,169,232,.13);
+    pointer-events: none;
+}
+.vnccs-i3s__camera-look-axis--x { width: 70%; height: 1px; transform: translate(-50%,-50%); }
+.vnccs-i3s__camera-look-axis--y { width: 1px; height: 70%; transform: translate(-50%,-50%); }
+.vnccs-i3s__camera-look-arrow {
+    position: absolute;
+    color: currentColor;
+    font: 800 18px/1 var(--i3-font);
+    opacity: .66;
+    pointer-events: none;
+}
+.vnccs-i3s__camera-look-arrow--up { left: 50%; top: 5px; transform: translateX(-50%); }
+.vnccs-i3s__camera-look-arrow--right { right: 8px; top: 50%; transform: translateY(-55%); }
+.vnccs-i3s__camera-look-arrow--down { left: 50%; bottom: 4px; transform: translateX(-50%); }
+.vnccs-i3s__camera-look-arrow--left { left: 8px; top: 50%; transform: translateY(-55%); }
+.vnccs-i3s__camera-look-reticle {
+    position: absolute;
+    left: calc(50% - 9px);
+    top: calc(50% - 9px);
+    width: 18px;
+    height: 18px;
+    border: 1px solid var(--i3-pink);
+    border-radius: 50%;
+    box-shadow: 0 0 12px rgba(255,143,163,.34);
+    pointer-events: none;
+    transition: transform .045s linear;
+}
+.vnccs-i3s__camera-look-reticle::before,
+.vnccs-i3s__camera-look-reticle::after {
+    content: "";
+    position: absolute;
+    left: 50%;
+    top: 50%;
+    background: var(--i3-pink-hi);
+    transform: translate(-50%,-50%);
+}
+.vnccs-i3s__camera-look-reticle::before { width: 24px; height: 1px; }
+.vnccs-i3s__camera-look-reticle::after { width: 1px; height: 24px; }
+.vnccs-i3s__camera-roll {
+    display: grid;
+    grid-template-columns: 22px minmax(0,1fr) 22px;
+    align-items: center;
+    gap: 5px;
+}
+.vnccs-i3s__camera-roll-icon {
+    display: grid;
+    place-items: center;
+    color: var(--i3-muted);
+}
+.vnccs-i3s__camera-roll-icon svg { width: 16px; height: 16px; }
+.vnccs-i3s__camera-roll-range { margin: 0; cursor: ew-resize; }
+.vnccs-i3s__camera-help {
+    margin-top: -5px;
+    color: var(--i3-dim);
+    font-size: .68em;
+    letter-spacing: .025em;
+    text-align: center;
+}
+.vnccs-i3s__camera-manager {
+    overflow: hidden;
+    border: 1px solid var(--i3-line);
+    border-radius: 9px;
+    background: rgba(5,5,9,.25);
+}
+.vnccs-i3s__camera-group-head {
+    min-height: 28px;
+    display: grid;
+    grid-template-columns: 19px minmax(0,1fr) auto;
+    align-items: center;
+    gap: 6px;
+    padding: 5px 7px;
+    border-bottom: 1px solid var(--i3-line);
+    color: var(--i3-muted);
+}
+.vnccs-i3s__camera-group-head > span:first-child { color: var(--i3-lavender); }
+.vnccs-i3s__camera-group-head svg { width: 15px; height: 15px; }
+.vnccs-i3s__camera-group-head strong { color: var(--i3-text); font-size: .78em; }
+.vnccs-i3s__camera-list {
+    max-height: 150px;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: 4px;
+}
+.vnccs-i3s__camera-empty {
+    padding: 8px;
+    color: var(--i3-dim);
+    font-size: .72em;
+    text-align: center;
+}
+.vnccs-i3s__camera-item {
+    min-width: 0;
+    min-height: 30px;
+    display: grid;
+    grid-template-columns: 20px 20px minmax(0,1fr) 25px;
+    align-items: center;
+    gap: 4px;
+    padding: 3px 3px 3px 5px;
+    border: 1px solid transparent;
+    border-radius: 7px;
+    color: var(--i3-muted);
+    background: rgba(255,255,255,.018);
+    cursor: pointer;
+}
+.vnccs-i3s__camera-item:hover { border-color: var(--i3-line-strong); background: var(--i3-hover); }
+.vnccs-i3s__camera-item.is-selected {
+    border-color: var(--i3-pink-line);
+    background: linear-gradient(90deg,rgba(255,143,163,.11),rgba(184,169,232,.055));
+    color: var(--i3-pink-hi);
+}
+.vnccs-i3s__camera-index {
+    color: var(--i3-dim);
+    font: .68em var(--i3-mono);
+    text-align: center;
+}
+.vnccs-i3s__camera-item-icon { color: var(--i3-lavender); }
+.vnccs-i3s__camera-item-icon svg { width: 15px; height: 15px; }
+.vnccs-i3s__camera-item-name {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    color: var(--i3-text);
+    font-size: .76em;
+    font-weight: 680;
+}
+.vnccs-i3s__camera-delete {
+    width: 24px;
+    height: 24px;
+    display: grid;
+    place-items: center;
+    padding: 0;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--i3-dim);
+    cursor: pointer;
+}
+.vnccs-i3s__camera-delete:hover { background: rgba(255,91,107,.1); color: #ff9ba6; }
+.vnccs-i3s__camera-delete svg { width: 13px; height: 13px; }
 
 .vnccs-i3s__button { min-height: calc(31px * var(--i3-scale)); display: inline-flex; align-items: center; justify-content: center; gap: 6px; padding: 6px 10px; border: 1px solid var(--i3-line-strong); border-radius: var(--i3-radius-sm); background: var(--i3-surface); color: var(--i3-text); font-weight: 700; cursor: pointer; transition: transform .14s ease, border-color .14s ease, background .14s ease, color .14s ease; }
 .vnccs-i3s__button:hover:not(:disabled) { border-color: var(--i3-pink-line); background: var(--i3-hover); color: var(--i3-pink-hi); }

--- a/web/vnccs_3d_factory.css
+++ b/web/vnccs_3d_factory.css
@@ -251,19 +251,6 @@
 }
 .vnccs-i3s__camera-look-reticle::before { width: 24px; height: 1px; }
 .vnccs-i3s__camera-look-reticle::after { width: 1px; height: 24px; }
-.vnccs-i3s__camera-roll {
-    display: grid;
-    grid-template-columns: 22px minmax(0,1fr) 22px;
-    align-items: center;
-    gap: 5px;
-}
-.vnccs-i3s__camera-roll-icon {
-    display: grid;
-    place-items: center;
-    color: var(--i3-muted);
-}
-.vnccs-i3s__camera-roll-icon svg { width: 16px; height: 16px; }
-.vnccs-i3s__camera-roll-range { margin: 0; cursor: ew-resize; }
 .vnccs-i3s__camera-help {
     margin-top: -5px;
     color: var(--i3-dim);

--- a/web/vnccs_3d_factory.js
+++ b/web/vnccs_3d_factory.js
@@ -1,7 +1,7 @@
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
 import { installCustomSelects } from "./vnccs_custom_select.mjs";
-import { Factory3DViewer } from "./vnccs_3d_factory_viewer.js?v=20260726.17";
+import { Factory3DViewer } from "./vnccs_3d_factory_viewer.js?v=20260726.18";
 
 
 const VNCCS_DONATE_BANNER_URL = new URL("./assets/VNCCS_Donate_Button.png", import.meta.url).href;
@@ -40,7 +40,7 @@ const ENDPOINTS = Object.freeze({
 });
 const DEFAULT_NODE_SIZE = Object.freeze([1100, 760]);
 const STATE_VERSION = 10;
-const FRONTEND_BUILD = "20260726.3";
+const FRONTEND_BUILD = "20260726.4";
 const MAX_IMAGE_BYTES = 32 * 1024 * 1024;
 const MAX_PLY_BYTES = 2 * 1024 * 1024 * 1024;
 const MAX_SKYDOME_BYTES = 64 * 1024 * 1024;
@@ -167,8 +167,6 @@ const ICONS = Object.freeze({
     dice: `<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="3.5"/><circle cx="8.5" cy="8.5" r="1.4" class="fill"/><circle cx="15.5" cy="8.5" r="1.4" class="fill"/><circle cx="12" cy="12" r="1.4" class="fill"/><circle cx="8.5" cy="15.5" r="1.4" class="fill"/><circle cx="15.5" cy="15.5" r="1.4" class="fill"/></svg>`,
     camera: `<svg viewBox="0 0 24 24"><path d="M4 7.5h3l1.4-2h7.2l1.4 2h3v11H4v-11Z"/><circle cx="12" cy="13" r="3.5"/></svg>`,
     cameraAdd: `<svg viewBox="0 0 24 24"><path d="M3 8h3l1.5-2h7L16 8h2v4"/><path d="M12 19H3V8m16 7v6m-3-3h6"/><circle cx="10" cy="13" r="3"/></svg>`,
-    rollLeft: `<svg viewBox="0 0 24 24"><path d="M5 8v5h5"/><path d="M6 13a7 7 0 1 0 2-7"/></svg>`,
-    rollRight: `<svg viewBox="0 0 24 24"><path d="M19 8v5h-5"/><path d="M18 13a7 7 0 1 1-2-7"/></svg>`,
 });
 
 
@@ -526,14 +524,7 @@ class Factory3DWidget {
                             <span class="vnccs-i3s__camera-look-arrow vnccs-i3s__camera-look-arrow--left">‹</span>
                             <span class="vnccs-i3s__camera-look-reticle" aria-hidden="true"></span>
                         </div>
-                        <div class="vnccs-i3s__camera-roll" title="Camera roll">
-                            <span class="vnccs-i3s__camera-roll-icon">${ICONS.rollLeft}</span>
-                            <input class="vnccs-i3s__range vnccs-i3s__camera-roll-range"
-                                type="range" min="-30" max="30" step=".25" value="0"
-                                aria-label="Roll camera" />
-                            <span class="vnccs-i3s__camera-roll-icon">${ICONS.rollRight}</span>
-                        </div>
-                        <div class="vnccs-i3s__camera-help">Drag to look · slider to roll</div>
+                        <div class="vnccs-i3s__camera-help">Drag to look</div>
                         <button class="vnccs-i3s__button vnccs-i3s__button--primary vnccs-i3s__button--block vnccs-i3s__camera-add" type="button">
                             ${ICONS.cameraAdd}<span>Add camera</span>
                         </button>
@@ -785,7 +776,6 @@ class Factory3DWidget {
             generate: $(".vnccs-i3s__generate"),
             cameraLook: $(".vnccs-i3s__camera-look"),
             cameraReticle: $(".vnccs-i3s__camera-look-reticle"),
-            cameraRoll: $(".vnccs-i3s__camera-roll-range"),
             cameraAdd: $(".vnccs-i3s__camera-add"),
             cameraCount: $(".vnccs-i3s__camera-count"),
             cameraGroupCount: $(".vnccs-i3s__camera-group-count"),
@@ -1238,24 +1228,6 @@ class Factory3DWidget {
             event.preventDefault();
             rotate(delta);
         });
-
-        let previousRoll = 0;
-        const startRoll = () => {
-            previousRoll = Number(this.els.cameraRoll.value) || 0;
-        };
-        this._listen(this.els.cameraRoll, "pointerdown", startRoll);
-        this._listen(this.els.cameraRoll, "focus", startRoll);
-        this._listen(this.els.cameraRoll, "input", () => {
-            const value = Number(this.els.cameraRoll.value) || 0;
-            rotate({ roll: value - previousRoll });
-            previousRoll = value;
-        });
-        const resetRoll = () => {
-            previousRoll = 0;
-            this.els.cameraRoll.value = "0";
-        };
-        this._listen(this.els.cameraRoll, "change", resetRoll);
-        this._listen(this.els.cameraRoll, "pointerup", resetRoll);
     }
 
     async addCamera() {

--- a/web/vnccs_3d_factory.js
+++ b/web/vnccs_3d_factory.js
@@ -1,7 +1,7 @@
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
 import { installCustomSelects } from "./vnccs_custom_select.mjs";
-import { Factory3DViewer } from "./vnccs_3d_factory_viewer.js?v=20260725.15";
+import { Factory3DViewer } from "./vnccs_3d_factory_viewer.js?v=20260726.17";
 
 
 const VNCCS_DONATE_BANNER_URL = new URL("./assets/VNCCS_Donate_Button.png", import.meta.url).href;
@@ -19,8 +19,10 @@ const ENDPOINTS = Object.freeze({
     reference: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/reference`,
     skydome: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/skydome`,
     preview: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/preview`,
+    captureSet: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/capture-set`,
     previewError: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/preview/error`,
     generate: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/generate`,
+    importObject: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/objects/import`,
     exportScene: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/export`,
     job: jobId => `${API_BASE}/jobs/${encodeURIComponent(jobId)}`,
     cancelJob: jobId => `${API_BASE}/jobs/${encodeURIComponent(jobId)}/cancel`,
@@ -37,9 +39,10 @@ const ENDPOINTS = Object.freeze({
     libraryRepositoryProgress: taskId => `${LIBRARY_BASE}/repositories/progress/${encodeURIComponent(taskId)}`,
 });
 const DEFAULT_NODE_SIZE = Object.freeze([1100, 760]);
-const STATE_VERSION = 9;
-const FRONTEND_BUILD = "20260725.20";
+const STATE_VERSION = 10;
+const FRONTEND_BUILD = "20260726.3";
 const MAX_IMAGE_BYTES = 32 * 1024 * 1024;
+const MAX_PLY_BYTES = 2 * 1024 * 1024 * 1024;
 const MAX_SKYDOME_BYTES = 64 * 1024 * 1024;
 const TERMINAL = new Set(["completed", "failed", "cancelled"]);
 const DEFAULT_SETTINGS = Object.freeze({
@@ -162,6 +165,10 @@ const ICONS = Object.freeze({
     ungroup: `<svg viewBox="0 0 24 24"><rect x="3" y="5" width="8" height="8" rx="1"/><rect x="13" y="11" width="8" height="8" rx="1"/><path d="M8 16H5v-3m11-5h3v3"/></svg>`,
     chevron: `<svg viewBox="0 0 24 24"><path d="m9 6 6 6-6 6"/></svg>`,
     dice: `<svg viewBox="0 0 24 24" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="3.5"/><circle cx="8.5" cy="8.5" r="1.4" class="fill"/><circle cx="15.5" cy="8.5" r="1.4" class="fill"/><circle cx="12" cy="12" r="1.4" class="fill"/><circle cx="8.5" cy="15.5" r="1.4" class="fill"/><circle cx="15.5" cy="15.5" r="1.4" class="fill"/></svg>`,
+    camera: `<svg viewBox="0 0 24 24"><path d="M4 7.5h3l1.4-2h7.2l1.4 2h3v11H4v-11Z"/><circle cx="12" cy="13" r="3.5"/></svg>`,
+    cameraAdd: `<svg viewBox="0 0 24 24"><path d="M3 8h3l1.5-2h7L16 8h2v4"/><path d="M12 19H3V8m16 7v6m-3-3h6"/><circle cx="10" cy="13" r="3"/></svg>`,
+    rollLeft: `<svg viewBox="0 0 24 24"><path d="M5 8v5h5"/><path d="M6 13a7 7 0 1 0 2-7"/></svg>`,
+    rollRight: `<svg viewBox="0 0 24 24"><path d="M19 8v5h-5"/><path d="M18 13a7 7 0 1 1-2-7"/></svg>`,
 });
 
 
@@ -170,7 +177,7 @@ function installStyles() {
     const link = document.createElement("link");
     link.id = "vnccs-3d-factory-styles";
     link.rel = "stylesheet";
-    link.href = new URL("./vnccs_3d_factory.css?v=20260725.7", import.meta.url).href;
+    link.href = new URL("./vnccs_3d_factory.css?v=20260726.2", import.meta.url).href;
     document.head.appendChild(link);
 }
 
@@ -246,6 +253,7 @@ function numericArraysEqual(left, right, epsilon = 1e-6) {
 function cameraStatesEqual(left = {}, right = {}) {
     return numericArraysEqual(left.position, right.position)
         && numericArraysEqual(left.target, right.target)
+        && numericArraysEqual(left.up || [0, 1, 0], right.up || [0, 1, 0])
         && Math.abs(Number(left.fov || 0) - Number(right.fov || 0)) <= 1e-6;
 }
 
@@ -327,6 +335,10 @@ class Factory3DWidget {
         this.selectedObjectIds = new Set();
         this.selectedGroupId = "";
         this.selectedSkydome = false;
+        this.selectedCameraId = "";
+        this._cameraReturnState = null;
+        this._cameraSelectionTransition = false;
+        this._cameraPadPointer = null;
         this.collapsedGroupIds = new Set();
         this.dragLayer = null;
         this.viewportFailures = new Map();
@@ -337,6 +349,7 @@ class Factory3DWidget {
         this.capabilities = null;
         this.currentJobId = "";
         this.currentJobToken = 0;
+        this.importingPly = false;
         this._listeners = [];
         this._timers = new Set();
         this._saveTimer = 0;
@@ -394,6 +407,7 @@ class Factory3DWidget {
                     cameraChanged
                     && !this._isRestoring
                     && !this._suppressViewerStatePersistence
+                    && !this.selectedCameraId
                     && this.scene
                 ) {
                     this.scene.camera = { ...state.camera };
@@ -410,6 +424,7 @@ class Factory3DWidget {
         this._resizeObserver.observe(this.container);
         this._navigationCleanup = enableCanvasNavigationForwarding(this.container);
         this._renderObjects();
+        this._renderCameras();
         this._syncSettings();
         this._syncExportSettings();
         this._syncLighting();
@@ -492,6 +507,44 @@ class Factory3DWidget {
                             </span>
                         </label>
                         <button class="vnccs-i3s__button vnccs-i3s__button--primary vnccs-i3s__button--block vnccs-i3s__generate" type="button">${ICONS.play}<span>Generate object</span></button>
+                    </div>
+                </section>
+                <section class="vnccs-i3s__section vnccs-i3s__camera-section">
+                    <div class="vnccs-i3s__section-head">
+                        <span>Camera</span>
+                        <span class="vnccs-i3s__camera-count">0</span>
+                    </div>
+                    <div class="vnccs-i3s__section-body">
+                        <div class="vnccs-i3s__camera-look" role="slider" tabindex="0"
+                            aria-label="First-person camera look control"
+                            aria-valuetext="Drag to look left, right, up or down">
+                            <span class="vnccs-i3s__camera-look-axis vnccs-i3s__camera-look-axis--x"></span>
+                            <span class="vnccs-i3s__camera-look-axis vnccs-i3s__camera-look-axis--y"></span>
+                            <span class="vnccs-i3s__camera-look-arrow vnccs-i3s__camera-look-arrow--up">⌃</span>
+                            <span class="vnccs-i3s__camera-look-arrow vnccs-i3s__camera-look-arrow--right">›</span>
+                            <span class="vnccs-i3s__camera-look-arrow vnccs-i3s__camera-look-arrow--down">⌄</span>
+                            <span class="vnccs-i3s__camera-look-arrow vnccs-i3s__camera-look-arrow--left">‹</span>
+                            <span class="vnccs-i3s__camera-look-reticle" aria-hidden="true"></span>
+                        </div>
+                        <div class="vnccs-i3s__camera-roll" title="Camera roll">
+                            <span class="vnccs-i3s__camera-roll-icon">${ICONS.rollLeft}</span>
+                            <input class="vnccs-i3s__range vnccs-i3s__camera-roll-range"
+                                type="range" min="-30" max="30" step=".25" value="0"
+                                aria-label="Roll camera" />
+                            <span class="vnccs-i3s__camera-roll-icon">${ICONS.rollRight}</span>
+                        </div>
+                        <div class="vnccs-i3s__camera-help">Drag to look · slider to roll</div>
+                        <button class="vnccs-i3s__button vnccs-i3s__button--primary vnccs-i3s__button--block vnccs-i3s__camera-add" type="button">
+                            ${ICONS.cameraAdd}<span>Add camera</span>
+                        </button>
+                        <div class="vnccs-i3s__camera-manager" aria-label="Saved cameras">
+                            <div class="vnccs-i3s__camera-group-head">
+                                <span>${ICONS.camera}</span>
+                                <strong>Cameras</strong>
+                                <span class="vnccs-i3s__camera-group-count">0</span>
+                            </div>
+                            <div class="vnccs-i3s__camera-list"></div>
+                        </div>
                     </div>
                 </section>
                 <a class="vnccs-i3s__donate-link" href="https://www.buymeacoffee.com/MIUProject" target="_blank" rel="noopener noreferrer" title="Support MIUProject">
@@ -643,6 +696,10 @@ class Factory3DWidget {
                     <button class="vnccs-ps-btn primary vnccs-i3s__library-open" type="button">
                         <span class="vnccs-ps-btn-icon">📚</span> Model Library
                     </button>
+                    <button class="vnccs-i3s__button vnccs-i3s__ply-import" type="button" title="Import a Gaussian PLY into the active scene">
+                        ${ICONS.upload}<span>Import PLY</span>
+                    </button>
+                    <input class="vnccs-i3s__file-input vnccs-i3s__ply-input" type="file" accept=".ply,application/octet-stream" tabindex="-1" />
                 </div>
                 <section class="vnccs-i3s__section vnccs-i3s__object-section">
                     <div class="vnccs-i3s__section-head"><span>Scene objects</span><span class="vnccs-i3s__object-count">0</span></div>
@@ -726,11 +783,20 @@ class Factory3DWidget {
             seed: $(".vnccs-i3s__seed"),
             seedDice: $(".vnccs-i3s__seed-dice"),
             generate: $(".vnccs-i3s__generate"),
+            cameraLook: $(".vnccs-i3s__camera-look"),
+            cameraReticle: $(".vnccs-i3s__camera-look-reticle"),
+            cameraRoll: $(".vnccs-i3s__camera-roll-range"),
+            cameraAdd: $(".vnccs-i3s__camera-add"),
+            cameraCount: $(".vnccs-i3s__camera-count"),
+            cameraGroupCount: $(".vnccs-i3s__camera-group-count"),
+            cameraList: $(".vnccs-i3s__camera-list"),
             donateLink: $(".vnccs-i3s__donate-link"),
             sceneName: $(".vnccs-i3s__scene-name-input"),
             sceneId: $(".vnccs-i3s__project-id"),
             sceneManager: $(".vnccs-i3s__scene-manager"),
             libraryOpen: $(".vnccs-i3s__library-open"),
+            plyImport: $(".vnccs-i3s__ply-import"),
+            plyInput: $(".vnccs-i3s__ply-input"),
             status: $(".vnccs-i3s__status-pill"),
             viewerHost: $(".vnccs-i3s__viewer-host"),
             fit: $(".vnccs-i3s__fit"),
@@ -871,7 +937,21 @@ class Factory3DWidget {
         this._listen(this.els.donateLink, "click", event => event.stopPropagation());
         this._listen(this.els.modelSetup, "click", () => this.openModelSetup());
         this._listen(this.els.generate, "click", () => void this.generate());
+        this._bindCameraControls();
+        this._listen(this.els.cameraAdd, "click", () => void this.addCamera());
         this._listen(this.els.libraryOpen, "click", () => void this.openLibrary());
+        this._listen(this.els.plyImport, "click", () => {
+            if (this.currentJobId || this.importingPly) {
+                this.toast("Wait for the active Factory job to finish.", "error");
+                return;
+            }
+            this.els.plyInput.click();
+        });
+        this._listen(this.els.plyInput, "change", () => {
+            const file = this.els.plyInput.files?.[0];
+            this.els.plyInput.value = "";
+            if (file) void this.importPly(file);
+        });
         this._listen(this.els.sceneManager, "click", () => void this.openSceneManager());
         this._listen(this.els.sceneName, "change", () => {
             if (!this.scene) return;
@@ -1058,6 +1138,265 @@ class Factory3DWidget {
             this._moveLayer(this.dragLayer, null, "end");
         });
         this._listen(this.els.sceneExport, "click", () => void this.exportScene());
+    }
+
+    _normalizeCameraState(value = {}, fallback = {}) {
+        const source = safeObject(value);
+        const previous = safeObject(fallback);
+        const vector = (key, defaultValue) => {
+            const raw = Array.isArray(source[key]) ? source[key] : previous[key];
+            return Array.isArray(raw) && raw.length === 3 && raw.every(item => Number.isFinite(Number(item)))
+                ? raw.map(Number)
+                : [...defaultValue];
+        };
+        return {
+            position: vector("position", [2.8, 2.1, 4.2]),
+            target: vector("target", [0, 0, 0]),
+            up: vector("up", [0, 1, 0]),
+            fov: clamp(source.fov ?? previous.fov ?? 42, 5, 120),
+        };
+    }
+
+    _normalizeSceneCameras(value) {
+        const output = [];
+        const seen = new Set();
+        for (const [index, raw] of (Array.isArray(value) ? value : []).slice(0, 32).entries()) {
+            const camera = safeObject(raw);
+            const cameraId = String(camera.camera_id || "");
+            if (!/^[a-f0-9]{32}$/.test(cameraId) || seen.has(cameraId)) continue;
+            seen.add(cameraId);
+            output.push({
+                camera_id: cameraId,
+                name: String(camera.name || `Camera ${index + 1}`).slice(0, 80),
+                created_at: Number.isFinite(Number(camera.created_at))
+                    ? Number(camera.created_at)
+                    : 0,
+                ...this._normalizeCameraState(camera),
+            });
+        }
+        return output;
+    }
+
+    _bindCameraControls() {
+        const rotate = delta => {
+            this.viewer?.rotateCameraFPV?.(delta);
+            if (this.selectedCameraId && this.scene) {
+                const camera = this.scene.cameras?.find(
+                    item => item.camera_id === this.selectedCameraId,
+                );
+                if (camera) {
+                    Object.assign(camera, this.viewer.getCameraState());
+                    this._scheduleSceneSave(140);
+                    this._scheduleStateSave(140);
+                }
+            }
+        };
+        const resetPad = () => {
+            this._cameraPadPointer = null;
+            this.els.cameraLook.classList.remove("is-active");
+            this.els.cameraReticle.style.transform = "";
+        };
+        this._listen(this.els.cameraLook, "pointerdown", event => {
+            if (event.button !== 0) return;
+            event.preventDefault();
+            this.els.cameraLook.setPointerCapture?.(event.pointerId);
+            this._cameraPadPointer = {
+                id: event.pointerId,
+                x: event.clientX,
+                y: event.clientY,
+                offsetX: 0,
+                offsetY: 0,
+            };
+            this.els.cameraLook.classList.add("is-active");
+        });
+        this._listen(this.els.cameraLook, "pointermove", event => {
+            const pointer = this._cameraPadPointer;
+            if (!pointer || pointer.id !== event.pointerId) return;
+            event.preventDefault();
+            const deltaX = event.clientX - pointer.x;
+            const deltaY = event.clientY - pointer.y;
+            pointer.x = event.clientX;
+            pointer.y = event.clientY;
+            pointer.offsetX = clamp(pointer.offsetX + deltaX, -34, 34);
+            pointer.offsetY = clamp(pointer.offsetY + deltaY, -34, 34);
+            this.els.cameraReticle.style.transform = (
+                `translate(${pointer.offsetX}px, ${pointer.offsetY}px)`
+            );
+            rotate({ yaw: -deltaX * 0.18, pitch: -deltaY * 0.18 });
+        });
+        for (const type of ["pointerup", "pointercancel", "lostpointercapture"]) {
+            this._listen(this.els.cameraLook, type, resetPad);
+        }
+        this._listen(this.els.cameraLook, "keydown", event => {
+            const delta = {
+                ArrowLeft: { yaw: 2 },
+                ArrowRight: { yaw: -2 },
+                ArrowUp: { pitch: 2 },
+                ArrowDown: { pitch: -2 },
+            }[event.key];
+            if (!delta) return;
+            event.preventDefault();
+            rotate(delta);
+        });
+
+        let previousRoll = 0;
+        const startRoll = () => {
+            previousRoll = Number(this.els.cameraRoll.value) || 0;
+        };
+        this._listen(this.els.cameraRoll, "pointerdown", startRoll);
+        this._listen(this.els.cameraRoll, "focus", startRoll);
+        this._listen(this.els.cameraRoll, "input", () => {
+            const value = Number(this.els.cameraRoll.value) || 0;
+            rotate({ roll: value - previousRoll });
+            previousRoll = value;
+        });
+        const resetRoll = () => {
+            previousRoll = 0;
+            this.els.cameraRoll.value = "0";
+        };
+        this._listen(this.els.cameraRoll, "change", resetRoll);
+        this._listen(this.els.cameraRoll, "pointerup", resetRoll);
+    }
+
+    async addCamera() {
+        if (!this.sceneId) await this.ensureScene();
+        if (!this.scene) return;
+        this.scene.cameras = this._normalizeSceneCameras(this.scene.cameras);
+        if (this.scene.cameras.length >= 32) {
+            this.toast("A scene can contain up to 32 cameras.", "error");
+            return;
+        }
+        const camera = {
+            camera_id: randomLayerId(),
+            name: `Camera ${this.scene.cameras.length + 1}`,
+            created_at: Date.now() / 1000,
+            ...this._normalizeCameraState(this.viewer.getCameraState()),
+        };
+        this.scene.cameras.push(camera);
+        this._renderCameras();
+        this._updateSceneSummary();
+        await this._saveSceneNow();
+        this.toast(`${camera.name} added.`, "success");
+    }
+
+    _selectCamera(cameraId) {
+        const camera = this.scene?.cameras?.find(item => item.camera_id === cameraId);
+        if (!camera) return;
+        if (this.selectedCameraId === cameraId) {
+            this._exitCameraView({ restore: true });
+            return;
+        }
+        if (!this.selectedCameraId) {
+            this._cameraReturnState = this._normalizeCameraState(
+                this.viewer.getCameraState(),
+                this.scene?.camera,
+            );
+        }
+        this._cameraSelectionTransition = true;
+        try {
+            this.selectedObjectId = "";
+            this.selectedObjectIds.clear();
+            this.selectedGroupId = "";
+            this.selectedSkydome = false;
+            this.viewer.select("");
+            this.selectedCameraId = cameraId;
+            this.viewer.setCameraState(camera, { emit: false });
+        } finally {
+            this._cameraSelectionTransition = false;
+        }
+        this._syncSelectionPresentation();
+        this._renderCameras();
+        this._scheduleStateSave();
+    }
+
+    _exitCameraView({ restore = true } = {}) {
+        if (!this.selectedCameraId && !this._cameraReturnState) return;
+        const returnState = this._cameraReturnState;
+        this._cameraSelectionTransition = true;
+        try {
+            this.selectedCameraId = "";
+            this._cameraReturnState = null;
+            if (restore && returnState) {
+                this.viewer.setCameraState(returnState, { emit: false });
+                this.viewerState = {
+                    ...this.viewerState,
+                    camera: this._normalizeCameraState(returnState),
+                };
+            }
+        } finally {
+            this._cameraSelectionTransition = false;
+        }
+        this._renderCameras();
+        this._scheduleStateSave();
+    }
+
+    async _deleteCamera(cameraId) {
+        if (!this.scene) return;
+        const camera = this.scene.cameras?.find(item => item.camera_id === cameraId);
+        if (!camera) return;
+        if (this.selectedCameraId === cameraId) this._exitCameraView({ restore: true });
+        this.scene.cameras = this.scene.cameras.filter(
+            item => item.camera_id !== cameraId,
+        );
+        this._renderCameras();
+        this._updateSceneSummary();
+        await this._saveSceneNow();
+        this.toast(`${camera.name} removed.`, "success");
+    }
+
+    _renderCameras() {
+        const cameras = this._normalizeSceneCameras(this.scene?.cameras);
+        if (this.scene) this.scene.cameras = cameras;
+        this.els.cameraCount.textContent = String(cameras.length);
+        this.els.cameraGroupCount.textContent = String(cameras.length);
+        this.els.cameraAdd.disabled = !this.scene || cameras.length >= 32;
+        this.els.cameraList.replaceChildren();
+        if (!cameras.length) {
+            this.els.cameraList.appendChild(
+                element("div", "vnccs-i3s__camera-empty", "No saved cameras"),
+            );
+            return;
+        }
+        const fragment = document.createDocumentFragment();
+        for (const [index, camera] of cameras.entries()) {
+            const card = element(
+                "div",
+                `vnccs-i3s__camera-item${
+                    camera.camera_id === this.selectedCameraId ? " is-selected" : ""
+                }`,
+            );
+            card.dataset.cameraId = camera.camera_id;
+            card.tabIndex = 0;
+            card.setAttribute("role", "button");
+            card.setAttribute("aria-pressed", String(camera.camera_id === this.selectedCameraId));
+            card.innerHTML = `
+                <span class="vnccs-i3s__camera-index">${index + 1}</span>
+                <span class="vnccs-i3s__camera-item-icon">${ICONS.camera}</span>
+                <span class="vnccs-i3s__camera-item-name"></span>
+                <button class="vnccs-i3s__camera-delete" type="button"
+                    title="Delete camera" aria-label="Delete camera">${ICONS.trash}</button>
+            `;
+            card.querySelector(".vnccs-i3s__camera-item-name").textContent = camera.name;
+            card.querySelector(".vnccs-i3s__camera-delete").setAttribute(
+                "aria-label",
+                `Delete ${camera.name}`,
+            );
+            this._listen(card, "click", event => {
+                if (event.target.closest(".vnccs-i3s__camera-delete")) return;
+                this._selectCamera(camera.camera_id);
+            });
+            this._listen(card, "keydown", event => {
+                if (event.key !== "Enter" && event.key !== " ") return;
+                event.preventDefault();
+                this._selectCamera(camera.camera_id);
+            });
+            this._listen(card.querySelector(".vnccs-i3s__camera-delete"), "click", event => {
+                event.stopPropagation();
+                void this._deleteCamera(camera.camera_id);
+            });
+            fragment.appendChild(card);
+        }
+        this.els.cameraList.appendChild(fragment);
     }
 
     _normalizeLighting(value = {}) {
@@ -1615,9 +1954,13 @@ class Factory3DWidget {
         const desiredGroupId = this.selectedGroupId;
         const desiredObjectIds = new Set(this.selectedObjectIds);
         const desiredSkydome = incremental && this.selectedSkydome;
+        const desiredCameraId = incremental ? this.selectedCameraId : "";
+        this.selectedCameraId = "";
+        this._cameraReturnState = null;
         if (this.selectedObjectId) desiredObjectIds.add(this.selectedObjectId);
         this.scene = scene;
         this.sceneId = scene.scene_id;
+        this.scene.cameras = this._normalizeSceneCameras(scene.cameras);
         if (this.scene.skydome) {
             this.scene.skydome = this._normalizeSkydome(this.scene.skydome);
         }
@@ -1704,7 +2047,11 @@ class Factory3DWidget {
                 additive: this.selectedObjectIds.size > 1,
             });
         }
+        if (this.scene.cameras.some(camera => camera.camera_id === desiredCameraId)) {
+            this._selectCamera(desiredCameraId);
+        }
         this._renderObjects();
+        this._renderCameras();
         this._scheduleStateSave();
         this.syncToNode();
         const loaded = Number(viewportResult.loaded) || 0;
@@ -1895,6 +2242,7 @@ class Factory3DWidget {
     _updateSceneSummary() {
         const objects = this.scene?.objects || [];
         const skydome = this.scene?.skydome || null;
+        const cameraCount = this.scene?.cameras?.length || 0;
         const visibleIds = this._effectiveVisibleObjectIds();
         this.container.classList.toggle("has-scene", Boolean(objects.length || skydome));
         this.els.objectCount.textContent = String(objects.length + (skydome ? 1 : 0));
@@ -1904,11 +2252,14 @@ class Factory3DWidget {
                 0,
             ).toLocaleString()} Gaussians`
             : "No Gaussian models";
-        this.els.sceneSummary.textContent = skydome
+        const contentSummary = skydome
             ? `${gaussianSummary} · Skydome ${skydome.visible === false ? "hidden" : "visible"}`
             : objects.length
                 ? gaussianSummary
                 : "No objects in this scene.";
+        this.els.sceneSummary.textContent = cameraCount
+            ? `${contentSummary} · ${cameraCount} camera${cameraCount === 1 ? "" : "s"}`
+            : contentSummary;
     }
 
     _hasRenderableScene() {
@@ -1919,6 +2270,9 @@ class Factory3DWidget {
     }
 
     _selectSkydome() {
+        if (this.selectedCameraId && !this._cameraSelectionTransition) {
+            this._exitCameraView({ restore: true });
+        }
         if (!this.scene?.skydome) {
             this.selectedSkydome = false;
             return;
@@ -1933,6 +2287,9 @@ class Factory3DWidget {
     }
 
     _selectObject(objectId, { fromViewer = false, additive = false } = {}) {
+        if (this.selectedCameraId && !this._cameraSelectionTransition) {
+            this._exitCameraView({ restore: true });
+        }
         const valid = this.scene?.objects?.some(item => item.object_id === objectId)
             ? objectId
             : "";
@@ -1953,6 +2310,9 @@ class Factory3DWidget {
     }
 
     _selectGroup(groupId) {
+        if (this.selectedCameraId && !this._cameraSelectionTransition) {
+            this._exitCameraView({ restore: true });
+        }
         const group = this._groupById(groupId);
         this.selectedSkydome = false;
         this.selectedGroupId = group?.group_id || "";
@@ -2208,6 +2568,8 @@ class Factory3DWidget {
             item.settings?.effective_conditioning_resolution
             || item.settings?.conditioning_resolution,
         );
+        const importedPly = item.source?.type === "ply_import"
+            || item.settings?.source === "ply_import";
         copy.append(
             name,
             element(
@@ -2216,8 +2578,9 @@ class Factory3DWidget {
                 [
                     viewportFailure ? "Viewport failed" : "",
                     `${Number(item.gaussians || 0).toLocaleString()} splats`,
+                    importedPly ? "Imported PLY" : "",
                     conditioning ? `${conditioning}² input` : "",
-                    `seed ${item.seed}`,
+                    !importedPly && item.seed !== undefined ? `seed ${item.seed}` : "",
                 ].filter(Boolean).join(" · "),
             ),
         );
@@ -2679,7 +3042,9 @@ class Factory3DWidget {
     }
 
     _scenePayload() {
-        const camera = this.viewer?.getState?.().camera || this.viewerState.camera;
+        const camera = this.selectedCameraId
+            ? this.scene?.camera
+            : this.viewer?.getCameraState?.() || this.viewerState.camera;
         return {
             name: this.els.sceneName.value.trim() || this.scene?.name || "Untitled scene",
             render: { ...this.exportSettings },
@@ -2696,6 +3061,12 @@ class Factory3DWidget {
                 }
                 : undefined,
             camera: camera ? { ...camera } : undefined,
+            cameras: this._normalizeSceneCameras(this.scene?.cameras).map(saved => ({
+                ...saved,
+                position: [...saved.position],
+                target: [...saved.target],
+                up: [...saved.up],
+            })),
             objects: (this.scene?.objects || []).map(item => ({
                 object_id: item.object_id,
                 name: item.name,
@@ -2737,6 +3108,9 @@ class Factory3DWidget {
                 this.scene.exports = updated.exports;
                 this.scene.render = updated.render || this.scene.render;
                 this.scene.camera = updated.camera || this.scene.camera;
+                this.scene.cameras = this._normalizeSceneCameras(
+                    updated.cameras || this.scene.cameras,
+                );
                 this.scene.lighting = updated.lighting || this.scene.lighting;
                 this.scene.skydome = updated.skydome || this.scene.skydome;
             }
@@ -2842,6 +3216,54 @@ class Factory3DWidget {
         }
     }
 
+    async _saveExecutionCaptureSet(captureToken) {
+        clearTimeout(this._previewSaveTimer);
+        this._previewSaveTimer = 0;
+        const sceneId = this.sceneId;
+        const operation = this._previewSaveSerial.then(async () => {
+            if (this.destroyed || !sceneId || this.sceneId !== sceneId) return null;
+            const savedScene = await this._saveSceneNow({ showError: false });
+            if (this.destroyed || this.sceneId !== sceneId) return null;
+            const cameras = this._normalizeSceneCameras(savedScene.cameras);
+            const dimensions = {
+                width: Number(savedScene.render?.width) || this.exportSettings.width,
+                height: Number(savedScene.render?.height) || this.exportSettings.height,
+            };
+            const current = await this.viewer.capturePreview({
+                ...dimensions,
+                cameraState: this.viewer.getCameraState(),
+            });
+            if (!current) throw new Error("The current 3D view could not be captured.");
+            const form = new FormData();
+            form.append("current", current, "current.png");
+            form.append(
+                "camera_ids",
+                JSON.stringify(cameras.map(camera => camera.camera_id)),
+            );
+            for (const camera of cameras) {
+                const blob = await this.viewer.capturePreview({
+                    ...dimensions,
+                    cameraState: camera,
+                });
+                if (!blob) throw new Error(`${camera.name} could not be captured.`);
+                form.append(`camera_${camera.camera_id}`, blob, `${camera.camera_id}.png`);
+            }
+            form.append("revision", String(savedScene.revision));
+            form.append("render_revision", String(savedScene.render_revision));
+            form.append("capture_token", captureToken);
+            const result = await this._fetchJSON(ENDPOINTS.captureSet(sceneId), {
+                method: "POST",
+                body: form,
+            });
+            if (this.sceneId === sceneId && this.scene && result.preview) {
+                this.scene.preview = result.preview;
+            }
+            return result;
+        });
+        this._previewSaveSerial = operation.catch(() => null);
+        return await operation;
+    }
+
     async _reportExecutionPreviewFailure(sceneId, captureToken, error) {
         if (!sceneId || !captureToken) return;
         try {
@@ -2872,9 +3294,6 @@ class Factory3DWidget {
                     `The widget has scene ${this.sceneId || "none"} open; execution requested ${sceneId}.`,
                 );
             }
-            if (!this._hasRenderableScene()) {
-                throw new Error("The requested scene has no visible renderable content.");
-            }
             console.info("[VNCCS 3D Factory][viewport] Execution preview requested", {
                 sceneId,
                 captureToken,
@@ -2882,13 +3301,14 @@ class Factory3DWidget {
                 renderRevision: detail.render_revision,
                 documentVisible: document.visibilityState,
             });
-            const preview = await this._saveScenePreviewNow({ captureToken });
-            if (!preview) throw new Error("The 3D viewport returned no execution preview.");
+            const captureSet = await this._saveExecutionCaptureSet(captureToken);
+            if (!captureSet) throw new Error("The 3D viewport returned no execution captures.");
             console.info("[VNCCS 3D Factory][viewport] Execution preview completed", {
                 sceneId,
                 captureToken,
-                width: preview.width,
-                height: preview.height,
+                cameraCount: captureSet.camera_count,
+                width: captureSet.preview?.width,
+                height: captureSet.preview?.height,
             });
         } catch (error) {
             console.error("[VNCCS 3D Factory] Execution preview failed", {
@@ -2939,6 +3359,55 @@ class Factory3DWidget {
             await this._monitorJob(job.job_id);
         } catch (error) {
             if (!error?.factoryErrorShown) this._showError("Generation failed", error);
+        }
+    }
+
+    async importPly(file) {
+        if (!file || this.currentJobId || this.importingPly) return;
+        if (!/\.ply$/i.test(String(file.name || ""))) {
+            this.toast("Choose a .ply Gaussian file.", "error");
+            return;
+        }
+        if (!file.size || file.size > MAX_PLY_BYTES) {
+            this.toast(`PLY files must be between 1 byte and ${formatBytes(MAX_PLY_BYTES)}.`, "error");
+            return;
+        }
+        this.importingPly = true;
+        this.els.plyImport.disabled = true;
+        this._setStatus("Importing PLY", "working");
+        try {
+            if (!this.sceneId) await this.ensureScene();
+            const sceneId = this.sceneId;
+            const form = new FormData();
+            form.append("ply", file, file.name || "model.ply");
+            form.append("name", objectNameFromFileName(file.name));
+            const result = await this._fetchJSON(ENDPOINTS.importObject(sceneId), {
+                method: "POST",
+                body: form,
+            });
+            if (this.sceneId !== sceneId) {
+                this._setStatus("PLY imported", "success");
+                this.toast("PLY was added to the scene where the import started.", "success");
+                return;
+            }
+            await this._applyScene(result.scene, { preserveSource: true });
+            this._selectObject(result.object_id);
+            if (this.viewportFailures.has(result.object_id)) {
+                this._setStatus("Imported; preview failed", "error");
+                this.toast("PLY was added, but the viewport could not render it.", "error");
+                return;
+            }
+            this.viewer.fit(result.object_id);
+            this._scheduleScenePreview(120);
+            this._scheduleStateSave(0);
+            this._setStatus("PLY imported", "success");
+            this.toast("PLY added to the active scene.", "success");
+        } catch (error) {
+            this._setStatus("PLY import failed", "error");
+            this._showError("PLY could not be imported", error);
+        } finally {
+            this.importingPly = false;
+            if (this.els.plyImport.isConnected) this.els.plyImport.disabled = false;
         }
     }
 
@@ -4054,7 +4523,9 @@ class Factory3DWidget {
                 if (includePreview.checked) {
                     const blob = isObject
                         ? await this.viewer.captureObjectPreview(selectedObjectId, { width: 640, height: 640 })
-                        : await this.viewer.capturePreview({ width: 640, height: 640 });
+                        : isSkydome
+                            ? await this.viewer.captureSkydomePreview({ width: 640, height: 640 })
+                            : await this.viewer.capturePreview({ width: 640, height: 640 });
                     preview = blob ? await blobToDataURL(blob) : "";
                 }
                 const result = await this._fetchJSON(ENDPOINTS.libraryItems, {

--- a/web/vnccs_3d_factory_viewer.js
+++ b/web/vnccs_3d_factory_viewer.js
@@ -15,7 +15,7 @@ const SPLAT_BOUND_SAMPLES = 4_096;
 const INTERACTIVE_FRAME_MS = 1000 / 30;
 const LIGHTING_UPDATE_MS = 1000 / 15;
 const LIGHTING_BASE_RESPONSE = 0.65;
-export const FACTORY_VIEWER_BUILD = "20260725.15";
+export const FACTORY_VIEWER_BUILD = "20260726.17";
 
 const DEFAULT_LIGHTING = Object.freeze({
     preset: "day",
@@ -1863,29 +1863,75 @@ export class Factory3DViewer {
             selected_group_id: this.selectedGroupId,
             mode: this.mode,
             grid: this.gridVisible,
-            camera: {
-                position: this.camera.position.toArray(),
-                target: this.controls.target.toArray(),
-                fov: this.captureFov,
-            },
+            camera: this.getCameraState(),
         };
     }
 
-    setState(value = {}) {
-        if (value.mode) this.setMode(value.mode);
-        if ("grid" in value) this.setGrid(value.grid);
-        const position = finiteVector(value.camera?.position, this.camera.position.toArray());
-        const target = finiteVector(value.camera?.target, this.controls.target.toArray());
-        const fov = Number(value.camera?.fov);
+    getCameraState() {
+        return {
+            position: this.camera.position.toArray(),
+            target: this.controls.target.toArray(),
+            up: this.camera.up.toArray(),
+            fov: this.captureFov,
+        };
+    }
+
+    setCameraState(value = {}, { emit = false } = {}) {
+        const position = finiteVector(value.position, this.camera.position.toArray());
+        const target = finiteVector(value.target, this.controls.target.toArray());
+        const up = finiteVector(value.up, this.camera.up.toArray());
+        const fov = Number(value.fov);
         if (Number.isFinite(fov)) this.captureFov = Math.max(5, Math.min(120, fov));
         this.camera.position.fromArray(position);
+        this.camera.up.fromArray(up);
+        if (this.camera.up.lengthSq() < 1e-12) this.camera.up.set(0, 1, 0);
+        this.camera.up.normalize();
         this.controls.target.fromArray(target);
+        if (this.camera.position.distanceToSquared(this.controls.target) < 1e-12) {
+            this.controls.target.set(position[0], position[1], position[2] - 1);
+        }
+        this.camera.lookAt(this.controls.target);
         this.controls.update();
         this._updateCameraProjection();
         this._updateCameraFrame();
         this._updateClipPlanes();
         this._cameraStateDirty = false;
         this.invalidate();
+        if (emit) this._emitState();
+    }
+
+    rotateCameraFPV({ yaw = 0, pitch = 0, roll = 0 } = {}, { emit = true } = {}) {
+        const yawRadians = THREE.MathUtils.degToRad(Number(yaw) || 0);
+        const pitchRadians = THREE.MathUtils.degToRad(Number(pitch) || 0);
+        const rollRadians = THREE.MathUtils.degToRad(Number(roll) || 0);
+        if (!yawRadians && !pitchRadians && !rollRadians) return;
+        const distance = Math.max(
+            this.camera.position.distanceTo(this.controls.target),
+            0.001,
+        );
+        const delta = new THREE.Quaternion().setFromEuler(
+            new THREE.Euler(pitchRadians, yawRadians, rollRadians, "YXZ"),
+        );
+        this.camera.quaternion.multiply(delta).normalize();
+        const forward = new THREE.Vector3(0, 0, -1)
+            .applyQuaternion(this.camera.quaternion)
+            .normalize();
+        const up = new THREE.Vector3(0, 1, 0)
+            .applyQuaternion(this.camera.quaternion)
+            .normalize();
+        this.controls.target.copy(this.camera.position).addScaledVector(forward, distance);
+        this.camera.up.copy(up);
+        this.controls.update();
+        this._updateClipPlanes();
+        this._cameraStateDirty = false;
+        this.invalidate();
+        if (emit) this._emitState();
+    }
+
+    setState(value = {}) {
+        if (value.mode) this.setMode(value.mode);
+        if ("grid" in value) this.setGrid(value.grid);
+        this.setCameraState(value.camera || {}, { emit: false });
     }
 
     _emitState() {
@@ -1913,9 +1959,9 @@ export class Factory3DViewer {
     async capturePreview({
         width = this.captureWidth,
         height = this.captureHeight,
+        cameraState = null,
     } = {}) {
         if (this._disposed) throw new Error("3D viewport has been disposed");
-        if (!this.objects.size && !this.hasVisibleSkydome()) return null;
         const targetWidth = Math.max(64, Math.min(4096, Math.round(Number(width) || 1024)));
         const targetHeight = Math.max(64, Math.min(4096, Math.round(Number(height) || 1024)));
         let captureSkydomeTexture = null;
@@ -1967,13 +2013,45 @@ export class Factory3DViewer {
         }
 
         try {
-            this.captureCamera.position.copy(this.camera.position);
-            this.captureCamera.quaternion.copy(this.camera.quaternion);
-            this.captureCamera.up.copy(this.camera.up);
+            if (cameraState) {
+                const position = finiteVector(
+                    cameraState.position,
+                    this.camera.position.toArray(),
+                );
+                const targetState = finiteVector(
+                    cameraState.target,
+                    this.controls.target.toArray(),
+                );
+                const up = finiteVector(cameraState.up, this.camera.up.toArray());
+                this.captureCamera.position.fromArray(position);
+                this.captureCamera.up.fromArray(up);
+                if (this.captureCamera.up.lengthSq() < 1e-12) {
+                    this.captureCamera.up.set(0, 1, 0);
+                }
+                this.captureCamera.up.normalize();
+                const targetVector = new THREE.Vector3().fromArray(targetState);
+                if (this.captureCamera.position.distanceToSquared(targetVector) < 1e-12) {
+                    targetVector.set(position[0], position[1], position[2] - 1);
+                }
+                this.captureCamera.lookAt(targetVector);
+                const distance = Math.max(
+                    this.captureCamera.position.distanceTo(targetVector),
+                    0.001,
+                );
+                this.captureCamera.near = Math.max(0.000001, distance / 100000);
+                this.captureCamera.far = Math.max(1000, distance * 100000);
+            } else {
+                this.captureCamera.position.copy(this.camera.position);
+                this.captureCamera.quaternion.copy(this.camera.quaternion);
+                this.captureCamera.up.copy(this.camera.up);
+                this.captureCamera.near = this.camera.near;
+                this.captureCamera.far = this.camera.far;
+            }
             this.captureCamera.aspect = targetWidth / targetHeight;
-            this.captureCamera.fov = this.captureFov;
-            this.captureCamera.near = this.camera.near;
-            this.captureCamera.far = this.camera.far;
+            const requestedFov = Number(cameraState?.fov);
+            this.captureCamera.fov = Number.isFinite(requestedFov)
+                ? Math.max(5, Math.min(120, requestedFov))
+                : this.captureFov;
             this.captureCamera.updateProjectionMatrix();
             this.captureCamera.updateMatrixWorld(true);
 
@@ -1982,6 +2060,7 @@ export class Factory3DViewer {
             this.renderer.setPixelRatio(1);
             this.renderer.setSize(targetWidth, targetHeight, false);
             this.spark.setDirty?.();
+            await this.spark.update({ scene: this.scene, camera: this.captureCamera });
             this.renderer.render(this.scene, this.captureCamera);
             target = document.createElement("canvas");
             target.width = targetWidth;
@@ -2018,6 +2097,82 @@ export class Factory3DViewer {
                 "image/png",
             );
         });
+    }
+
+    async captureSkydomePreview({
+        width = 640,
+        height = 640,
+    } = {}) {
+        if (!this.skydomeTexture || !this.skydome) return null;
+        const skydome = this.skydome;
+        const objectState = new Map();
+        for (const [id, value] of this.objects) {
+            const parent = value.mesh.parent;
+            objectState.set(id, {
+                parent,
+                parentIndex: parent ? parent.children.indexOf(value.mesh) : -1,
+                rootVisible: value.mesh.visible,
+                splatVisible: value.splat.visible,
+            });
+        }
+        const previousSkydomeVisible = skydome.visible;
+        const previousSuppressState = this._suppressStateEvents;
+        const previousCaptureState = this._capturing;
+        this._suppressStateEvents = true;
+        this._capturing = true;
+        try {
+            // Spark retains its own generated mapping, so remove every
+            // Gaussian root as well as hiding it. This guarantees that a
+            // library preview for a skydome contains only the environment.
+            for (const value of this.objects.values()) {
+                value.mesh.visible = false;
+                value.splat.visible = false;
+                value.mesh.parent?.remove(value.mesh);
+            }
+            skydome.visible = true;
+            this._applySkydomeSettings();
+            this.spark.setDirty?.();
+            await this.spark.update({ scene: this.scene, camera: this.camera });
+            return await this.capturePreview({ width, height });
+        } finally {
+            try {
+                if (this.skydome === skydome) {
+                    skydome.visible = previousSkydomeVisible;
+                    this._applySkydomeSettings();
+                }
+                for (const [id, state] of objectState) {
+                    const value = this.objects.get(id);
+                    if (!value) continue;
+                    if (state.parent && value.mesh.parent !== state.parent) {
+                        state.parent.add(value.mesh);
+                        const currentIndex = state.parent.children.indexOf(value.mesh);
+                        if (
+                            state.parentIndex >= 0
+                            && currentIndex >= 0
+                            && currentIndex !== state.parentIndex
+                        ) {
+                            state.parent.children.splice(currentIndex, 1);
+                            state.parent.children.splice(state.parentIndex, 0, value.mesh);
+                        }
+                    }
+                    value.mesh.visible = state.rootVisible;
+                    value.splat.visible = state.splatVisible;
+                    value.mesh.updateMatrixWorld(true);
+                }
+                this._refreshSelectionBounds();
+                this.spark.setDirty?.();
+                try {
+                    await this.spark.update({ scene: this.scene, camera: this.camera });
+                } catch (error) {
+                    this.options.onError(error);
+                }
+                this.renderer.render(this.scene, this.camera);
+                this.invalidate();
+            } finally {
+                this._capturing = previousCaptureState;
+                this._suppressStateEvents = previousSuppressState;
+            }
+        }
     }
 
     async captureObjectPreview(objectId, {

--- a/web/vnccs_3d_factory_viewer.js
+++ b/web/vnccs_3d_factory_viewer.js
@@ -15,7 +15,7 @@ const SPLAT_BOUND_SAMPLES = 4_096;
 const INTERACTIVE_FRAME_MS = 1000 / 30;
 const LIGHTING_UPDATE_MS = 1000 / 15;
 const LIGHTING_BASE_RESPONSE = 0.65;
-export const FACTORY_VIEWER_BUILD = "20260726.17";
+export const FACTORY_VIEWER_BUILD = "20260726.18";
 
 const DEFAULT_LIGHTING = Object.freeze({
     preset: "day",
@@ -1900,27 +1900,42 @@ export class Factory3DViewer {
         if (emit) this._emitState();
     }
 
-    rotateCameraFPV({ yaw = 0, pitch = 0, roll = 0 } = {}, { emit = true } = {}) {
+    rotateCameraFPV({ yaw = 0, pitch = 0 } = {}, { emit = true } = {}) {
         const yawRadians = THREE.MathUtils.degToRad(Number(yaw) || 0);
         const pitchRadians = THREE.MathUtils.degToRad(Number(pitch) || 0);
-        const rollRadians = THREE.MathUtils.degToRad(Number(roll) || 0);
-        if (!yawRadians && !pitchRadians && !rollRadians) return;
+        if (!yawRadians && !pitchRadians) return;
         const distance = Math.max(
             this.camera.position.distanceTo(this.controls.target),
             0.001,
         );
-        const delta = new THREE.Quaternion().setFromEuler(
-            new THREE.Euler(pitchRadians, yawRadians, rollRadians, "YXZ"),
-        );
-        this.camera.quaternion.multiply(delta).normalize();
-        const forward = new THREE.Vector3(0, 0, -1)
-            .applyQuaternion(this.camera.quaternion)
+        const worldUp = new THREE.Vector3(0, 1, 0);
+        const forward = this.controls.target.clone()
+            .sub(this.camera.position)
             .normalize();
-        const up = new THREE.Vector3(0, 1, 0)
-            .applyQuaternion(this.camera.quaternion)
-            .normalize();
+        if (yawRadians) forward.applyAxisAngle(worldUp, yawRadians).normalize();
+        if (pitchRadians) {
+            const currentPitch = Math.asin(THREE.MathUtils.clamp(
+                forward.dot(worldUp),
+                -1,
+                1,
+            ));
+            const maximumPitch = THREE.MathUtils.degToRad(89);
+            const targetPitch = THREE.MathUtils.clamp(
+                currentPitch + pitchRadians,
+                -maximumPitch,
+                maximumPitch,
+            );
+            const appliedPitch = targetPitch - currentPitch;
+            const right = new THREE.Vector3().crossVectors(forward, worldUp);
+            if (right.lengthSq() > 1e-12 && Math.abs(appliedPitch) > 1e-12) {
+                forward.applyAxisAngle(right.normalize(), appliedPitch).normalize();
+            }
+        }
         this.controls.target.copy(this.camera.position).addScaledVector(forward, distance);
-        this.camera.up.copy(up);
+        // The look pad owns yaw/pitch only. Rebuilding from world-up prevents
+        // local quaternion composition from accumulating an unintended roll.
+        this.camera.up.copy(worldUp);
+        this.camera.lookAt(this.controls.target);
         this.controls.update();
         this._updateClipPlanes();
         this._cameraStateDirty = false;

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -3987,7 +3987,15 @@ class PoseStudioWidget {
         this.canvas = null;
         this.viewer = null;
 
-        this.poses = [{}];  // Array of pose data
+        this.poses = [{
+            cameraParams: {
+                offset_x: 0,
+                offset_y: 0,
+                zoom: 1,
+                yaw_deg: 0,
+                pitch_deg: 0,
+            },
+        }];  // Array of pose data
         this.posePrompts = [""]; // User prompt per pose tab
         this.activeTab = 0;
         this.poseCaptures = []; // Cache for captured images
@@ -5109,6 +5117,7 @@ class PoseStudioWidget {
                     { reveal: true },
                 );
             } else {
+                this.restoreActivePoseCameraParams({ updateViewer: false });
                 this._applyingAnimationPose = true;
                 this.viewer.setPose(this.poses[this.activeTab] || {}, true);
                 this._applyingAnimationPose = false;
@@ -5563,6 +5572,7 @@ class PoseStudioWidget {
             this.syncToNode(false, { skipCapture: true });
             return;
         }
+        pose.cameraParams = this.currentCameraParams();
         this.poses[this.activeTab] = pose;
         this.syncToNode(fullCapture, syncOptions);
     }
@@ -5892,6 +5902,7 @@ class PoseStudioWidget {
                 if (!this._applyingAnimationPose) this.captureAnimationEdits();
             } else {
                 const pose = this.stripSceneCameraFromPose(this.viewer.getPose());
+                pose.cameraParams = this.currentCameraParams();
                 pose.prompt = this.getPosePrompt(this.activeTab);
                 this.poses[this.activeTab] = pose;
             }
@@ -5972,10 +5983,19 @@ class PoseStudioWidget {
         return character.poses[poseIndex] || character.poses[0] || {};
     }
 
-    characterTransformForScene(character, { frame = null } = {}) {
+    characterTransformForScene(character, { frame = null, poseIndex = this.activeTab } = {}) {
         if (!character?.animationState) this.ensureCharacterRuntime(character);
         if (!this.isAnimationMode()) {
-            return { ...character.transform };
+            const cameraParams = this.cameraParamsForPose(
+                character.poses[poseIndex] || character.poses[0] || {},
+                character,
+            );
+            return normalizeCharacterTransform({
+                ...character.transform,
+                x: cameraParams.offset_x,
+                y: cameraParams.offset_y,
+                zoom: cameraParams.zoom,
+            });
         }
         const targetFrame = frame ?? this.sharedTimeline.currentFrame;
         return evaluateCharacterTransform(
@@ -5994,7 +6014,7 @@ class PoseStudioWidget {
                 this.viewer.removePassiveCharacter?.(id);
             }
         }
-        const activeTransform = this.characterTransformForScene(active, { frame });
+        const activeTransform = this.characterTransformForScene(active, { frame, poseIndex });
         this.viewer.setActiveCharacterAppearance({
             color: active.color,
             transform: activeTransform,
@@ -6003,7 +6023,7 @@ class PoseStudioWidget {
         for (const character of this.characters) {
             if (character.id === active.id) continue;
             const pose = this.characterPoseForScene(character, { frame, poseIndex });
-            const transform = this.characterTransformForScene(character, { frame });
+            const transform = this.characterTransformForScene(character, { frame, poseIndex });
             if (!this.viewer.passiveCharacters?.has?.(character.id) && rebuildMissing) {
                 this.viewer.upsertPassiveCharacterFromActive(character.id, {
                     pose,
@@ -6042,8 +6062,19 @@ class PoseStudioWidget {
         if (slot < 0) return false;
         const id = nextCharacterId(this.characters);
         const spread = [0, 3, -3, 6][slot] ?? slot * 3;
-        const poses = Array.from({ length: Math.max(1, this.poses.length) }, () => ({}));
         const initialTransform = { x: spread, y: 0, z: 0, zoom: 1 };
+        const poses = Array.from({ length: Math.max(1, this.poses.length) }, (_, index) => {
+            const sceneCamera = this.cameraParamsForPose(this.poses[index]);
+            return {
+                cameraParams: {
+                    offset_x: initialTransform.x,
+                    offset_y: initialTransform.y,
+                    zoom: initialTransform.zoom,
+                    yaw_deg: sceneCamera.yaw_deg,
+                    pitch_deg: sceneCamera.pitch_deg,
+                },
+            };
+        });
         const animationState = createDefaultAnimationState(
             poses[this.activeTab] || poses[0],
             { baseTransform: initialTransform },
@@ -6184,10 +6215,19 @@ class PoseStudioWidget {
             target.animationState = this.animationState;
             target.transform = this.characterTransformForScene(target, {
                 frame: this.sharedTimeline.currentFrame,
+                poseIndex: this.activeTab,
             });
             this.exportParams.cam_offset_x = target.transform.x;
             this.exportParams.cam_offset_y = target.transform.y;
             this.exportParams.cam_zoom = target.transform.zoom;
+            if (!this.isAnimationMode()) {
+                const targetCamera = this.cameraParamsForPose(
+                    target.poses[this.activeTab],
+                    target,
+                );
+                this.exportParams.cam_yaw_deg = targetCamera.yaw_deg;
+                this.exportParams.cam_pitch_deg = targetCamera.pitch_deg;
+            }
             this.viewer?.removePassiveCharacter?.(target.id);
 
             const meshChanged = JSON.stringify(previous.mesh || {}) !== JSON.stringify(target.mesh || {});
@@ -6480,15 +6520,40 @@ class PoseStudioWidget {
     persistActivePoseCameraParams() {
         const character = this.getActiveCharacter();
         if (!character) return;
+        const cameraParams = this.currentCameraParams();
         const previousTransform = { ...character.transform };
         const nextTransform = normalizeCharacterTransform({
             ...character.transform,
-            x: this.exportParams.cam_offset_x,
-            y: this.exportParams.cam_offset_y,
-            zoom: this.exportParams.cam_zoom,
+            x: cameraParams.offset_x,
+            y: cameraParams.offset_y,
+            zoom: cameraParams.zoom,
         });
         character.transform = nextTransform;
         this.captureAnimationTransformEdits(previousTransform, nextTransform);
+
+        if (!this.isAnimationMode()) {
+            const pose = this.poses?.[this.activeTab] || {};
+            pose.cameraParams = { ...cameraParams };
+            this.poses[this.activeTab] = pose;
+            character.poses = this.poses;
+
+            // Camera angles describe the shared scene view. Keep them identical
+            // for every character on this pose tab while leaving each
+            // character's own position and zoom untouched.
+            for (const sceneCharacter of this.characters || []) {
+                if (sceneCharacter.id === character.id) continue;
+                this.ensureCharacterRuntime(sceneCharacter);
+                const scenePose = sceneCharacter.poses[this.activeTab] || {};
+                const existing = this.cameraParamsForPose(scenePose, sceneCharacter);
+                scenePose.cameraParams = {
+                    ...existing,
+                    yaw_deg: cameraParams.yaw_deg,
+                    pitch_deg: cameraParams.pitch_deg,
+                };
+                sceneCharacter.poses[this.activeTab] = scenePose;
+            }
+        }
+
         this.viewer?.setActiveCharacterAppearance?.({
             color: character.color,
             transform: nextTransform,
@@ -6503,6 +6568,78 @@ class PoseStudioWidget {
             yaw_deg: this.exportParams.cam_yaw_deg || 0,
             pitch_deg: this.exportParams.cam_pitch_deg || 0
         };
+    }
+
+    cameraParamsForPose(
+        pose = this.poses?.[this.activeTab],
+        character = this.getActiveCharacter(),
+    ) {
+        const transform = normalizeCharacterTransform(character?.transform || {});
+        return resolveCaptureCameraParams(pose?.cameraParams, {
+            offset_x: transform.x,
+            offset_y: transform.y,
+            zoom: transform.zoom,
+            yaw_deg: this.exportParams.cam_yaw_deg || 0,
+            pitch_deg: this.exportParams.cam_pitch_deg || 0,
+        });
+    }
+
+    ensurePoseCameraParams() {
+        const active = this.getActiveCharacter();
+        const orderedCharacters = [
+            ...(active ? [active] : []),
+            ...(this.characters || []).filter(character => character !== active),
+        ];
+        for (const character of orderedCharacters) {
+            this.ensureCharacterRuntime(character);
+            for (let index = 0; index < character.poses.length; index += 1) {
+                const pose = character.poses[index] || {};
+                if (!pose.cameraParams || typeof pose.cameraParams !== "object") {
+                    const params = this.cameraParamsForPose(pose, character);
+                    if (active && character !== active) {
+                        const activeCamera = this.cameraParamsForPose(
+                            active.poses[index] || active.poses[0] || {},
+                            active,
+                        );
+                        params.yaw_deg = activeCamera.yaw_deg;
+                        params.pitch_deg = activeCamera.pitch_deg;
+                    }
+                    pose.cameraParams = params;
+                    character.poses[index] = pose;
+                }
+            }
+        }
+    }
+
+    restoreActivePoseCameraParams({ updateViewer = true } = {}) {
+        if (this.isAnimationMode()) return this.currentCameraParams();
+        const character = this.getActiveCharacter();
+        if (!character) return this.currentCameraParams();
+        const params = this.cameraParamsForPose(
+            this.poses?.[this.activeTab],
+            character,
+        );
+        this.exportParams.cam_offset_x = params.offset_x;
+        this.exportParams.cam_offset_y = params.offset_y;
+        this.exportParams.cam_zoom = params.zoom;
+        this.exportParams.cam_yaw_deg = params.yaw_deg;
+        this.exportParams.cam_pitch_deg = params.pitch_deg;
+        character.transform = normalizeCharacterTransform({
+            ...character.transform,
+            x: params.offset_x,
+            y: params.offset_y,
+            zoom: params.zoom,
+        });
+        this.syncCameraWidgets();
+        if (updateViewer) {
+            this.viewer?.setActiveCharacterAppearance?.({
+                color: character.color,
+                transform: character.transform,
+            });
+            this.applyCameraToViewer(true);
+            this.viewer?.setCameraParams?.(params);
+        }
+        return params;
     }
 
     setSkydomeFromCameraPrompt(cameraPrompt, { force = false } = {}) {
@@ -6944,8 +7081,10 @@ class PoseStudioWidget {
         const h = this.exportParams.view_height || 1024;
         const bg = this.exportParams.bg_color || [40, 40, 40];
         const isOriginalLighting = this.exportParams.keepOriginalLighting;
-        const yaw = this.exportParams.cam_yaw_deg || 0;
-        const pitch = this.exportParams.cam_pitch_deg || 0;
+        const activeCamera = this.cameraParamsForPose(
+            this.poses[this.activeTab],
+            this.getActiveCharacter(),
+        );
 
         if (!this.poseCaptures) this.poseCaptures = [];
         if (!this.lightingPrompts) this.lightingPrompts = [];
@@ -6958,6 +7097,10 @@ class PoseStudioWidget {
             const endIndex = Math.min(this.poses.length, startIndex + capturesPerFrame);
             for (let i = startIndex; i < endIndex; i++) {
                 const pose = this.poses[i] || {};
+                const poseCamera = this.cameraParamsForPose(
+                    pose,
+                    this.getActiveCharacter(),
+                );
                 this.viewer.setPose(pose, true);
                 this.updateCharacterScene({ poseIndex: i });
 
@@ -6970,8 +7113,8 @@ class PoseStudioWidget {
                 const framing = this.viewer.computeModelFitFraming?.(
                     w,
                     h,
-                    yaw,
-                    pitch,
+                    poseCamera.yaw_deg,
+                    poseCamera.pitch_deg,
                     0.08,
                 );
                 const nextCapture = this.viewer.capture(
@@ -6981,8 +7124,8 @@ class PoseStudioWidget {
                     bg,
                     framing?.offsetX ?? 0,
                     framing?.offsetY ?? 0,
-                    yaw,
-                    pitch,
+                    poseCamera.yaw_deg,
+                    poseCamera.pitch_deg,
                 );
                 this.setPoseCapture(i, nextCapture);
                 this.lightingPrompts[i] = this.generatePromptFromLights(
@@ -6999,7 +7142,15 @@ class PoseStudioWidget {
             // Per-card fitting temporarily moves the shared capture camera.
             // Restore its neutral scene framing so opening Studio or applying a
             // library pose cannot inherit the final manager card's offsets.
-            this.viewer.updateCaptureCamera?.(w, h, 1, 0, 0, yaw, pitch);
+            this.viewer.updateCaptureCamera?.(
+                w,
+                h,
+                1,
+                0,
+                0,
+                activeCamera.yaw_deg,
+                activeCamera.pitch_deg,
+            );
             if (captureBatchStarted) this.viewer.endCaptureBatch?.();
         }
 
@@ -7255,6 +7406,7 @@ class PoseStudioWidget {
             });
             this.captureAnimationTransformEdits(previousTransform, activeCharacter.transform);
             this.exportParams.cam_zoom = activeCharacter.transform.zoom;
+            this.persistActivePoseCameraParams();
             this.viewer.setActiveCharacterAppearance({
                 color: activeCharacter.color,
                 transform: activeCharacter.transform,
@@ -8521,6 +8673,7 @@ class PoseStudioWidget {
         // Save current pose & capture
         if (this.viewer && this.viewer.isInitialized()) {
             const savedPose = this.stripSceneCameraFromPose(this.viewer.getPose());
+            savedPose.cameraParams = this.currentCameraParams();
             savedPose.prompt = this.getPosePrompt(this.activeTab);
             this.poses[this.activeTab] = savedPose;
             this.syncToNode(false);
@@ -8533,6 +8686,7 @@ class PoseStudioWidget {
 
         // Load new pose
         const newPose = this.poses[this.activeTab] || {};
+        this.restoreActivePoseCameraParams({ updateViewer: false });
         if (this.viewer && this.viewer.isInitialized()) {
             this.viewer.setPose(newPose, true);
             this.updateCharacterScene({ poseIndex: this.activeTab });
@@ -8551,6 +8705,7 @@ class PoseStudioWidget {
         // Save current & capture
         if (this.viewer && this.viewer.isInitialized()) {
             const savedPose = this.stripSceneCameraFromPose(this.viewer.getPose());
+            savedPose.cameraParams = this.currentCameraParams();
             savedPose.prompt = this.getPosePrompt(this.activeTab);
             this.poses[this.activeTab] = savedPose;
             this.syncToNode(false);
@@ -8560,13 +8715,23 @@ class PoseStudioWidget {
         for (const character of this.characters) {
             if (!Array.isArray(character.poses)) character.poses = [];
             while (character.poses.length < previousPoseCount) character.poses.push({});
-            character.poses.push({});
+            const transform = normalizeCharacterTransform(character.transform || {});
+            character.poses.push({
+                cameraParams: {
+                    offset_x: transform.x,
+                    offset_y: transform.y,
+                    zoom: transform.zoom,
+                    yaw_deg: 0,
+                    pitch_deg: 0,
+                },
+            });
         }
         this.poses = this.getActiveCharacter().poses;
         this.posePrompts.push("");
         this.activeTab = this.poses.length - 1;
         this.updateTabs();
         this.clearSAMCameraMode();
+        this.resetCameraParams();
         this.syncPromptFieldToActiveTab();
 
         if (this.viewer && this.viewer.isInitialized()) {
@@ -8608,12 +8773,14 @@ class PoseStudioWidget {
             if (this.activeTab >= this.poses.length) {
                 this.activeTab = this.poses.length - 1;
             }
-            // Load new pose since active was deleted
-            if (this.viewer && this.viewer.isInitialized()) {
-                this.viewer.setPose(this.poses[this.activeTab] || {}, true);
-                this.updateCharacterScene({ poseIndex: this.activeTab });
-                this.updateRotationSliders();
-            }
+        }
+
+        this.restoreActivePoseCameraParams({ updateViewer: false });
+        if (this.viewer && this.viewer.isInitialized()) {
+            this.viewer.setPose(this.poses[this.activeTab] || {}, true);
+            this.updateCharacterScene({ poseIndex: this.activeTab });
+            this.updateRotationSliders();
+            this.applyCameraToViewer(true);
         }
 
         this.updateTabs();
@@ -8758,6 +8925,7 @@ class PoseStudioWidget {
                 this._clipboard = JSON.parse(JSON.stringify(pose));
                 return;
             }
+            pose.cameraParams = this.currentCameraParams();
             this.poses[this.activeTab] = pose;
         }
         this._clipboard = JSON.parse(JSON.stringify(this.poses[this.activeTab]));
@@ -8782,9 +8950,12 @@ class PoseStudioWidget {
         }
         this.poses[this.activeTab] = JSON.parse(JSON.stringify(this._clipboard));
         this.setPosePrompt(this.activeTab, this.poses[this.activeTab].prompt || "");
+        this.restoreActivePoseCameraParams({ updateViewer: false });
+        this.persistActivePoseCameraParams();
         if (this.viewer && this.viewer.isInitialized()) {
             this.viewer.setPose(this.poses[this.activeTab], true);
             this.updateCharacterScene({ poseIndex: this.activeTab });
+            this.applyCameraToViewer(true);
         }
         this.syncToNode();
     }
@@ -8876,7 +9047,12 @@ class PoseStudioWidget {
             filename = `pose_animation_${name}.json`;
         } else if (type === 'set') {
             // Ensure current active pose is saved to array
-            if (this.viewer) this.poses[this.activeTab] = this.viewer.getPose();
+            if (this.viewer) {
+                const pose = this.stripSceneCameraFromPose(this.viewer.getPose());
+                pose.cameraParams = this.currentCameraParams();
+                pose.prompt = this.getPosePrompt(this.activeTab);
+                this.poses[this.activeTab] = pose;
+            }
 
             data = {
                 type: "pose_set",
@@ -8886,13 +9062,19 @@ class PoseStudioWidget {
             filename = `pose_set_${name}.json`;
         } else {
             // Single pose
-            if (this.viewer) this.poses[this.activeTab] = this.viewer.getPose();
+            if (this.viewer) {
+                const pose = this.stripSceneCameraFromPose(this.viewer.getPose());
+                pose.cameraParams = this.currentCameraParams();
+                pose.prompt = this.getPosePrompt(this.activeTab);
+                this.poses[this.activeTab] = pose;
+            }
 
             data = {
                 type: "single_pose",
                 version: "1.0",
                 bones: this.poses[this.activeTab].bones,
-                modelRotation: this.poses[this.activeTab].modelRotation
+                modelRotation: this.poses[this.activeTab].modelRotation,
+                cameraParams: this.poses[this.activeTab].cameraParams,
             };
             filename = `pose_${name}.json`;
         }
@@ -10071,7 +10253,16 @@ class PoseStudioWidget {
                         this.setEditorMode("image", { sync: false });
                         this.clearSAMCameraMode();
                         const activeCharacter = this.getActiveCharacter();
-                        this.poses = newPoses.map(pose => this.stripSceneCameraFromPose(pose));
+                        this.poses = newPoses.map(sourcePose => {
+                            const pose = JSON.parse(JSON.stringify(sourcePose || {}));
+                            const savedCamera = pose.cameraParams;
+                            this.stripSceneCameraFromPose(pose);
+                            pose.cameraParams = resolveCaptureCameraParams(
+                                savedCamera,
+                                this.currentCameraParams(),
+                            );
+                            return pose;
+                        });
                         if (activeCharacter) activeCharacter.poses = this.poses;
                         for (const character of this.characters) {
                             if (character === activeCharacter) continue;
@@ -10080,6 +10271,8 @@ class PoseStudioWidget {
                             while (character.poses.length > this.poses.length) character.poses.pop();
                         }
                         this.activeTab = 0;
+                        this.ensurePoseCameraParams();
+                        this.restoreActivePoseCameraParams({ updateViewer: false });
                         this.updateTabs();
                         // Load first pose
                         if (this.viewer && this.viewer.isInitialized()) {
@@ -10093,10 +10286,21 @@ class PoseStudioWidget {
                 } else if (data.type === "single_pose" || data.bones) {
                     // Import Single to current tab
                     this.clearSAMCameraMode();
-                    const poseData = data.bones ? data : data;
+                    const poseData = JSON.parse(JSON.stringify(data));
+                    const savedCamera = poseData.cameraParams;
+                    this.stripSceneCameraFromPose(poseData);
+                    if (savedCamera && typeof savedCamera === "object") {
+                        poseData.cameraParams = resolveCaptureCameraParams(
+                            savedCamera,
+                            this.currentCameraParams(),
+                        );
+                        this.poses[this.activeTab] = poseData;
+                        this.restoreActivePoseCameraParams({ updateViewer: false });
+                        this.persistActivePoseCameraParams();
+                    }
 
                     if (this.viewer && this.viewer.isInitialized()) {
-                        this.viewer.setPose(this.stripSceneCameraFromPose(poseData), true);
+                        this.viewer.setPose(poseData, true);
                         this.updateRotationSliders();
                     }
                     this.updateCaptureCameraPreview();
@@ -11412,7 +11616,6 @@ class PoseStudioWidget {
                     animationSnapshot.basePose.prompt = savePrompt;
                 }
                 const serialized = serializePoseStudioCharacter(character, animationSnapshot);
-                serialized.poses = serialized.poses.map(pose => this.stripSceneCameraFromPose(pose));
                 if (character.id === this.activeCharacterId) {
                     serialized.poses[this.activeTab] = serialized.poses[this.activeTab] || {};
                     serialized.poses[this.activeTab].prompt = savePrompt;
@@ -11450,6 +11653,7 @@ class PoseStudioWidget {
                 }
             } else {
                 const pose = this.stripSceneCameraFromPose(this.viewer.getPose());
+                pose.cameraParams = this.currentCameraParams();
                 pose.prompt = savePrompt;
                 assetData = { ...pose, ...sceneBase, prompt: pose.prompt };
             }
@@ -11536,6 +11740,7 @@ class PoseStudioWidget {
         this.exportParams.cam_zoom = transform.zoom;
         this.exportParams.cam_yaw_deg = yaw;
         this.exportParams.cam_pitch_deg = pitch;
+        if (!this.isAnimationMode()) this.persistActivePoseCameraParams();
 
         this.viewer.setActiveCharacterAppearance({
             color: character.color,
@@ -11612,6 +11817,8 @@ class PoseStudioWidget {
             this.exportParams.cam_yaw_deg = Number(asset.camera.yaw_deg) || 0;
             this.exportParams.cam_pitch_deg = Number(asset.camera.pitch_deg) || 0;
         }
+        this.ensurePoseCameraParams();
+        this.restoreActivePoseCameraParams({ updateViewer: false });
 
         await this.hydrateCharacterSceneModels({ showOverlay: true, recenterViewport: false });
         this.animationTimeline?.setState(this.animationState);
@@ -13549,6 +13756,7 @@ class PoseStudioWidget {
         // Save current pose before syncing (only if we are NOT in a sub-sync loop)
         if (!animationMode && !fullCapture && this.viewer && this.viewer.isInitialized()) {
             const syncPose = this.stripSceneCameraFromPose(this.viewer.getPose());
+            syncPose.cameraParams = this.currentCameraParams();
             syncPose.prompt = this.getPosePrompt(this.activeTab);
             this.poses[this.activeTab] = syncPose;
         }
@@ -13636,6 +13844,11 @@ class PoseStudioWidget {
                         this.updateCharacterScene(animationMode
                             ? { frame: i }
                             : { poseIndex: i });
+                        const poseCamera = resolveCaptureCameraParams(
+                            capturePoses[i]?.cameraParams,
+                            currentCaptureCamera,
+                            animationMode,
+                        );
 
                         // Lighting Toggle
                         if (isOriginalLighting) {
@@ -13651,8 +13864,8 @@ class PoseStudioWidget {
                             bg,
                             currentCaptureCamera.offset_x,
                             currentCaptureCamera.offset_y,
-                            currentCaptureCamera.yaw_deg,
-                            currentCaptureCamera.pitch_deg,
+                            poseCamera.yaw_deg,
+                            poseCamera.pitch_deg,
                         ));
                         const framePrompt = animationMode
                             ? String(this.animationState.basePose?.prompt ?? this.getPosePrompt(this.activeTab))
@@ -13672,6 +13885,7 @@ class PoseStudioWidget {
                     this.applyAnimationFrame(this.animationState.currentFrame, { transient: true });
                 } else {
                     this.viewer.setPose(this.poses[this.activeTab], true);
+                    this.restoreActivePoseCameraParams({ updateViewer: false });
                     this.updateCharacterScene({ poseIndex: this.activeTab });
                     this.refreshTabActiveState({ scroll: false });
                     this.updateRotationSliders();
@@ -13687,8 +13901,11 @@ class PoseStudioWidget {
 
             } else {
                 // Capture only ACTIVE
-                const yaw = this.exportParams.cam_yaw_deg || 0;
-                const pitch = this.exportParams.cam_pitch_deg || 0;
+                const activeCamera = resolveCaptureCameraParams(
+                    this.poses[this.activeTab]?.cameraParams,
+                    currentCaptureCamera,
+                    animationMode,
+                );
                 this.updateCharacterScene(animationMode
                     ? { frame: this.animationState.currentFrame }
                     : { poseIndex: this.activeTab });
@@ -13699,7 +13916,16 @@ class PoseStudioWidget {
                     this.viewer.updateLights(this.lightParams);
                 }
 
-                this.setPoseCapture(this.activeTab, this.viewer.capture(w, h, 1, bg, 0, 0, yaw, pitch));
+                this.setPoseCapture(this.activeTab, this.viewer.capture(
+                    w,
+                    h,
+                    1,
+                    bg,
+                    0,
+                    0,
+                    activeCamera.yaw_deg,
+                    activeCamera.pitch_deg,
+                ));
                 this.lightingPrompts[this.activeTab] = this.generatePromptFromLights(
                     isOriginalLighting ? [] : this.lightParams,
                     this.getPosePrompt(this.activeTab),
@@ -13755,7 +13981,6 @@ class PoseStudioWidget {
                 : null;
             if (animationSnapshot?.basePose) this.stripSceneCameraFromPose(animationSnapshot.basePose);
             const serialized = serializePoseStudioCharacter(character, animationSnapshot);
-            serialized.poses = serialized.poses.map(pose => this.stripSceneCameraFromPose(pose));
             if (animationToSave) {
                 serialized.animation = {
                     ...createAnimationCacheReference(character.animationState, {
@@ -13979,6 +14204,7 @@ class PoseStudioWidget {
             const savedImagePoses = Array.isArray(data.image_poses) ? data.image_poses : data.poses;
             if (!Array.isArray(data.characters) && Array.isArray(savedImagePoses) && savedImagePoses.length) {
                 this.poses = savedImagePoses;
+                if (restoredActiveCharacter) restoredActiveCharacter.poses = this.poses;
                 this.posePrompts = []; // rebuild from pose.prompt on next ensurePosePrompts() call
             }
             if (Array.isArray(data.pose_prompts)) {
@@ -14066,6 +14292,8 @@ class PoseStudioWidget {
             if (typeof data.activeTab === 'number') {
                 this.activeTab = Math.max(0, Math.min(data.activeTab, this.poses.length - 1));
             }
+            this.ensurePoseCameraParams();
+            this.restoreActivePoseCameraParams({ updateViewer: false });
 
             // captured_images are no longer persisted in widget (stored in server-side LRU cache).
             // poseCaptures will be regenerated on the next syncToNode(true) call.


### PR DESCRIPTION
# Version 0.6.1
## 3D Factory Cameras, Gaussian PLY Import, and Per-Pose Framing

### New Features

*   **Gaussian PLY import for 3D Factory**: Existing Gaussian models can now be added directly to the active scene from the Factory UI.
    *   Binary little-endian Gaussian PLY files up to 2 GiB are streamed to temporary storage, fully inspected, and validated before the scene is changed; invalid, oversized, empty, and polygon-mesh payloads are rejected without leaving partial objects behind.
    *   Imported coordinates are normalized into Factory's canonical source convention so the live SPLAT viewport and later object export preserve the model's expected world orientation.
    *   Each import becomes a persistent visible layer with source metadata, checksums, validation statistics, a generated card thumbnail, and the same transform, duplication, library, cache, and PLY export support as generated objects.
    *   A successful import immediately loads, selects, and frames the new object in the live viewport.

*   **Saved scene cameras in 3D Factory**: Added a dedicated Camera block and one persistent Cameras group for up to 32 viewpoints.
    *   The graphical look pad and keyboard arrows rotate yaw and pitch in place while preserving camera position, target distance, vertical FOV, and a normalized up vector.
    *   Cameras can be added from the current view, selected for exact viewport inspection, adjusted with the look pad, and deleted.
    *   Leaving a saved-camera view by selecting it again, clicking empty viewport space, or selecting a scene object, group, or skydome restores the previous editor camera.
    *   Current and saved cameras persist in scene manifests and workflow snapshots; scene-list summaries now expose the saved-camera count.

*   **Multi-camera 3D Factory output**: Changed `preview` to an ordered ComfyUI `IMAGE` LIST.
    *   Item 0 is the current viewport, followed by every saved camera in Cameras-group order.
    *   Every frame is a clean PNG at the shared Scene Export dimensions, without the editor grid, selection bounds, or transform gizmos, while retaining its camera's own position, orientation, up vector, and FOV.
    *   Scenes containing only an environment or saved cameras can participate in the same capture path; scenes with no renderable content still return one empty image.

### Improvements

*   **Atomic execution capture sets**: Current-view and saved-camera renders are now uploaded and committed as one token-, scene-revision-, render-revision-, dimension-, and camera-order-bound set.
    *   The backend validates every frame before publishing any of them and rejects captures if the scene, export frame, or camera list changed during rendering.
    *   Node execution waits for the complete requested set, reports viewport failures explicitly, and can reuse only a complete saved set that still matches the current scene revision.
    *   Old capture directories are pruned after a successful atomic replacement, while internal capture manifests are omitted from public scene payloads and library packages.

*   **Camera-aware PLY export and scene packages**: Updated Gaussian scene metadata to `vnccs-3d-factory-gaussian-scene/v2`.
    *   Scene PLY headers now include the current camera plus every saved camera's stable ID, name, position, target, normalized up vector, and vertical FOV, alongside shared render dimensions and aspect metadata.
    *   `.vnccs3d` scene packages preserve current and saved cameras; loaded copies receive fresh camera IDs so they remain independent of the source scene.

*   **Pose Studio per-pose framing**: Image-mode pose tabs now retain independent camera framing.
    *   Each character stores its own X/Y position and zoom for every pose, while yaw and pitch remain shared across all characters on that pose tab.
    *   Switching, adding, deleting, resetting, copying, pasting, importing, exporting, saving to the library, loading a scene, and reopening a workflow now preserve the appropriate pose camera values.
    *   Full-scene and active-pose captures apply the correct framing for each pose and restore the active tab's camera afterward; Animation mode continues to use animated character transforms and its shared capture camera.
    *   Legacy poses without camera data are migrated from their character transform and existing camera settings.

*   **Skydome library previews**: Skydome capture now temporarily removes every Gaussian root from the Spark scene, renders the environment alone, and restores object parents, order, visibility, selection, camera, and viewport state afterward.

### Fixes

*   **3D Factory FPV camera stability**: Reworked look-pad rotation around world-up yaw and a clamped local pitch axis so repeated adjustments cannot accumulate unintended roll or flip at the poles.
*   **Pose Studio preview camera restoration**: Temporary Pose Manager fitting and batch captures now restore the active pose's camera instead of leaking preview framing into Studio or saved library poses.

### Packaging and Documentation

*   Bumped the package version to `0.6.1` and advanced the 3D Factory scene, export, workflow-state, frontend, and viewer schema/build revisions.
*   Updated the README and 3D Factory guide for PLY import, saved cameras, camera-aware PLY/library persistence, and ordered multi-camera node output.
*   Expanded backend, node, frontend, library, Pose Studio bootstrap, character-scene, and widget-hardening regression coverage for the new workflows.