### PR TITLE
0.6.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -210,3 +210,6 @@ __marimo__/
 # img2threejs Studio runtime data (fallback paths outside ComfyUI)
 /output/vnccs_img2threejs/
 /models/LLM/img2threejs/
+
+# Runtime shallow clones used to accelerate external Pose Library sync.
+/PoseLibrary/.repository_git_cache/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,68 @@
+# Version 0.6.2
+## Pose Library Repository Sync, Publishing, and Pose Manager Reliability
+
+### New Features
+
+*   **Fast external Pose Library synchronization**: Public Hugging Face pose repositories now use a one-shot shallow Git clone instead of downloading every changed file through a separate HTTP request.
+    *   The complete repository is transferred with `git clone --depth 1 --single-branch --no-tags`, providing a substantial speedup for libraries containing hundreds or thousands of small pose and preview files.
+    *   The clone exists only in the operating system's temporary directory on the machine running ComfyUI. It is used as the import source and removed immediately after synchronization, without creating a nested Git checkout in `custom_nodes`, PoseLibrary, or `ComfyUI/user`.
+    *   Manifest paths, file boundaries, declared SHA-256 hashes, size limits, symbolic links, and Git LFS/Xet pointers are validated before files are imported into PoseLibrary.
+    *   Private repositories and unsupported Git/LFS transfers continue through the authenticated bounded HTTP path.
+
+*   **Automatic repository installation**: Adding a Pose Library repository is now a complete single action.
+    *   Both `owner/repository` identifiers and Hugging Face repository URLs are accepted.
+    *   Clicking Add registers the repository, immediately downloads its manifest, poses, animations, and previews, refreshes the library, and makes the new assets available without another user action.
+    *   Inline progress reports the current transfer, file count, imported, unchanged, and removed totals.
+
+*   **Second default Pose Library repository**: Added [`Totemistyk/General_Poses_PoseStudio`](https://huggingface.co/Totemistyk/General_Poses_PoseStudio) as the enabled second built-in repository after `MIUProject/VNCCS_PoseLibrary_Main`.
+    *   Existing installations receive it automatically after updating and restarting the node.
+    *   Its project title is fixed as **General Poses PoseStudio**, independently of generic legacy titles stored in a remote manifest.
+
+### Improvements
+
+*   **Repository diagnostics and recovery**: Git failures no longer disappear when the HTTP fallback begins.
+    *   The Git exit code and relevant stderr lines are retained in repository state, written to the ComfyUI log, and displayed in an expandable diagnostics block in Library settings.
+    *   Settings remain open after a fallback so the error can be inspected instead of being overwritten by per-file download progress.
+    *   Successfully cloned repositories are imported directly from their temporary checkout; the Windows directory-promotion step that could fail with `WinError 5` has been removed.
+
+*   **Reliable local-library publishing**: Publishing now binds every operation to the repository selected in the current dialog.
+    *   Switching between Create New and Use Existing keeps separate input drafts and cannot silently retain the previous target.
+    *   Create New requires and creates exactly the requested repository, while malformed requests can no longer fall back to the previously saved repository.
+    *   The active target is shown throughout upload, concurrent publish attempts are blocked, and the saved repository link changes only after the requested publish succeeds.
+
+*   **Explicit pose versus pose-set semantics**: Multi-character scene data and Pose Manager pose sets now use separate axes and separate loading paths.
+    *   A scene containing `characters[]` remains one library pose even when a character contains runtime `poses[]`; only an asset explicitly marked `type: "pose_set"` replaces the complete Pose Manager list.
+    *   Loading a single library pose updates the selected pose without deleting the other Pose Manager entries or switching the interface to Studio.
+    *   Loading an animation remains the only library operation that automatically switches to Studio and its animation timeline.
+    *   Saving Current Pose stores only the selected pose for every scene character; All Poses (Set) remains the explicit path for exporting the complete set.
+
+*   **Pose Manager preview and execution consistency**: Shape changes now produce one authoritative set of visible pose images.
+    *   Age, head size, and other supported mesh changes restart preview generation from the first card after the updated model is ready.
+    *   Every deformed pose is fitted and centered independently, and captures wait for the real skin texture before replacing a card.
+    *   RUN in Pose Manager uploads an immutable snapshot of the images already displayed in the cards. It performs no second camera fit or render reinterpretation that could change their scale or position.
+    *   Execution fails explicitly if a required Pose Manager card is incomplete instead of substituting a differently framed image.
+
+*   **Library camera and scene preservation**: Static library poses retain the framing that was visible when they were saved.
+    *   Scene-format poses restore the active character's exact saved transform rather than applying the legacy camera-pivot conversion a second time.
+    *   SAM projection FOV and camera position are normalized, serialized, published, downloaded, and restored alongside ordinary pose camera data.
+    *   Legacy flat poses continue to use the compatible camera-framing conversion path.
+
+### Fixes
+
+*   **Repository identity**: Fixed different third-party repositories inheriting the same generic `VNCCS Pose Library` title.
+*   **Stale publication target**: Fixed publish progress initially displaying the old repository and fixed Create New uploads that could create an empty repository while sending files to the previous target.
+*   **Repository installation timing**: Fixed newly added repositories remaining empty until a later enable, refresh, or restart action.
+*   **Pose Manager mode stability**: Fixed loading a static multi-character pose switching the UI back to standard Pose Studio.
+*   **Pose Manager set replacement**: Fixed a single scene pose being mistaken for a pose set and replacing the complete current pose list.
+*   **Pose Manager RUN framing**: Fixed execution recapturing correctly fitted cards with neutral or stale camera values, causing poses to become tiny, oversized, cropped, or displaced.
+*   **Saved pose framing**: Fixed library poses losing SAM projection zoom and camera position between save, publication, download, and reload.
+*   **Reset scope**: Reset now restores all head, limb, hand, foot, shoulder, hip, and spine mesh-proportion controls while leaving gender, age, weight, muscle, height, and other character attributes unchanged.
+
+### Packaging and Documentation
+
+*   Bumped the package version to `0.6.2`.
+*   Expanded Pose Library backend, publication, Git transport, character-schema, camera-framing, Pose Manager, and widget-hardening regression coverage.
+
 # Version 0.6.1
 ## 3D Factory Cameras, Gaussian PLY Import, and Per-Pose Framing
 

--- a/api/pose_library.py
+++ b/api/pose_library.py
@@ -9,18 +9,25 @@ import tempfile
 import uuid
 import threading
 import asyncio
+import subprocess
+import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime, timezone
 from fractions import Fraction
+from urllib.parse import unquote, urlparse
 from aiohttp import web
 from PIL import Image
 
+LOGGER = logging.getLogger(__name__)
+
 DEFAULT_REPO_ID = "MIUProject/VNCCS_PoseLibrary_Main"
+SECONDARY_DEFAULT_REPO_ID = "Totemistyk/General_Poses_PoseStudio"
 LOCAL_USER_REPOSITORY = "local_user_poses"
 DEFAULT_CATEGORY = "Uncategorized"
 POSE_ASSET_TYPE = "pose"
 ANIMATION_ASSET_TYPE = "animation"
 ANIMATION_SYSTEM_TAG = "Animation"
+LEGACY_GENERIC_REPOSITORY_TITLES = {"VNCCS Pose Library"}
 RESERVED_LIBRARY_JSON = {"repositories.user.json", "pose_library.json"}
 MAX_PREVIEW_BYTES = 16 * 1024 * 1024
 MAX_VIDEO_PREVIEW_INPUT_BYTES = 40 * 1024 * 1024
@@ -28,8 +35,12 @@ MAX_VIDEO_PREVIEW_STORED_BYTES = 32 * 1024 * 1024
 MAX_LIBRARY_SAVE_REQUEST_BYTES = 64 * 1024 * 1024
 MAX_POSE_REPOSITORY_FILE_BYTES = 32 * 1024 * 1024
 MAX_POSE_REPOSITORY_SYNC_BYTES = 256 * 1024 * 1024
+POSE_REPOSITORY_LEGACY_GIT_CACHE_DIR = ".repository_git_cache"
+POSE_REPOSITORY_GIT_TIMEOUT_SECONDS = 180
 _REPOSITORY_PROGRESS = {}
 _REPOSITORY_PROGRESS_LOCK = threading.Lock()
+_REPOSITORY_GIT_LOCKS = {}
+_REPOSITORY_GIT_LOCKS_GUARD = threading.Lock()
 _REPOSITORY_PROGRESS_MAX = 256
 _REPOSITORY_PROGRESS_TTL_SECONDS = 60 * 60
 _REPOSITORY_PROGRESS_RUNNING_TTL_SECONDS = 24 * 60 * 60
@@ -116,6 +127,125 @@ def get_library_path():
     os.makedirs(lib_path, exist_ok=True)
     return lib_path
 
+class GitRepositorySyncUnavailable(RuntimeError):
+    """Signals that repository sync should retry through the HTTP transport."""
+
+def get_repository_git_lock(repo_id):
+    with _REPOSITORY_GIT_LOCKS_GUARD:
+        return _REPOSITORY_GIT_LOCKS.setdefault(repo_id, threading.Lock())
+
+def walk_pose_library(lib_path):
+    """Walk user-visible pose data without exposing the internal Git cache."""
+    for root, dirs, files in os.walk(lib_path):
+        if os.path.abspath(root) == os.path.abspath(lib_path):
+            dirs[:] = [directory for directory in dirs if directory != POSE_REPOSITORY_LEGACY_GIT_CACHE_DIR]
+        yield root, dirs, files
+
+def safe_repository_source_file(source_root, path_in_repo):
+    normalized = str(path_in_repo or "").replace("\\", "/").strip()
+    parts = normalized.split("/")
+    if not normalized or normalized.startswith("/") or any(part in {"", ".", ".."} for part in parts):
+        raise GitRepositorySyncUnavailable(f"Unsafe repository path: {path_in_repo}")
+
+    source_root = os.path.abspath(source_root)
+    candidate = os.path.abspath(os.path.join(source_root, *parts))
+    real_source_root = os.path.realpath(source_root)
+    real_candidate = os.path.realpath(candidate)
+    try:
+        inside_root = os.path.commonpath([real_source_root, real_candidate]) == real_source_root
+    except ValueError:
+        inside_root = False
+    if not inside_root or os.path.islink(candidate) or not os.path.isfile(candidate):
+        raise GitRepositorySyncUnavailable(f"Repository file is missing or unsafe: {path_in_repo}")
+    return candidate
+
+def is_git_lfs_pointer(path):
+    try:
+        if os.path.getsize(path) > 4096:
+            return False
+        with open(path, "rb") as file:
+            return file.read(256).startswith(b"version https://git-lfs.github.com/spec/v1")
+    except Exception:
+        return False
+
+def run_pose_repository_git(command):
+    env = os.environ.copy()
+    env["GIT_TERMINAL_PROMPT"] = "0"
+    # Do not let optional Git LFS hooks start an unbounded second transfer. A
+    # pointer in a manifest-listed asset is detected below and retried through
+    # the bounded HTTP downloader instead.
+    env["GIT_LFS_SKIP_SMUDGE"] = "1"
+    try:
+        completed = subprocess.run(
+            command,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            timeout=POSE_REPOSITORY_GIT_TIMEOUT_SECONDS,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError) as exc:
+        raise GitRepositorySyncUnavailable(f"Git command failed: {exc}") from exc
+    if completed.returncode != 0:
+        output = completed.stderr or completed.stdout or "unknown Git error"
+        detail = [line.strip() for line in output.splitlines() if line.strip()]
+        # Retain enough stderr to diagnose transport/filesystem failures while
+        # keeping the progress payload bounded and readable in the UI.
+        summary = " | ".join(detail[-8:]) if detail else "unknown Git error"
+        summary = summary[-2000:]
+        raise GitRepositorySyncUnavailable(
+            f"Git exited with code {completed.returncode}: {summary}"
+        )
+    return completed.stdout.strip()
+
+def update_git_pose_repository_checkout(repo_id, task_id=None):
+    git = shutil.which("git")
+    if not git:
+        raise GitRepositorySyncUnavailable("Git is not installed")
+
+    repository_url = f"https://huggingface.co/{repo_id}"
+    repository_progress_update(task_id, message=f"Cloning {repo_id}...", progress=4)
+    # The extension itself already lives in ComfyUI/custom_nodes and must not
+    # contain another persistent Git working tree. Clone once into the runtime
+    # machine's OS temp directory, import the manifest assets, then let the
+    # caller remove the entire checkout.
+    temporary_checkout = tempfile.mkdtemp(prefix="vnccs_pose_repository_")
+    try:
+        run_pose_repository_git([
+            git,
+            "clone",
+            "--depth", "1",
+            "--single-branch",
+            "--no-tags",
+            repository_url,
+            temporary_checkout,
+        ])
+        if not os.path.isdir(os.path.join(temporary_checkout, ".git")):
+            raise GitRepositorySyncUnavailable("Git clone did not create a working tree")
+        return temporary_checkout
+    except Exception:
+        shutil.rmtree(temporary_checkout, ignore_errors=True)
+        raise
+
+def load_git_pose_manifest(checkout, manifest_path):
+    source = safe_repository_source_file(checkout, manifest_path)
+    size = os.path.getsize(source)
+    if size > MAX_POSE_REPOSITORY_FILE_BYTES:
+        raise GitRepositorySyncUnavailable(
+            f"{manifest_path} is too large ({human_bytes(size)} > {human_bytes(MAX_POSE_REPOSITORY_FILE_BYTES)})"
+        )
+    if is_git_lfs_pointer(source):
+        raise GitRepositorySyncUnavailable(f"{manifest_path} is stored through Git LFS/Xet")
+    try:
+        with open(source, "r", encoding="utf-8") as file:
+            manifest = json.load(file)
+    except Exception as exc:
+        raise GitRepositorySyncUnavailable(f"Cannot read {manifest_path}: {exc}") from exc
+    if not isinstance(manifest, dict):
+        raise GitRepositorySyncUnavailable(f"Invalid repository manifest: {manifest_path}")
+    return manifest
+
 def get_default_repositories_path():
     base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
     return os.path.join(base_dir, "config", "default_pose_repositories.json")
@@ -164,26 +294,55 @@ def save_vnccs_user_config(new_data):
 
 def normalize_repo_id(repo_id):
     repo_id = str(repo_id or "").strip()
+    if repo_id.lower().startswith(("https://", "http://")):
+        try:
+            parsed = urlparse(repo_id)
+            if parsed.hostname not in {"huggingface.co", "www.huggingface.co"}:
+                return ""
+            parts = [unquote(part) for part in parsed.path.split("/") if part]
+            if len(parts) < 2 or parts[0] in {"datasets", "spaces"}:
+                return ""
+            repo_id = "/".join(parts[:2])
+        except Exception:
+            return ""
+    repo_id = repo_id.strip("/")
     if not repo_id or " " in repo_id or repo_id.count("/") != 1:
         return ""
     return repo_id
 
+def repository_manifest_title(repo_id, title=""):
+    """Return a stable, repository-specific title for generated manifests."""
+    title = str(title or "").strip()
+    if not title or title in LEGACY_GENERIC_REPOSITORY_TITLES:
+        return repo_id
+    return title
+
 def load_default_repositories():
     path = get_default_repositories_path()
-    fallback = {
-        "repo_id": DEFAULT_REPO_ID,
-        "title": "VNCCS Pose Library Main",
-        "description": "Default curated VNCCS Pose Studio pose library.",
-        "manifest_path": "pose_library.json",
-        "enabled": True,
-        "builtin": True,
-    }
+    fallbacks = [
+        {
+            "repo_id": DEFAULT_REPO_ID,
+            "title": "VNCCS Pose Library Main",
+            "description": "Default curated VNCCS Pose Studio pose library.",
+            "manifest_path": "pose_library.json",
+            "enabled": True,
+            "builtin": True,
+        },
+        {
+            "repo_id": SECONDARY_DEFAULT_REPO_ID,
+            "title": "General Poses PoseStudio",
+            "description": "Default community pose library by Totemistyk.",
+            "manifest_path": "pose_library.json",
+            "enabled": True,
+            "builtin": True,
+        },
+    ]
     try:
         with open(path, "r", encoding="utf-8") as f:
             data = json.load(f)
         repos = data.get("repositories") or []
     except Exception:
-        repos = [fallback]
+        repos = fallbacks
     out = []
     for repo in repos:
         repo_id = normalize_repo_id(repo.get("repo_id"))
@@ -197,7 +356,7 @@ def load_default_repositories():
             "enabled": bool(repo.get("enabled", True)),
             "builtin": True,
         })
-    return out or [fallback]
+    return out or fallbacks
 
 def load_user_repositories():
     path = get_user_repositories_path()
@@ -244,6 +403,13 @@ def load_pose_repositories():
         merged[repo_id] = {**merged.get(repo_id, {}), **repo}
         if repo_id in defaults:
             merged[repo_id]["builtin"] = True
+            if merged[repo_id].get("title") in LEGACY_GENERIC_REPOSITORY_TITLES:
+                merged[repo_id]["title"] = defaults[repo_id]["title"]
+        else:
+            merged[repo_id]["title"] = repository_manifest_title(
+                repo_id,
+                merged[repo_id].get("title"),
+            )
     return list(merged.values())
 
 def get_hf_token():
@@ -275,6 +441,8 @@ def refresh_pose_repository(repo, task_id=None):
         "asset_count": int(repo.get("asset_count") or repo.get("pose_count") or 0),
         "last_checked": time.time(),
         "last_error": "",
+        "git_error": "",
+        "transport": "",
     }
     try:
         from huggingface_hub import HfApi
@@ -283,54 +451,127 @@ def refresh_pose_repository(repo, task_id=None):
         repository_progress_update(task_id, message=f"Reading repository info for {repo_id}...", progress=2)
         info = api.repo_info(repo_id=repo_id, repo_type="model", token=token)
         result["sha"] = getattr(info, "sha", "") or ""
-        try:
-            manifest_file = download_hf_file_with_progress(
-                repo_id=repo_id,
-                path_in_repo=manifest_path,
-                token=token,
-                task_id=task_id,
-                file_index=0,
-                total_files=1,
-            )
-            with open(manifest_file, "r", encoding="utf-8") as f:
-                manifest = json.load(f)
+        manifest = None
+        sync_result = None
+        transport = ""
+        git_failure = ""
+
+        # A shallow Git transfer packs all of the small JSON/WebP assets into a
+        # handful of requests, avoiding one HTTP round trip per file. Private
+        # repositories stay on the authenticated HTTP path so tokens never
+        # appear in Git configuration or process arguments.
+        if not bool(getattr(info, "private", False)):
+            checkout = None
             try:
-                os.remove(manifest_file)
-            except Exception:
-                pass
-            poses = manifest.get("poses") or []
-            sync_result = sync_pose_repository_files(repo, manifest, token, task_id=task_id)
-            result["animation_count"] = sum(
-                1 for item in poses
-                if isinstance(item, dict) and (
-                    normalize_asset_type(item.get("asset_type")) == ANIMATION_ASSET_TYPE
-                    or str(item.get("json_path") or "").replace("\\", "/").startswith("animations/")
+                with get_repository_git_lock(repo_id):
+                    checkout = update_git_pose_repository_checkout(repo_id, task_id=task_id)
+                    manifest = load_git_pose_manifest(checkout, manifest_path)
+                    sync_result = sync_pose_repository_files(
+                        repo,
+                        manifest,
+                        token,
+                        task_id=task_id,
+                        source_root=checkout,
+                    )
+                transport = "git"
+            except GitRepositorySyncUnavailable as exc:
+                git_failure = str(exc)
+                LOGGER.warning(
+                    "Git sync failed for %s; using HTTP fallback: %s",
+                    repo_id,
+                    git_failure,
                 )
+                manifest = None
+                sync_result = None
+                result["git_error"] = git_failure
+            finally:
+                if checkout:
+                    shutil.rmtree(checkout, ignore_errors=True)
+
+        if manifest is None:
+            fallback_message = f"Using compatible HTTP download for {repo_id}..."
+            if git_failure:
+                fallback_message = f"Git unavailable ({git_failure}). Using HTTP download..."
+            repository_progress_update(
+                task_id,
+                message=fallback_message,
+                progress=5,
+                git_error=git_failure,
+                transport="http",
             )
-            result["pose_count"] = len(poses) - result["animation_count"]
-            result["asset_count"] = len(poses)
-            result["downloaded_count"] = sync_result["downloaded_count"]
-            result["skipped_count"] = sync_result["skipped_count"]
-            result["removed_count"] = sync_result["removed_count"]
-            result["title"] = manifest.get("title") or result.get("title") or repo_id
-            result["description"] = manifest.get("description") or result.get("description") or ""
-            result["updated_at"] = manifest.get("updated_at") or ""
-            result["status"] = "ok"
-            repository_progress_finish(task_id, f"Repository sync complete: {sync_result['downloaded_count']} downloaded, {sync_result['skipped_count']} unchanged, {sync_result['removed_count']} removed.")
-        except Exception:
-            repository_progress_update(task_id, message=f"Manifest not found. Counting files in {repo_id}...", progress=50)
-            files = api.list_repo_files(repo_id=repo_id, repo_type="model", token=token)
-            result["asset_count"] = len([
-                file for file in files
-                if file.lower().endswith(".json") and os.path.basename(file) != manifest_path
-            ])
-            result["animation_count"] = len([
-                file for file in files
-                if str(file).replace("\\", "/").startswith("animations/") and file.lower().endswith(".json")
-            ])
-            result["pose_count"] = result["asset_count"] - result["animation_count"]
-            result["status"] = "ok"
-            repository_progress_finish(task_id, f"Repository checked: {result['asset_count']} library JSON files found, no manifest to sync.")
+            manifest_file = None
+            try:
+                manifest_file = download_hf_file_with_progress(
+                    repo_id=repo_id,
+                    path_in_repo=manifest_path,
+                    token=token,
+                    task_id=task_id,
+                    file_index=0,
+                    total_files=1,
+                )
+                with open(manifest_file, "r", encoding="utf-8") as f:
+                    manifest = json.load(f)
+                if not isinstance(manifest, dict):
+                    raise ValueError(f"Invalid repository manifest: {manifest_path}")
+            except Exception:
+                repository_progress_update(task_id, message=f"Manifest not found. Counting files in {repo_id}...", progress=50)
+                files = api.list_repo_files(repo_id=repo_id, repo_type="model", token=token)
+                result["asset_count"] = len([
+                    file for file in files
+                    if file.lower().endswith(".json") and os.path.basename(file) != manifest_path
+                ])
+                result["animation_count"] = len([
+                    file for file in files
+                    if str(file).replace("\\", "/").startswith("animations/") and file.lower().endswith(".json")
+                ])
+                result["pose_count"] = result["asset_count"] - result["animation_count"]
+                result["transport"] = "api"
+                result["status"] = "ok"
+                repository_progress_finish(task_id, f"Repository checked: {result['asset_count']} library JSON files found, no manifest to sync.")
+                return result
+            finally:
+                if manifest_file:
+                    try:
+                        os.remove(manifest_file)
+                    except Exception:
+                        pass
+
+            sync_result = sync_pose_repository_files(repo, manifest, token, task_id=task_id)
+            transport = "http"
+
+        poses = manifest.get("poses") or []
+        result["animation_count"] = sum(
+            1 for item in poses
+            if isinstance(item, dict) and (
+                normalize_asset_type(item.get("asset_type")) == ANIMATION_ASSET_TYPE
+                or str(item.get("json_path") or "").replace("\\", "/").startswith("animations/")
+            )
+        )
+        result["pose_count"] = len(poses) - result["animation_count"]
+        result["asset_count"] = len(poses)
+        result["downloaded_count"] = sync_result["downloaded_count"]
+        result["skipped_count"] = sync_result["skipped_count"]
+        result["removed_count"] = sync_result["removed_count"]
+        result["transport"] = transport
+        manifest_title = manifest.get("title")
+        result["title"] = (
+            (result.get("title") or repo_id)
+            if result.get("builtin")
+            else repository_manifest_title(repo_id, manifest_title)
+        )
+        result["description"] = manifest.get("description") or result.get("description") or ""
+        result["updated_at"] = manifest.get("updated_at") or ""
+        result["status"] = "ok"
+        repository_progress_finish(
+            task_id,
+            f"Repository sync complete via {transport}: {sync_result['downloaded_count']} downloaded, "
+            f"{sync_result['skipped_count']} unchanged, {sync_result['removed_count']} removed.",
+        )
+        repository_progress_update(
+            task_id,
+            git_error=git_failure,
+            transport=transport,
+        )
     except Exception as exc:
         result["status"] = "error"
         result["last_error"] = str(exc)
@@ -637,17 +878,16 @@ def remove_local_repository_cache(repo_id):
     repo_root = os.path.abspath(os.path.join(lib_root, repository_to_dir(repo_id)))
     if repo_root == lib_root or not repo_root.startswith(lib_root + os.sep):
         return 0
-    if not os.path.exists(repo_root):
-        return 0
 
     removed_count = 0
-    for _root, _dirs, files in os.walk(repo_root):
-        removed_count += len(files)
-    shutil.rmtree(repo_root, ignore_errors=True)
+    if os.path.exists(repo_root):
+        for _root, _dirs, files in os.walk(repo_root):
+            removed_count += len(files)
+        shutil.rmtree(repo_root, ignore_errors=True)
     return removed_count
 
-def sync_pose_repository_files(repo, manifest, token, task_id=None):
-    """Download new/changed pose files from a Hugging Face pose repository."""
+def sync_pose_repository_files(repo, manifest, token, task_id=None, source_root=None):
+    """Import new/changed pose files from Git or the Hugging Face HTTP API."""
     repo_id = repo["repo_id"]
     poses = manifest.get("poses") or []
     pose_states = {}
@@ -711,20 +951,50 @@ def sync_pose_repository_files(repo, manifest, token, task_id=None):
             errors.append(f"{hub_json_path}: {exc}")
             pose_states[hub_json_path]["error"] = True
 
+    if source_root and download_jobs:
+        source_bytes = 0
+        try:
+            for job in download_jobs:
+                source_path = safe_repository_source_file(source_root, job["hub_path"])
+                file_bytes = os.path.getsize(source_path)
+                if file_bytes > MAX_POSE_REPOSITORY_FILE_BYTES:
+                    raise GitRepositorySyncUnavailable(
+                        f"{job['hub_path']} is too large ({human_bytes(file_bytes)} > {human_bytes(MAX_POSE_REPOSITORY_FILE_BYTES)})"
+                    )
+                if is_git_lfs_pointer(source_path):
+                    raise GitRepositorySyncUnavailable(f"{job['hub_path']} is stored through Git LFS/Xet")
+                source_bytes += file_bytes
+                if source_bytes > MAX_POSE_REPOSITORY_SYNC_BYTES:
+                    raise GitRepositorySyncUnavailable(
+                        f"Repository sync exceeds the total limit ({human_bytes(MAX_POSE_REPOSITORY_SYNC_BYTES)})"
+                    )
+                verify_expected_sha(source_path, job.get("expected_sha") or "")
+                job["source_path"] = source_path
+        except GitRepositorySyncUnavailable:
+            raise
+        except Exception as exc:
+            raise GitRepositorySyncUnavailable(f"Cannot validate Git checkout: {exc}") from exc
+
     if download_jobs:
         downloaded_bytes = 0
+        operation = "Importing" if source_root else "Downloading"
+        progress_start = 8 if source_root else 2
+        progress_span = 88 if source_root else 94
         repository_progress_update(
             task_id,
-            message=f"Downloading {len(download_jobs)} changed files...",
+            message=f"{operation} {len(download_jobs)} changed files...",
             current_file="",
             file_index=0,
             total_files=len(download_jobs),
-            progress=2,
+            progress=progress_start,
         )
         for completed, job in enumerate(download_jobs, start=1):
             tmp_path = None
             try:
-                tmp_path = download_hf_file(repo_id, job["hub_path"], token=token)
+                if source_root:
+                    tmp_path = job["source_path"]
+                else:
+                    tmp_path = download_hf_file(repo_id, job["hub_path"], token=token)
                 file_bytes = os.path.getsize(tmp_path)
                 if downloaded_bytes + file_bytes > MAX_POSE_REPOSITORY_SYNC_BYTES:
                     raise ValueError(f"Repository sync exceeded the total download limit ({human_bytes(MAX_POSE_REPOSITORY_SYNC_BYTES)})")
@@ -740,18 +1010,18 @@ def sync_pose_repository_files(repo, manifest, token, task_id=None):
                 errors.append(f"{job['hub_path']}: {exc}")
                 pose_states[job["pose_key"]]["error"] = True
             finally:
-                if tmp_path:
+                if tmp_path and not source_root:
                     try:
                         os.remove(tmp_path)
                     except Exception:
                         pass
             repository_progress_update(
                 task_id,
-                message=f"Downloaded {completed}/{len(download_jobs)} changed files...",
+                message=f"{'Imported' if source_root else 'Downloaded'} {completed}/{len(download_jobs)} changed files...",
                 current_file=job["hub_path"],
                 file_index=completed,
                 total_files=len(download_jobs),
-                progress=2 + (completed / max(len(download_jobs), 1)) * 94,
+                progress=progress_start + (completed / max(len(download_jobs), 1)) * progress_span,
             )
     else:
         repository_progress_update(task_id, message="All repository files are already up to date.", progress=96)
@@ -809,7 +1079,7 @@ def build_pose_manifest(repo_id, remote_manifest, local_poses, changed_paths):
     title = remote_manifest.get("title") if isinstance(remote_manifest, dict) else ""
     return {
         "schema_version": 2,
-        "title": title or "VNCCS Pose Library",
+        "title": repository_manifest_title(repo_id, title),
         "repo_id": repo_id,
         "updated_at": now,
         "poses": sorted(manifest_poses, key=lambda item: (item.get("category") or "", item.get("name") or "")),
@@ -909,7 +1179,10 @@ def publish_local_repository_to_hf(repo_id, token=None, create=False, private=Fa
         api = HfApi(token=token)
         repository_progress_update(task_id, progress=2, message=f"Checking {repo_id}...")
         if create:
-            api.create_repo(repo_id=repo_id, repo_type="model", private=bool(private), exist_ok=True)
+            # "Create new" must never silently reuse an existing target. Apart
+            # from matching the UI contract, this prevents a stale repo id from
+            # redirecting a publish into the previously configured repository.
+            api.create_repo(repo_id=repo_id, repo_type="model", private=bool(private), exist_ok=False)
         else:
             api.repo_info(repo_id=repo_id, repo_type="model", token=token)
 
@@ -1092,13 +1365,14 @@ async def add_pose_repository(request):
     except Exception:
         return web.json_response({"error": "Invalid JSON"}, status=400)
     repo_id = normalize_repo_id(data.get("repo_id"))
+    task_id = str(data.get("task_id") or uuid.uuid4())
     if not repo_id:
         return web.json_response({"error": "Invalid Hugging Face repo id"}, status=400)
     repos = load_pose_repositories()
     if any(repo["repo_id"] == repo_id for repo in repos):
         return web.json_response({"error": "Repository already exists"}, status=400)
     user_repos = load_user_repositories()
-    user_repos.append({
+    new_repository = {
         "repo_id": repo_id,
         "title": data.get("title") or repo_id,
         "description": data.get("description") or "",
@@ -1108,9 +1382,25 @@ async def add_pose_repository(request):
         "asset_count": 0,
         "pose_count": 0,
         "animation_count": 0,
-    })
+    }
+    user_repos.append(new_repository)
     save_user_repositories(user_repos)
-    return web.json_response({"success": True, "repositories": load_pose_repositories()})
+
+    # Add is a complete user action: registering a repository also downloads
+    # its manifest, poses, and previews. The response is held until the cache is
+    # ready, while the existing progress endpoint keeps the UI responsive.
+    refreshed = await asyncio.to_thread(
+        refresh_pose_repository,
+        new_repository,
+        task_id=task_id,
+    )
+    persist_refreshed_repositories([refreshed])
+    return web.json_response({
+        "success": True,
+        "task_id": task_id,
+        "repositories": load_pose_repositories(),
+        "refreshed": refreshed,
+    })
 
 async def toggle_pose_repository(request):
     try:
@@ -1180,6 +1470,8 @@ def persist_refreshed_repositories(refreshed):
                     "downloaded_count",
                     "skipped_count",
                     "removed_count",
+                    "transport",
+                    "git_error",
                 )
             })
         elif repo["repo_id"] in by_id:
@@ -1279,7 +1571,10 @@ async def publish_local_pose_repository(request):
     except Exception:
         return web.json_response({"error": "Invalid JSON"}, status=400)
 
-    repo_id = normalize_repo_id(data.get("repo_id") or get_vnccs_user_config().get("pose_library_publish_repo_id"))
+    # The target is part of every publish request. Falling back to the saved
+    # target here can turn a malformed "create new" request into a destructive
+    # publish to the old repository.
+    repo_id = normalize_repo_id(data.get("repo_id"))
     token = data.get("hf_token") or get_hf_token()
     create = bool(data.get("create"))
     private = bool(data.get("private", False))
@@ -1638,7 +1933,7 @@ def find_pose_file(name, repository=None, category=None):
         return legacy_path, LOCAL_USER_REPOSITORY, ""
 
     repo_map = repository_dir_map()
-    for root, _dirs, files in os.walk(lib_path):
+    for root, _dirs, files in walk_pose_library(lib_path):
         filename = f"{name}.json"
         if filename not in files:
             continue
@@ -1673,7 +1968,7 @@ async def list_poses(request):
     }
     repository_states[LOCAL_USER_REPOSITORY] = True
     try:
-        walker = os.walk(lib_path)
+        walker = walk_pose_library(lib_path)
     except FileNotFoundError:
         return web.json_response({"poses": []})
 

--- a/config/default_pose_repositories.json
+++ b/config/default_pose_repositories.json
@@ -7,6 +7,13 @@
       "description": "Default curated VNCCS Pose Studio pose library.",
       "manifest_path": "pose_library.json",
       "enabled": true
+    },
+    {
+      "repo_id": "Totemistyk/General_Poses_PoseStudio",
+      "title": "General Poses PoseStudio",
+      "description": "Default community pose library by Totemistyk.",
+      "manifest_path": "pose_library.json",
+      "enabled": true
     }
   ]
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs-utils"
 description = "VNCCS utility nodes: Pose Studio, UniCanvas, and 3D Factory."
-version = "0.6.1"
+version = "0.6.2"
 license = {file = "LICENSE"} 
 
 dependencies = [

--- a/tests/test_pose_character_regressions.mjs
+++ b/tests/test_pose_character_regressions.mjs
@@ -177,7 +177,7 @@ test("image pose tabs keep independent camera framing", () => {
 test("library poses key their saved crop and zoom before editor commit", () => {
     const framingMethod = methodSource(
         poseStudioSource,
-        "applyLibraryPoseFraming(cameraParams)",
+        "applyLibraryPoseTransform(transformSource, cameraParams = {})",
         "\n    async loadCharacterSceneLibraryAsset(",
     );
     assert.match(
@@ -199,24 +199,59 @@ test("library poses key their saved crop and zoom before editor commit", () => {
         "\n    showSettingsModal()",
     );
     const snapshotCamera = loadMethod.indexOf("const savedFraming = (");
+    const snapshotTransform = loadMethod.indexOf("const activeSceneTransform = activeScenePose");
     const stripCamera = loadMethod.indexOf(
         "const pose = this.stripSceneCameraFromPose(poseSource)",
     );
     const applyPose = loadMethod.indexOf("this.viewer.setPose(pose, true)");
-    const restoreCamera = loadMethod.indexOf(
-        "this.applyLibraryPoseFraming(savedFraming)",
+    const restoreSceneTransform = loadMethod.indexOf(
+        "this.applyLibraryPoseTransform(activeSceneTransform, savedAngles)",
         applyPose,
+    );
+    const restoreLegacyCamera = loadMethod.indexOf(
+        "this.applyLibraryPoseFraming(savedFraming)",
+        restoreSceneTransform,
     );
     const commitPose = loadMethod.indexOf(
         "this.commitViewerPoseToCurrentEditor()",
-        restoreCamera,
+        restoreLegacyCamera,
     );
 
+    assert.ok(snapshotTransform >= 0, "scene character transform must be preserved before pose cleanup");
     assert.ok(snapshotCamera >= 0, "cameraParams must be preserved before pose cleanup");
     assert.ok(stripCamera > snapshotCamera, "pose-local camera data is stripped only after it is saved");
     assert.ok(applyPose > stripCamera, "the skeletal pose is applied before restoring its framing");
-    assert.ok(restoreCamera > applyPose, "saved crop and zoom are restored after applying the pose");
-    assert.ok(commitPose > restoreCamera, "the restored framing reaches the active character transform");
+    assert.ok(restoreSceneTransform > applyPose, "v3 character transform is restored without conversion");
+    assert.ok(restoreLegacyCamera > restoreSceneTransform, "legacy flat poses keep their camera conversion fallback");
+    assert.ok(commitPose > restoreLegacyCamera, "the restored framing reaches the active character transform");
+    const snapshotProjection = loadMethod.indexOf("const savedSAMProjection = normalizeSAMProjectionFrame(");
+    const restoreProjection = loadMethod.indexOf(
+        "this.applyLibrarySAMProjection(savedSAMProjection)",
+        restoreLegacyCamera,
+    );
+    assert.ok(snapshotProjection > snapshotCamera, "SAM projection camera is preserved before pose cleanup");
+    assert.ok(restoreProjection > restoreLegacyCamera, "SAM projection camera is restored after character placement");
+});
+
+
+test("library saving persists the active SAM projection camera in both pose representations", () => {
+    const saveMethod = methodSource(
+        poseStudioSource,
+        "async saveToLibrary(name, includePreview = true, metadata = {})",
+        "\n    applyLibraryPoseFraming(cameraParams)",
+    );
+    assert.match(
+        saveMethod,
+        /normalizeSAMProjectionFrame\(this\._samCamStoredProjectionFrame\)/,
+    );
+    assert.match(
+        saveMethod,
+        /selectedPose\.sam_projection = JSON\.parse\(JSON\.stringify\(savedSAMProjection\)\)/,
+    );
+    assert.match(
+        saveMethod,
+        /pose\.sam_projection = JSON\.parse\(JSON\.stringify\(savedSAMProjection\)\)/,
+    );
 });
 
 

--- a/tests/test_pose_characters.mjs
+++ b/tests/test_pose_characters.mjs
@@ -6,13 +6,75 @@ import {
     MAX_POSE_STUDIO_CHARACTERS,
     cameraFramingToCharacterTransform,
     createPoseStudioCharacter,
+    extractActiveCharacterTransformFromSceneAsset,
+    extractActivePoseFromSceneAsset,
     nextCharacterColor,
     nextCharacterSlot,
     normalizeCharacterColor,
     normalizeCharacterTransform,
     normalizePoseStudioCharacters,
+    normalizeSAMProjectionFrame,
     serializePoseStudioCharacter,
 } from "../web/vnccs_pose_characters.mjs";
+
+
+test("one-character one-pose scene wrappers remain individual library poses", () => {
+    const wrapped = {
+        schema_version: 3,
+        prompt: "top-level prompt",
+        cameraParams: { offset_x: 2, offset_y: -1, zoom: 1.4, yaw_deg: 10, pitch_deg: 0 },
+        characters: [{
+            id: "character-1",
+            poses: [{ bones: { head: [5, 10, 15] } }],
+        }],
+    };
+
+    const pose = extractActivePoseFromSceneAsset(wrapped);
+
+    assert.deepEqual(pose, {
+        bones: { head: [5, 10, 15] },
+        cameraParams: wrapped.cameraParams,
+        prompt: "top-level prompt",
+    });
+    assert.notEqual(pose, wrapped.characters[0].poses[0]);
+    assert.notEqual(pose.bones, wrapped.characters[0].poses[0].bones);
+    pose.bones.head[0] = 99;
+    assert.equal(wrapped.characters[0].poses[0].bones.head[0], 5);
+});
+
+
+test("character and pose axes do not implicitly classify a library pose as a set", () => {
+    const wrapped = {
+        active_character_id: "support",
+        activeTab: 1,
+        characters: [
+            {
+                id: "lead",
+                transform: { x: 1, y: 2, z: 3, zoom: 1.1 },
+                poses: [{ marker: "lead-1" }, { marker: "lead-2" }],
+            },
+            {
+                id: "support",
+                transform: { x: -4, y: 5, z: 6, zoom: 1.7 },
+                poses: [{ marker: "support-1" }, { marker: "support-2" }],
+            },
+        ],
+    };
+    const pose = extractActivePoseFromSceneAsset(wrapped);
+    assert.deepEqual(pose, { marker: "support-2" });
+    assert.deepEqual(
+        extractActiveCharacterTransformFromSceneAsset(wrapped),
+        { x: -4, y: 5, z: 6, zoom: 1.7 },
+    );
+
+    const poseSet = {
+        type: "pose_set",
+        characters: [{ poses: [{ marker: 1 }] }],
+        poses: [{ marker: 1 }],
+    };
+    assert.equal(extractActivePoseFromSceneAsset(poseSet), null);
+    assert.equal(extractActiveCharacterTransformFromSceneAsset(poseSet), null);
+});
 
 
 test("legacy singleton state migrates to one main character", () => {
@@ -135,6 +197,27 @@ test("character colors and transforms are normalized and bounded", () => {
     assert.equal(second.slot, 1);
     assert.equal(second.color, DEFAULT_CHARACTER_COLORS[1]);
     assert.deepEqual(second.transform, { x: 1, y: 2, z: 3, zoom: 4 });
+});
+
+
+test("SAM projection cameras survive JSON serialization with finite values only", () => {
+    const source = {
+        fov: 37.5,
+        cameraPosition: { x: -1.25, y: 12.5, z: 42 },
+        ignored: "runtime-only",
+    };
+    assert.deepEqual(normalizeSAMProjectionFrame(source), {
+        fov: 37.5,
+        cameraPosition: { x: -1.25, y: 12.5, z: 42 },
+    });
+    assert.equal(normalizeSAMProjectionFrame({
+        fov: 0,
+        cameraPosition: { x: 0, y: 0, z: 0 },
+    }), null);
+    assert.equal(normalizeSAMProjectionFrame({
+        fov: 30,
+        cameraPosition: { x: 0, y: Number.NaN, z: 0 },
+    }), null);
 });
 
 test("saved camera framing converts zoom around the model camera target", () => {

--- a/tests/test_pose_library_progress.py
+++ b/tests/test_pose_library_progress.py
@@ -1,8 +1,12 @@
+import asyncio
 import importlib.util
+import json
 import sys
+import tempfile
 import types
 import unittest
 from pathlib import Path
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parents[1]
@@ -52,6 +56,488 @@ class PoseLibraryProgressTests(unittest.TestCase):
         POSE_LIBRARY._prune_repository_progress(1.0 + POSE_LIBRARY._REPOSITORY_PROGRESS_TTL_SECONDS + 1)
 
         self.assertNotIn("finished", POSE_LIBRARY._REPOSITORY_PROGRESS)
+
+    def test_generated_manifest_uses_repository_specific_title(self):
+        manifest = POSE_LIBRARY.build_pose_manifest(
+            "Totemistyk/General_Poses_PoseStudio",
+            {"title": "VNCCS Pose Library", "poses": []},
+            [],
+            set(),
+        )
+
+        self.assertEqual(manifest["title"], "Totemistyk/General_Poses_PoseStudio")
+
+    def test_repository_id_accepts_a_hugging_face_tree_url(self):
+        self.assertEqual(
+            POSE_LIBRARY.normalize_repo_id(
+                "https://huggingface.co/Totemistyk/General_Poses_PoseStudio/tree/main"
+            ),
+            "Totemistyk/General_Poses_PoseStudio",
+        )
+        self.assertEqual(
+            POSE_LIBRARY.normalize_repo_id("https://example.com/owner/repository"),
+            "",
+        )
+
+    def test_project_defaults_include_totemistyk_second_and_enabled(self):
+        repositories = POSE_LIBRARY.load_default_repositories()
+
+        self.assertEqual(
+            [repo["repo_id"] for repo in repositories[:2]],
+            [
+                "MIUProject/VNCCS_PoseLibrary_Main",
+                "Totemistyk/General_Poses_PoseStudio",
+            ],
+        )
+        self.assertTrue(repositories[1]["enabled"])
+        self.assertTrue(repositories[1]["builtin"])
+        self.assertEqual(repositories[1]["title"], "General Poses PoseStudio")
+
+    def test_git_clone_uses_one_shot_os_temp_without_directory_promotion(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            checkout = Path(temporary) / "one-shot-clone"
+
+            def clone_into_checkout(command):
+                self.assertEqual(command[-1], str(checkout))
+                (checkout / ".git").mkdir(parents=True)
+                return ""
+
+            with (
+                mock.patch.object(POSE_LIBRARY.shutil, "which", return_value="/usr/bin/git"),
+                mock.patch.object(
+                    POSE_LIBRARY.tempfile,
+                    "mkdtemp",
+                    side_effect=lambda **kwargs: (checkout.mkdir(), str(checkout))[1],
+                ) as make_temp,
+                mock.patch.object(POSE_LIBRARY, "run_pose_repository_git", side_effect=clone_into_checkout),
+                mock.patch.object(POSE_LIBRARY.os, "replace") as promote_directory,
+            ):
+                result = POSE_LIBRARY.update_git_pose_repository_checkout("artist/poses")
+
+            self.assertEqual(result, str(checkout))
+            self.assertEqual(make_temp.call_args.kwargs, {"prefix": "vnccs_pose_repository_"})
+            promote_directory.assert_not_called()
+
+    def test_generated_manifest_preserves_a_custom_title(self):
+        manifest = POSE_LIBRARY.build_pose_manifest(
+            "owner/repository",
+            {"title": "Portrait Pose Collection", "poses": []},
+            [],
+            set(),
+        )
+
+        self.assertEqual(manifest["title"], "Portrait Pose Collection")
+
+    def test_legacy_generic_titles_are_normalized_while_loading_repositories(self):
+        with (
+            mock.patch.object(POSE_LIBRARY, "load_default_repositories", return_value=[{
+                "repo_id": "official/main",
+                "title": "Official Pose Library",
+                "builtin": True,
+            }]),
+            mock.patch.object(POSE_LIBRARY, "load_user_repositories", return_value=[
+                {
+                    "repo_id": "official/main",
+                    "title": "VNCCS Pose Library",
+                    "builtin": False,
+                },
+                {
+                    "repo_id": "artist/poses",
+                    "title": "VNCCS Pose Library",
+                    "builtin": False,
+                },
+            ]),
+        ):
+            repositories = {
+                item["repo_id"]: item
+                for item in POSE_LIBRARY.load_pose_repositories()
+            }
+
+        self.assertEqual(repositories["official/main"]["title"], "Official Pose Library")
+        self.assertEqual(repositories["artist/poses"]["title"], "artist/poses")
+
+    def test_create_publish_is_exclusive_and_uploads_only_to_requested_target(self):
+        calls = {"create": [], "uploads": []}
+
+        class FakeHfApi:
+            def __init__(self, token=None):
+                self.token = token
+
+            def create_repo(self, **kwargs):
+                calls["create"].append(kwargs)
+
+            def list_repo_files(self, **_kwargs):
+                return []
+
+            def upload_file(self, **kwargs):
+                recorded = dict(kwargs)
+                if kwargs.get("path_in_repo", "").endswith(".json"):
+                    recorded["uploaded_json"] = json.loads(
+                        Path(kwargs["path_or_fileobj"]).read_text(encoding="utf-8")
+                    )
+                calls["uploads"].append(recorded)
+
+        fake_hub = types.ModuleType("huggingface_hub")
+        fake_hub.HfApi = FakeHfApi
+        with tempfile.TemporaryDirectory() as temporary:
+            pose_path = Path(temporary) / "pose.json"
+            saved_pose = {
+                "cameraParams": {
+                    "offset_x": 2.5,
+                    "offset_y": -1.25,
+                    "zoom": 1.75,
+                    "yaw_deg": 15,
+                    "pitch_deg": -5,
+                },
+                "sam_projection": {
+                    "fov": 37.5,
+                    "cameraPosition": {"x": -1.25, "y": 12.5, "z": 42},
+                },
+            }
+            pose_path.write_text(json.dumps(saved_pose), encoding="utf-8")
+            local_pose = {
+                "name": "Standing",
+                "category": "General",
+                "tags": [],
+                "asset_type": "pose",
+                "json_path": str(pose_path),
+                "preview_path": "",
+                "preview_type": "",
+                "hub_json_path": "poses/General/Standing.json",
+                "hub_preview_path": "",
+                "json_sha256": POSE_LIBRARY.sha256_file(pose_path),
+                "preview_sha256": "",
+            }
+            with (
+                mock.patch.dict(sys.modules, {"huggingface_hub": fake_hub}),
+                mock.patch.object(POSE_LIBRARY, "collect_local_pose_files", return_value=[local_pose]),
+                mock.patch.object(POSE_LIBRARY, "load_remote_pose_manifest", return_value={}),
+                mock.patch.object(POSE_LIBRARY, "save_vnccs_user_config"),
+            ):
+                result = POSE_LIBRARY.publish_local_repository_to_hf(
+                    "owner/new-library",
+                    token="hf_test",
+                    create=True,
+                    task_id="publish-test",
+                )
+
+        self.assertEqual(result["repo_id"], "owner/new-library")
+        self.assertEqual(calls["create"], [{
+            "repo_id": "owner/new-library",
+            "repo_type": "model",
+            "private": False,
+            "exist_ok": False,
+        }])
+        self.assertTrue(calls["uploads"])
+        self.assertEqual(
+            {call["repo_id"] for call in calls["uploads"]},
+            {"owner/new-library"},
+        )
+        pose_upload = next(
+            call for call in calls["uploads"]
+            if call["path_in_repo"] == "poses/General/Standing.json"
+        )
+        self.assertEqual(
+            pose_upload["uploaded_json"],
+            saved_pose,
+        )
+
+    def test_publish_endpoint_never_falls_back_to_saved_repository(self):
+        class FakeRequest:
+            headers = {}
+            can_read_body = False
+
+            async def json(self):
+                return {"create": True, "hf_token": "hf_test"}
+
+        class FakeResponse:
+            def __init__(self, payload, status=200):
+                self.payload = payload
+                self.status = status
+
+        fake_web = types.SimpleNamespace(
+            json_response=lambda payload, status=200: FakeResponse(payload, status),
+        )
+        with (
+            mock.patch.object(POSE_LIBRARY, "web", fake_web),
+            mock.patch.object(
+                POSE_LIBRARY,
+                "get_vnccs_user_config",
+                return_value={"pose_library_publish_repo_id": "owner/old-library"},
+            ),
+            mock.patch.object(POSE_LIBRARY, "publish_local_repository_to_hf") as publish,
+        ):
+            response = asyncio.run(POSE_LIBRARY.publish_local_pose_repository(FakeRequest()))
+
+        self.assertEqual(response.status, 400)
+        self.assertEqual(response.payload["error"], "Repository id is required")
+        publish.assert_not_called()
+
+    def test_add_repository_downloads_it_before_responding(self):
+        class FakeRequest:
+            headers = {}
+            can_read_body = False
+
+            async def json(self):
+                return {
+                    "repo_id": "artist/new-poses",
+                    "task_id": "add-and-sync",
+                }
+
+        class FakeResponse:
+            def __init__(self, payload, status=200):
+                self.payload = payload
+                self.status = status
+
+        refreshed = {
+            "repo_id": "artist/new-poses",
+            "title": "artist/new-poses",
+            "status": "ok",
+            "pose_count": 12,
+            "animation_count": 0,
+            "downloaded_count": 12,
+        }
+        fake_web = types.SimpleNamespace(
+            json_response=lambda payload, status=200: FakeResponse(payload, status),
+        )
+        saved = []
+        with (
+            mock.patch.object(POSE_LIBRARY, "web", fake_web),
+            mock.patch.object(POSE_LIBRARY, "load_pose_repositories", side_effect=[[], [refreshed]]),
+            mock.patch.object(POSE_LIBRARY, "load_user_repositories", return_value=[]),
+            mock.patch.object(POSE_LIBRARY, "save_user_repositories", side_effect=lambda repos: saved.extend(repos)),
+            mock.patch.object(POSE_LIBRARY, "refresh_pose_repository", return_value=refreshed) as refresh,
+            mock.patch.object(POSE_LIBRARY, "persist_refreshed_repositories") as persist,
+        ):
+            response = asyncio.run(POSE_LIBRARY.add_pose_repository(FakeRequest()))
+
+        self.assertEqual(response.status, 200)
+        self.assertEqual(response.payload["task_id"], "add-and-sync")
+        self.assertEqual(response.payload["refreshed"], refreshed)
+        self.assertEqual(saved[0]["repo_id"], "artist/new-poses")
+        refresh.assert_called_once()
+        self.assertEqual(refresh.call_args.args[0]["repo_id"], "artist/new-poses")
+        self.assertEqual(refresh.call_args.kwargs["task_id"], "add-and-sync")
+        persist.assert_called_once_with([refreshed])
+
+    def test_git_checkout_imports_manifest_assets_without_http_requests(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            library_root = Path(temporary) / "PoseLibrary"
+            checkout = Path(temporary) / "checkout"
+            json_source = checkout / "poses" / "General" / "Standing.json"
+            preview_source = checkout / "previews" / "General" / "Standing.webp"
+            json_source.parent.mkdir(parents=True)
+            preview_source.parent.mkdir(parents=True)
+            json_source.write_bytes(b'{"pose": true}')
+            preview_source.write_bytes(b"RIFF-test-webp")
+            manifest = {
+                "poses": [{
+                    "name": "Standing",
+                    "category": "General",
+                    "json_path": "poses/General/Standing.json",
+                    "preview_path": "previews/General/Standing.webp",
+                    "json_sha256": POSE_LIBRARY.sha256_file(json_source),
+                    "preview_sha256": POSE_LIBRARY.sha256_file(preview_source),
+                }],
+            }
+
+            with (
+                mock.patch.object(POSE_LIBRARY, "get_library_path", return_value=str(library_root)),
+                mock.patch.object(POSE_LIBRARY, "download_hf_file") as http_download,
+            ):
+                result = POSE_LIBRARY.sync_pose_repository_files(
+                    {"repo_id": "artist/poses"},
+                    manifest,
+                    token=None,
+                    source_root=str(checkout),
+                )
+
+            target = library_root / "artist__poses" / "General"
+            self.assertEqual((target / "Standing.json").read_bytes(), json_source.read_bytes())
+            self.assertEqual((target / "Standing.webp").read_bytes(), preview_source.read_bytes())
+            self.assertEqual(result["downloaded_count"], 1)
+            self.assertEqual(result["errors"], [])
+            http_download.assert_not_called()
+
+    def test_git_lfs_pointer_falls_back_before_modifying_the_library(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            library_root = Path(temporary) / "PoseLibrary"
+            checkout = Path(temporary) / "checkout"
+            json_source = checkout / "poses" / "General" / "Standing.json"
+            json_source.parent.mkdir(parents=True)
+            json_source.write_text(
+                "version https://git-lfs.github.com/spec/v1\n"
+                "oid sha256:0123456789abcdef\n"
+                "size 12345\n",
+                encoding="utf-8",
+            )
+            manifest = {
+                "poses": [{
+                    "name": "Standing",
+                    "category": "General",
+                    "json_path": "poses/General/Standing.json",
+                    "json_sha256": POSE_LIBRARY.sha256_file(json_source),
+                }],
+            }
+
+            with mock.patch.object(POSE_LIBRARY, "get_library_path", return_value=str(library_root)):
+                with self.assertRaises(POSE_LIBRARY.GitRepositorySyncUnavailable):
+                    POSE_LIBRARY.sync_pose_repository_files(
+                        {"repo_id": "artist/poses"},
+                        manifest,
+                        token=None,
+                        source_root=str(checkout),
+                    )
+
+            self.assertFalse((library_root / "artist__poses" / "General" / "Standing.json").exists())
+
+    def test_public_repository_refresh_prefers_shallow_git_checkout(self):
+        class FakeHfApi:
+            def repo_info(self, **_kwargs):
+                return types.SimpleNamespace(sha="git-sha", private=False)
+
+        fake_hub = types.ModuleType("huggingface_hub")
+        fake_hub.HfApi = FakeHfApi
+        with tempfile.TemporaryDirectory() as temporary:
+            library_root = Path(temporary) / "PoseLibrary"
+            checkout = Path(temporary) / "checkout"
+            pose_source = checkout / "poses" / "General" / "Standing.json"
+            pose_source.parent.mkdir(parents=True)
+            pose_source.write_bytes(b'{"pose": true}')
+            (checkout / "pose_library.json").write_text(
+                json.dumps({
+                    "title": "VNCCS Pose Library",
+                    "poses": [{
+                        "name": "Standing",
+                        "category": "General",
+                        "json_path": "poses/General/Standing.json",
+                        "json_sha256": POSE_LIBRARY.sha256_file(pose_source),
+                    }],
+                }),
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.dict(sys.modules, {"huggingface_hub": fake_hub}),
+                mock.patch.object(POSE_LIBRARY, "get_library_path", return_value=str(library_root)),
+                mock.patch.object(POSE_LIBRARY, "get_hf_token", return_value=None),
+                mock.patch.object(
+                    POSE_LIBRARY,
+                    "update_git_pose_repository_checkout",
+                    return_value=str(checkout),
+                ) as git_checkout,
+                mock.patch.object(POSE_LIBRARY, "download_hf_file_with_progress") as http_manifest,
+                mock.patch.object(POSE_LIBRARY, "download_hf_file") as http_asset,
+            ):
+                result = POSE_LIBRARY.refresh_pose_repository(
+                    {"repo_id": "artist/poses", "enabled": True},
+                    task_id="git-refresh",
+                )
+
+            self.assertEqual(result["status"], "ok")
+            self.assertEqual(result["transport"], "git")
+            self.assertEqual(result["title"], "artist/poses")
+            self.assertEqual(result["downloaded_count"], 1)
+            git_checkout.assert_called_once_with("artist/poses", task_id="git-refresh")
+            http_manifest.assert_not_called()
+            http_asset.assert_not_called()
+            self.assertFalse(checkout.exists())
+
+    def test_git_failure_automatically_retries_through_http(self):
+        class FakeHfApi:
+            def repo_info(self, **_kwargs):
+                return types.SimpleNamespace(sha="remote-sha", private=False)
+
+        fake_hub = types.ModuleType("huggingface_hub")
+        fake_hub.HfApi = FakeHfApi
+        with tempfile.TemporaryDirectory() as temporary:
+            library_root = Path(temporary) / "PoseLibrary"
+            downloaded_pose = Path(temporary) / "downloaded-pose.json"
+            downloaded_pose.write_bytes(b'{"pose": true}')
+            manifest_download = Path(temporary) / "downloaded-manifest.json"
+            manifest_download.write_text(
+                json.dumps({
+                    "poses": [{
+                        "name": "Standing",
+                        "category": "General",
+                        "json_path": "poses/General/Standing.json",
+                        "json_sha256": POSE_LIBRARY.sha256_file(downloaded_pose),
+                    }],
+                }),
+                encoding="utf-8",
+            )
+
+            with (
+                mock.patch.dict(sys.modules, {"huggingface_hub": fake_hub}),
+                mock.patch.object(POSE_LIBRARY, "get_library_path", return_value=str(library_root)),
+                mock.patch.object(POSE_LIBRARY, "get_hf_token", return_value=None),
+                mock.patch.object(
+                    POSE_LIBRARY,
+                    "update_git_pose_repository_checkout",
+                    side_effect=POSE_LIBRARY.GitRepositorySyncUnavailable("Git is unavailable"),
+                ),
+                mock.patch.object(
+                    POSE_LIBRARY,
+                    "download_hf_file_with_progress",
+                    return_value=str(manifest_download),
+                ) as http_manifest,
+                mock.patch.object(
+                    POSE_LIBRARY,
+                    "download_hf_file",
+                    return_value=str(downloaded_pose),
+                ) as http_asset,
+            ):
+                result = POSE_LIBRARY.refresh_pose_repository(
+                    {"repo_id": "artist/poses", "enabled": True},
+                    task_id="http-fallback",
+                )
+
+            self.assertEqual(result["status"], "ok")
+            self.assertEqual(result["transport"], "http")
+            self.assertEqual(result["git_error"], "Git is unavailable")
+            self.assertEqual(result["downloaded_count"], 1)
+            progress = POSE_LIBRARY.get_repository_progress("http-fallback")
+            self.assertEqual(progress["git_error"], "Git is unavailable")
+            self.assertEqual(progress["transport"], "http")
+            http_manifest.assert_called_once()
+            http_asset.assert_called_once()
+
+    def test_failed_clone_removes_its_one_shot_checkout(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            checkout = Path(temporary) / "failed-clone"
+            checkout.mkdir()
+
+            with (
+                mock.patch.object(POSE_LIBRARY.shutil, "which", return_value="/usr/bin/git"),
+                mock.patch.object(POSE_LIBRARY.tempfile, "mkdtemp", return_value=str(checkout)),
+                mock.patch.object(
+                    POSE_LIBRARY,
+                    "run_pose_repository_git",
+                    side_effect=POSE_LIBRARY.GitRepositorySyncUnavailable("clone timeout"),
+                ),
+            ):
+                with self.assertRaises(POSE_LIBRARY.GitRepositorySyncUnavailable):
+                    POSE_LIBRARY.update_git_pose_repository_checkout("artist/poses")
+
+            self.assertFalse(checkout.exists())
+
+    def test_pose_library_walker_hides_internal_git_checkout(self):
+        with tempfile.TemporaryDirectory() as temporary:
+            library_root = Path(temporary)
+            visible = library_root / "artist__poses" / "General"
+            hidden = library_root / POSE_LIBRARY.POSE_REPOSITORY_LEGACY_GIT_CACHE_DIR / "artist__poses"
+            visible.mkdir(parents=True)
+            hidden.mkdir(parents=True)
+            (visible / "Standing.json").write_text("{}", encoding="utf-8")
+            (hidden / "pose_library.json").write_text("{}", encoding="utf-8")
+
+            walked_files = {
+                str(Path(root, filename).relative_to(library_root))
+                for root, _dirs, files in POSE_LIBRARY.walk_pose_library(str(library_root))
+                for filename in files
+            }
+
+            self.assertEqual(walked_files, {str(Path("artist__poses/General/Standing.json"))})
 
 
 if __name__ == "__main__":

--- a/tests/test_widget_hardening.mjs
+++ b/tests/test_widget_hardening.mjs
@@ -67,6 +67,106 @@ test("Pose Studio library launcher uses the concise product name", () => {
 });
 
 
+test("Pose Library create-new publishing cannot retain or silently reuse the old target", () => {
+    const modalStart = poseStudioSource.indexOf("showPublishLocalRepositoryModal(forceConfigure = false)");
+    const modalEnd = poseStudioSource.indexOf("\n    async runLocalPoseRepositoryPublish", modalStart);
+    const modalMethod = poseStudioSource.slice(modalStart, modalEnd);
+    assert.match(modalMethod, /let existingRepoDraft = current\.publish_repo_id \|\| "";/);
+    assert.match(modalMethod, /let newRepoDraft = "";/);
+    assert.match(
+        modalMethod,
+        /repoEl\.value = modeEl\.value === "create" \? newRepoDraft : existingRepoDraft;/,
+    );
+
+    const publishStart = poseStudioSource.indexOf("async runLocalPoseRepositoryPublish(payload)");
+    const publishEnd = poseStudioSource.indexOf("\n    async addPoseRepository", publishStart);
+    const publishMethod = poseStudioSource.slice(publishStart, publishEnd);
+    assert.match(publishMethod, /const repoId = String\(payload\?\.repo_id \|\| ""\)\.trim\(\);/);
+    assert.match(publishMethod, /this\.setRepositoryProgressState\(progressKey, \{ repoId \}\);/);
+    assert.match(publishMethod, /JSON\.stringify\(\{ \.\.\.payload, repo_id: repoId, task_id: taskId \}\)/);
+    assert.match(publishMethod, /this\._localPoseRepositoryPublishActive/);
+});
+
+
+test("adding a Pose Library repository downloads it and refreshes the library in one action", () => {
+    const normalizeStart = poseStudioSource.indexOf("normalizePoseRepositoryInput(value)");
+    const addStart = poseStudioSource.indexOf("async addPoseRepository()", normalizeStart);
+    const addEnd = poseStudioSource.indexOf("\n    createRepositoryTaskId", addStart);
+    const normalizeMethod = poseStudioSource.slice(normalizeStart, addStart);
+    const addMethod = poseStudioSource.slice(addStart, addEnd);
+    assert.match(normalizeMethod, /\['huggingface\.co', 'www\.huggingface\.co'\]/);
+    assert.match(normalizeMethod, /return `\$\{parts\[0\]\}\/\$\{parts\[1\]\}`;/);
+    assert.match(addMethod, /this\.normalizePoseRepositoryInput\(input\?\.value\)/);
+    assert.match(addMethod, /const taskId = this\.createRepositoryTaskId\("repo-add"\);/);
+    assert.match(addMethod, /JSON\.stringify\(\{ repo_id: repoId, task_id: taskId \}\)/);
+    assert.match(addMethod, /setInterval\(\(\) => this\.pollRepositoryProgress\(taskId, progress\), 350\)/);
+    assert.match(addMethod, /const refreshed = data\.refreshed \|\| \{\};/);
+    assert.match(addMethod, /await this\.refreshLibrary\(true\);/);
+    assert.match(addMethod, /refreshed\.status !== "error"[\s\S]*await this\.toggleLibrarySettings\(false\);/);
+});
+
+
+test("loading a scene-format pose preserves Pose Manager while animations open Studio", () => {
+    const loadStart = poseStudioSource.indexOf("async loadCharacterSceneLibraryAsset(asset, { animation = false } = {})");
+    const loadEnd = poseStudioSource.indexOf("\n    loadAnimationLibraryAsset", loadStart);
+    const loadMethod = poseStudioSource.slice(loadStart, loadEnd);
+    assert.match(
+        loadMethod,
+        /if \(animation\) this\.setInterfaceMode\("studio", \{ sync: false \}\);/,
+    );
+    assert.doesNotMatch(
+        loadMethod,
+        /\n\s*this\.setInterfaceMode\("studio", \{ sync: false \}\);/,
+    );
+
+    const dispatchStart = poseStudioSource.indexOf("async loadFromLibrary(poseOrName)");
+    const dispatchEnd = poseStudioSource.indexOf("\n    showSettingsModal()", dispatchStart);
+    const dispatchMethod = poseStudioSource.slice(dispatchStart, dispatchEnd);
+    assert.match(
+        dispatchMethod,
+        /const activeScenePose = assetType === "pose"[\s\S]*extractActivePoseFromSceneAsset\(data\.pose\)/,
+    );
+    assert.match(
+        dispatchMethod,
+        /assetType === "animation"[\s\S]*data\.pose\.characters\.length/,
+    );
+    assert.match(
+        dispatchMethod,
+        /JSON\.stringify\(activeScenePose \|\| data\.pose\)/,
+    );
+    assert.match(
+        dispatchMethod,
+        /data\.pose\?\.type === "pose_set"[\s\S]*this\.loadPoseSetAsset\(data\.pose\)/,
+    );
+});
+
+
+test("only explicit pose-set assets replace the Pose Manager pose list", () => {
+    const setStart = poseStudioSource.indexOf("loadPoseSetAsset(asset)");
+    const setEnd = poseStudioSource.indexOf("\n    loadAnimationLibraryAsset", setStart);
+    const setMethod = poseStudioSource.slice(setStart, setEnd);
+    assert.match(setMethod, /this\.poses = sourcePoses\.map/);
+    assert.match(setMethod, /this\.activeTab = 0;/);
+
+    const dispatchStart = poseStudioSource.indexOf("async loadFromLibrary(poseOrName)");
+    const dispatchEnd = poseStudioSource.indexOf("\n    showSettingsModal()", dispatchStart);
+    const dispatchMethod = poseStudioSource.slice(dispatchStart, dispatchEnd);
+    assert.match(dispatchMethod, /const isPoseSet = data\.pose\?\.type === "pose_set"/);
+    assert.doesNotMatch(dispatchMethod, /const isPoseSet = [^;]*characters/);
+});
+
+
+test("saving a current library pose does not serialize the whole Pose Manager set", () => {
+    const saveStart = poseStudioSource.indexOf("async saveToLibrary(name, includePreview = true, metadata = {})");
+    const saveEnd = poseStudioSource.indexOf("\n    applyLibraryPoseFraming", saveStart);
+    const saveMethod = poseStudioSource.slice(saveStart, saveEnd);
+    assert.match(saveMethod, /type: animationMode \? "pose_animation" : "scene_pose"/);
+    assert.match(saveMethod, /const selectedPose = serialized\.poses\[this\.activeTab\]/);
+    assert.match(saveMethod, /serialized\.poses = \[selectedPose\];/);
+    assert.match(saveMethod, /activeTab: animationMode \? this\.activeTab : 0/);
+});
+
+
 test("Pose Manager regenerates missing previews after worker model load and mode entry", () => {
     const modeStart = poseStudioSource.indexOf("setInterfaceMode(mode, { sync = true } = {})");
     const modeEnd = poseStudioSource.indexOf("\n    applyInterfaceMode()", modeStart);
@@ -141,10 +241,10 @@ test("Pose Manager independently fits and centers every deformed pose preview", 
     const refreshStart = poseStudioSource.indexOf("refreshAllManagerPreviews(generation");
     const refreshEnd = poseStudioSource.indexOf("\n    updateExistingPoseManagerDetailCards", refreshStart);
     const refreshMethod = poseStudioSource.slice(refreshStart, refreshEnd);
-    assert.match(refreshMethod, /viewer\.setPose\(pose, true\);[\s\S]*computeModelFitFraming\?\.\(/);
+    assert.match(refreshMethod, /viewer\.setPose\(pose, true\);[\s\S]*computePoseManagerCaptureFraming\(w, h, poseCamera\)/);
     assert.match(
         refreshMethod,
-        /viewer\.capture\([\s\S]*framing\?\.zoom \?\? 1,[\s\S]*framing\?\.offsetX \?\? 0,[\s\S]*framing\?\.offsetY \?\? 0/,
+        /if \(!framing\) continue;[\s\S]*viewer\.capture\([\s\S]*framing\.zoom,[\s\S]*framing\.offsetX,[\s\S]*framing\.offsetY/,
     );
     assert.match(
         refreshMethod,
@@ -154,6 +254,25 @@ test("Pose Manager independently fits and centers every deformed pose preview", 
 
     assert.match(poseStudioCoreSource, /computeModelFitFraming\(/);
     assert.match(poseStudioCoreSource, /const determinant = j00 \* j11 - j01 \* j10;/);
+});
+
+test("Pose Manager RUN uploads the visible cards without rendering again", () => {
+    const syncStart = poseStudioSource.indexOf("syncToNode(fullCapture = false, options = {})");
+    const syncEnd = poseStudioSource.indexOf("\n    loadFromNode()", syncStart);
+    const syncMethod = poseStudioSource.slice(syncStart, syncEnd);
+    assert.match(syncMethod, /const reusePoseManagerCaptures = \(/);
+    assert.match(syncMethod, /options\.executionCapture === true[\s\S]*&& poseManagerInterface/);
+    assert.match(syncMethod, /\|\| reusePoseManagerCaptures/);
+    assert.match(syncMethod, /this\._executionCaptureSnapshot = this\.poseCaptures\.slice\(\)/);
+    assert.match(syncMethod, /Pose Manager previews are not ready/);
+    assert.doesNotMatch(syncMethod, /computePoseManagerCaptureFraming/);
+
+    const uploadStart = poseStudioSource.indexOf("const uploadPoseStudioSync = async");
+    const uploadEnd = poseStudioSource.indexOf("\n        const reportPoseStudioSyncFailure", uploadStart);
+    const uploadMethod = poseStudioSource.slice(uploadStart, uploadEnd);
+    assert.match(uploadMethod, /const capturedImages = node\.studioWidget\._executionCaptureSnapshot/);
+    assert.match(uploadMethod, /captured_images: capturedImages/);
+    assert.match(uploadMethod, /lighting_prompts: capturedLightingPrompts/);
 });
 
 test("Reset clears library framing together with the pose", () => {
@@ -171,6 +290,25 @@ test("Reset clears library framing together with the pose", () => {
         /syncToNode\(false, \{ skipCapture: true, skipCaptureUpload: true \}\);/,
     );
     assert.match(resetMethod, /this\.poseCaptures\[this\.activeTab\] = null;/);
+    assert.match(resetMethod, /this\.resetMeshProportions\(\);/);
+
+    const proportionsStart = poseStudioSource.indexOf("\n    resetMeshProportions() {");
+    const proportionsEnd = poseStudioSource.indexOf("\n    resetCurrentAnimation()", proportionsStart);
+    const proportionsMethod = poseStudioSource.slice(proportionsStart, proportionsEnd);
+    assert.match(
+        proportionsMethod,
+        /Object\.assign\(this\.meshParams, DEFAULT_POSE_STUDIO_MESH_PROPORTIONS\);/,
+    );
+    assert.match(
+        proportionsMethod,
+        /LEGACY_POSE_STUDIO_MESH_PROPORTION_KEYS[\s\S]*delete this\.meshParams\[key\]/,
+    );
+    assert.match(proportionsMethod, /viewer\.updateHeadScale\?\./);
+    assert.match(proportionsMethod, /viewer\.updateArmScale\?\./);
+    assert.match(proportionsMethod, /viewer\.updateHandScale\?\./);
+    assert.match(proportionsMethod, /viewer\.updateFootScale\?\./);
+    assert.match(proportionsMethod, /viewer\.updateBoneLengthScale\?\./);
+    assert.doesNotMatch(proportionsMethod, /\b(age|gender|weight|muscle|height|breast_size|penis_len)\b/);
 
     const clearStart = poseAnimationSource.indexOf("export function createClearedAnimationState");
     const clearEnd = poseAnimationSource.indexOf("\nexport function serializeAnimationStateSnapshot", clearStart);
@@ -395,4 +533,26 @@ test("full capture updates every character for the current frame or pose before 
         sceneUpdate >= 0 && compositeCapture > sceneUpdate,
         "the complete character scene must be updated before its composite capture",
     );
+});
+
+
+test("repository Git fallback keeps clone diagnostics visible", () => {
+    const renderStart = poseStudioSource.indexOf("renderPoseRepositorySettings() {");
+    const renderEnd = poseStudioSource.indexOf("\n    renderLocalPoseRepositorySettings()", renderStart);
+    const renderMethod = poseStudioSource.slice(renderStart, renderEnd);
+    assert.match(renderMethod, /repo\.git_error/);
+    assert.match(renderMethod, /Git clone failed — HTTP fallback was used/);
+    assert.match(renderMethod, /vnccs-ps-library-repo-diagnostic/);
+
+    const progressStart = poseStudioSource.indexOf("createInlineRepositoryProgress(key");
+    const progressEnd = poseStudioSource.indexOf("\n    async pollRepositoryProgress", progressStart);
+    const progressMethod = poseStudioSource.slice(progressStart, progressEnd);
+    assert.match(progressMethod, /hasOwnProperty\.call\(status, "git_error"\)/);
+    assert.match(progressMethod, /patch\.git_error = status\.git_error/);
+
+    const addStart = poseStudioSource.indexOf("async addPoseRepository() {");
+    const addEnd = poseStudioSource.indexOf("\n    createRepositoryTaskId", addStart);
+    const addMethod = poseStudioSource.slice(addStart, addEnd);
+    assert.match(addMethod, /!refreshed\.git_error/);
+    assert.match(addMethod, /Open Git diagnostics below/);
 });

--- a/web/vnccs_pose_characters.mjs
+++ b/web/vnccs_pose_characters.mjs
@@ -49,6 +49,22 @@ export function normalizeCharacterTransform(source = {}) {
     };
 }
 
+export function normalizeSAMProjectionFrame(source) {
+    if (!source || typeof source !== "object" || Array.isArray(source)) return null;
+    const fov = Number(source.fov);
+    const cameraPosition = source.cameraPosition;
+    const x = Number(cameraPosition?.x);
+    const y = Number(cameraPosition?.y);
+    const z = Number(cameraPosition?.z);
+    if (
+        !Number.isFinite(fov)
+        || fov <= 0
+        || fov >= 179
+        || ![x, y, z].every(Number.isFinite)
+    ) return null;
+    return { fov, cameraPosition: { x, y, z } };
+}
+
 export function cameraFramingToCharacterTransform(cameraParams, pivot) {
     const values = [
         cameraParams?.zoom,
@@ -143,6 +159,61 @@ export function createPoseStudioCharacter({
         poses: sourcePoses,
         animation: cloneJSON(animation, null),
     };
+}
+
+/**
+ * Newer Pose Studio versions wrap saved poses in the v3 character-scene
+ * schema. `characters[]` and each character's runtime `poses[]` do not make the
+ * library item a pose set; only the explicit `type: "pose_set"` format does.
+ * Resolve the pose selected when the item was saved without mutating the
+ * cached library response.
+ */
+function activeCharacterFromSceneAsset(data = {}) {
+    if (!data || typeof data !== "object" || !Array.isArray(data.characters)) return null;
+    if (data.type === "pose_set" || !data.characters.length) return null;
+    const requestedCharacterId = String(data.active_character_id || data.activeCharacterId || "");
+    return data.characters.find(character => (
+        String(character?.id || "") === requestedCharacterId
+    )) || data.characters[0];
+}
+
+export function extractActiveCharacterTransformFromSceneAsset(data = {}) {
+    const sourceCharacter = activeCharacterFromSceneAsset(data);
+    if (
+        !sourceCharacter?.transform
+        || typeof sourceCharacter.transform !== "object"
+        || Array.isArray(sourceCharacter.transform)
+    ) return null;
+    return normalizeCharacterTransform(sourceCharacter.transform);
+}
+
+export function extractActivePoseFromSceneAsset(data = {}) {
+    const sourceCharacter = activeCharacterFromSceneAsset(data);
+    if (!sourceCharacter) return null;
+    const sourcePoses = sourceCharacter?.poses;
+    if (!Array.isArray(sourcePoses) || !sourcePoses.length) return null;
+    const requestedPoseIndex = Math.max(0, Math.floor(finite(data.activeTab, 0)));
+    const sourcePose = sourcePoses[requestedPoseIndex] || sourcePoses[0];
+    if (!sourcePose || typeof sourcePose !== "object" || Array.isArray(sourcePose)) return null;
+
+    const pose = cloneJSON(sourcePose, null);
+    if (!pose) return null;
+    // Early v3 exports also mirrored the active pose at the top level. Keep
+    // those values as compatibility fallbacks for partially wrapped assets.
+    for (const key of [
+        "bones",
+        "hipBonePosition",
+        "ikEffectorPositions",
+        "poleTargetPositions",
+        "modelRotation",
+        "cameraParams",
+        "prompt",
+    ]) {
+        if (pose[key] === undefined && data[key] !== undefined) {
+            pose[key] = cloneJSON(data[key], data[key]);
+        }
+    }
+    return pose;
 }
 
 /**

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -19,14 +19,17 @@ import {
     MAX_POSE_STUDIO_CHARACTERS,
     cameraFramingToCharacterTransform,
     createPoseStudioCharacter,
+    extractActiveCharacterTransformFromSceneAsset,
+    extractActivePoseFromSceneAsset,
     nextCharacterColor,
     nextCharacterId,
     nextCharacterSlot,
     normalizeCharacterColor,
     normalizeCharacterTransform,
     normalizePoseStudioCharacters,
+    normalizeSAMProjectionFrame,
     serializePoseStudioCharacter,
-} from "./vnccs_pose_characters.mjs?v=20260725.1";
+} from "./vnccs_pose_characters.mjs?v=20260802.3";
 import {
     MAX_VIDEO_POSE_SAMPLES,
     canvasToBlob,
@@ -79,6 +82,34 @@ let VNCCS_SHARED_MORPH_WORKER_WARMED = false;
 let VNCCS_SHARED_MORPH_CLIENT_ID = 1;
 const VNCCS_SHARED_MORPH_CLIENTS = new Map();
 let VNCCS_MODAL_SEQUENCE = 1;
+
+const DEFAULT_POSE_STUDIO_MESH_PROPORTIONS = Object.freeze({
+    head_size: 1.0,
+    arm_size: 1.0,
+    hand_size: 1.0,
+    foot_size: 1.0,
+    shoulder_l_length: 0.5,
+    shoulder_r_length: 0.5,
+    hip_l_length: 0.5,
+    hip_r_length: 0.5,
+    upper_arm_l_length: 0.5,
+    upper_arm_r_length: 0.5,
+    forearm_l_length: 0.5,
+    forearm_r_length: 0.5,
+    thigh_l_length: 0.5,
+    thigh_r_length: 0.5,
+    shin_l_length: 0.5,
+    shin_r_length: 0.5,
+    spine_length: 0.5,
+});
+const LEGACY_POSE_STUDIO_MESH_PROPORTION_KEYS = Object.freeze([
+    "arm_length",
+    "upper_arm_length",
+    "forearm_length",
+    "leg_length",
+    "thigh_length",
+    "shin_length",
+]);
 
 function getVNCCSSharedMorphWorker() {
     if (VNCCS_SHARED_MORPH_WORKER_FAILED || typeof Worker === "undefined") return null;
@@ -3280,6 +3311,35 @@ const STYLES = `
     white-space: nowrap;
 }
 
+.vnccs-ps-library-repo-diagnostic,
+.vnccs-ps-library-repo-progress-diagnostic {
+    margin-top: 12px;
+    color: #ffd27d;
+    font-size: 17px;
+    line-height: 1.4;
+}
+
+.vnccs-ps-library-repo-diagnostic summary,
+.vnccs-ps-library-repo-progress-diagnostic summary {
+    cursor: pointer;
+    font-weight: 700;
+}
+
+.vnccs-ps-library-repo-diagnostic pre,
+.vnccs-ps-library-repo-progress-diagnostic pre {
+    max-height: 180px;
+    margin: 10px 0 0;
+    padding: 12px;
+    overflow: auto;
+    border: 1px solid rgba(255, 210, 125, 0.3);
+    border-radius: 6px;
+    background: rgba(0, 0, 0, 0.28);
+    color: var(--ps-text-muted);
+    font: 14px/1.45 ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+}
+
 .vnccs-ps-library-repo-actions {
     display: flex;
     gap: 12px;
@@ -4034,23 +4094,7 @@ class PoseStudioWidget {
             // Male-specific
             penis_len: 0.5, penis_circ: 0.5, penis_test: 0.5,
             // Visual modifiers (client-side bone scaling)
-            head_size: 1.0,
-            arm_size: 1.0,
-            hand_size: 1.0,
-            foot_size: 1.0,
-            shoulder_l_length: 0.5,
-            shoulder_r_length: 0.5,
-            hip_l_length: 0.5,
-            hip_r_length: 0.5,
-            upper_arm_l_length: 0.5,
-            upper_arm_r_length: 0.5,
-            forearm_l_length: 0.5,
-            forearm_r_length: 0.5,
-            thigh_l_length: 0.5,
-            thigh_r_length: 0.5,
-            shin_l_length: 0.5,
-            shin_r_length: 0.5,
-            spine_length: 0.5
+            ...DEFAULT_POSE_STUDIO_MESH_PROPORTIONS,
         };
 
         // Export settings
@@ -4200,6 +4244,7 @@ class PoseStudioWidget {
         this._libraryRenderFrame = null;
         this._autoRepoRefreshTimer = null;
         this.repositoryProgressStates = {};
+        this._localPoseRepositoryPublishActive = false;
         this._skydomePromptKey = "";
         this._nodeWidgetCache = null;
         this._lastCaptureUploadSnapshot = null;
@@ -4925,7 +4970,7 @@ class PoseStudioWidget {
         const resetBtn = document.createElement("button");
         resetBtn.className = "vnccs-ps-btn";
         resetBtn.innerHTML = '<span class="vnccs-ps-btn-icon">↺</span> Reset';
-        resetBtn.title = "Reset pose; in Animation mode clear the entire animation and all keyframes";
+        resetBtn.title = "Reset pose and Mesh Proportions; in Animation mode clear the entire animation and all keyframes";
         resetBtn.addEventListener("click", () => this.resetCurrentPose());
 
         const snapBtn = document.createElement("button");
@@ -5890,6 +5935,7 @@ class PoseStudioWidget {
         if (!pose || typeof pose !== "object") return pose;
         delete pose.camera;
         delete pose.cameraParams;
+        delete pose.sam_projection;
         return pose;
     }
 
@@ -7053,6 +7099,17 @@ class PoseStudioWidget {
         });
     }
 
+    computePoseManagerCaptureFraming(width, height, poseCamera) {
+        if (this.interfaceMode !== "manager" && this.interfaceMode !== "managerDetail") return null;
+        return this.viewer?.computeModelFitFraming?.(
+            width,
+            height,
+            poseCamera?.yaw_deg ?? 0,
+            poseCamera?.pitch_deg ?? 0,
+            0.08,
+        ) || null;
+    }
+
     refreshAllManagerPreviews(generation = this._managerPreviewRefreshGeneration) {
         if (this.interfaceMode !== "manager" && this.interfaceMode !== "managerDetail") return;
         if (!this.viewer?.isInitialized?.()) return;
@@ -7110,20 +7167,18 @@ class PoseStudioWidget {
                     this.viewer.updateLights(this.lightParams);
                 }
 
-                const framing = this.viewer.computeModelFitFraming?.(
-                    w,
-                    h,
-                    poseCamera.yaw_deg,
-                    poseCamera.pitch_deg,
-                    0.08,
-                );
+                const framing = this.computePoseManagerCaptureFraming(w, h, poseCamera);
+                // Do not replace a visible manager card with a neutral camera
+                // when fitting is temporarily unavailable. The last valid
+                // card (or its placeholder) remains authoritative for RUN.
+                if (!framing) continue;
                 const nextCapture = this.viewer.capture(
                     w,
                     h,
-                    framing?.zoom ?? 1,
+                    framing.zoom,
                     bg,
-                    framing?.offsetX ?? 0,
-                    framing?.offsetY ?? 0,
+                    framing.offsetX,
+                    framing.offsetY,
                     poseCamera.yaw_deg,
                     poseCamera.pitch_deg,
                 );
@@ -8832,6 +8887,7 @@ class PoseStudioWidget {
     }
 
     resetCurrentPose() {
+        this.resetMeshProportions();
         if (this.isAnimationMode()) {
             this.resetCurrentAnimation();
             return;
@@ -8856,6 +8912,44 @@ class PoseStudioWidget {
             this.lightingPrompts[this.activeTab] = "";
         }
         this.syncToNode(false, { skipCapture: true, skipCaptureUpload: true });
+    }
+
+    resetMeshProportions() {
+        for (const key of LEGACY_POSE_STUDIO_MESH_PROPORTION_KEYS) {
+            delete this.meshParams[key];
+        }
+        Object.assign(this.meshParams, DEFAULT_POSE_STUDIO_MESH_PROPORTIONS);
+        const active = this.getActiveCharacter();
+        if (active) active.mesh = this.meshParams;
+
+        for (const [key, value] of Object.entries(DEFAULT_POSE_STUDIO_MESH_PROPORTIONS)) {
+            const slider = this.sliders?.[key];
+            if (slider) {
+                slider.slider.value = value;
+                slider.label.innerText = this.formatManagerValue(key, value);
+            }
+            const widget = this.getNodeWidget(key);
+            if (widget) widget.value = value;
+        }
+        this.refreshPoseManagerControls();
+
+        if (this.viewer) {
+            this.applyMeshProportionsToViewer(this.meshParams);
+            this.viewer.updateHeadScale?.(DEFAULT_POSE_STUDIO_MESH_PROPORTIONS.head_size);
+            this.viewer.updateArmScale?.(DEFAULT_POSE_STUDIO_MESH_PROPORTIONS.arm_size);
+            this.viewer.updateHandScale?.(DEFAULT_POSE_STUDIO_MESH_PROPORTIONS.hand_size);
+            this.viewer.updateFootScale?.(DEFAULT_POSE_STUDIO_MESH_PROPORTIONS.foot_size);
+            for (const [key, value] of Object.entries(DEFAULT_POSE_STUDIO_MESH_PROPORTIONS)) {
+                if (key.endsWith("_length")) {
+                    this.viewer.updateBoneLengthScale?.(key.replace("_length", ""), value);
+                }
+            }
+        }
+
+        // Proportions affect every pose preview for the active character.
+        this.poseCaptures = [];
+        this.lightingPrompts = [];
+        this.scheduleAllManagerPreviewRefresh();
     }
 
     resetCurrentAnimation() {
@@ -10247,42 +10341,7 @@ class PoseStudioWidget {
                         }
                     }
                 } else if (data.type === "pose_set" || Array.isArray(data.poses)) {
-                    // Import Set
-                    const newPoses = data.poses || (Array.isArray(data) ? data : null);
-                    if (newPoses && Array.isArray(newPoses)) {
-                        this.setEditorMode("image", { sync: false });
-                        this.clearSAMCameraMode();
-                        const activeCharacter = this.getActiveCharacter();
-                        this.poses = newPoses.map(sourcePose => {
-                            const pose = JSON.parse(JSON.stringify(sourcePose || {}));
-                            const savedCamera = pose.cameraParams;
-                            this.stripSceneCameraFromPose(pose);
-                            pose.cameraParams = resolveCaptureCameraParams(
-                                savedCamera,
-                                this.currentCameraParams(),
-                            );
-                            return pose;
-                        });
-                        if (activeCharacter) activeCharacter.poses = this.poses;
-                        for (const character of this.characters) {
-                            if (character === activeCharacter) continue;
-                            if (!Array.isArray(character.poses)) character.poses = [];
-                            while (character.poses.length < this.poses.length) character.poses.push({});
-                            while (character.poses.length > this.poses.length) character.poses.pop();
-                        }
-                        this.activeTab = 0;
-                        this.ensurePoseCameraParams();
-                        this.restoreActivePoseCameraParams({ updateViewer: false });
-                        this.updateTabs();
-                        // Load first pose
-                        if (this.viewer && this.viewer.isInitialized()) {
-                            this.viewer.setPose(this.poses[0], true);
-                            this.updateCharacterScene({ poseIndex: 0 });
-                            this.updateRotationSliders();
-                        }
-                        this.updateCaptureCameraPreview();
-                    }
-                    this.syncToNode(true);
+                    this.loadPoseSetAsset(data);
                 } else if (data.type === "single_pose" || data.bones) {
                     // Import Single to current tab
                     this.clearSAMCameraMode();
@@ -10616,7 +10675,7 @@ class PoseStudioWidget {
             <div class="vnccs-ps-library-local-repo"></div>
             <div class="vnccs-ps-library-repo-notice"></div>
             <div class="vnccs-ps-library-repo-add">
-                <input class="vnccs-ps-input vnccs-ps-library-repo-input" type="text" placeholder="owner/repository">
+                <input class="vnccs-ps-input vnccs-ps-library-repo-input" type="text" placeholder="owner/repository or Hugging Face URL">
                 <button class="vnccs-ps-btn primary vnccs-ps-library-repo-add-btn">Add Repository</button>
             </div>
             <div class="vnccs-ps-library-repo-list"></div>
@@ -10644,11 +10703,19 @@ class PoseStudioWidget {
             const syncMeta = repo.downloaded_count !== undefined
                 ? ` · ${Number(repo.downloaded_count || 0)} downloaded · ${Number(repo.skipped_count || 0)} unchanged · ${Number(repo.removed_count || 0)} removed`
                 : '';
+            const transportMeta = repo.transport ? ` · via ${repo.transport}` : '';
+            const gitDiagnostic = repo.git_error
+                ? `<details class="vnccs-ps-library-repo-diagnostic">
+                    <summary>Git clone failed — HTTP fallback was used</summary>
+                    <pre>${this.escapeHtml(repo.git_error)}</pre>
+                </details>`
+                : '';
             card.innerHTML = `
                 <div>
                     <div class="vnccs-ps-library-repo-title">${this.escapeHtml(repo.title || repo.repo_id)}</div>
                     <div class="vnccs-ps-library-repo-id">${this.escapeHtml(repo.repo_id)}</div>
-                    <div class="vnccs-ps-library-repo-meta">${Number(repo.pose_count || 0)} poses · ${Number(repo.animation_count || 0)} animations · ${repo.enabled ? 'enabled' : 'disabled'} · ${this.escapeHtml(status)} · checked ${this.escapeHtml(checked)}${this.escapeHtml(syncMeta)}</div>
+                    <div class="vnccs-ps-library-repo-meta">${Number(repo.pose_count || 0)} poses · ${Number(repo.animation_count || 0)} animations · ${repo.enabled ? 'enabled' : 'disabled'} · ${this.escapeHtml(status)} · checked ${this.escapeHtml(checked)}${this.escapeHtml(syncMeta)}${this.escapeHtml(transportMeta)}</div>
+                    ${gitDiagnostic}
                 </div>
                 <div class="vnccs-ps-library-repo-actions">
                     <button class="vnccs-ps-library-repo-action toggle">${repo.enabled ? 'Disable' : 'Enable'}</button>
@@ -10669,7 +10736,11 @@ class PoseStudioWidget {
         const holder = this.librarySettingsEl?.querySelector('.vnccs-ps-library-local-repo');
         if (!holder) return;
         const repo = this.localPoseRepository || {};
-        const publishRepo = repo.publish_repo_id || "Not linked";
+        const publishState = this.repositoryProgressStates["local:publish"];
+        const activePublishRepo = this._localPoseRepositoryPublishActive
+            ? (publishState?.repoId || "")
+            : "";
+        const publishRepo = activePublishRepo || repo.publish_repo_id || "Not linked";
         const lastPublish = repo.last_publish ? new Date(repo.last_publish * 1000).toLocaleString() : "never";
         const lastResult = repo.last_publish_result
             ? `${Number(repo.last_publish_result.uploaded_count || 0)} uploaded · ${Number(repo.last_publish_result.deleted_count || 0)} deleted · ${Number(repo.last_publish_result.skipped_count || 0)} unchanged`
@@ -10682,8 +10753,8 @@ class PoseStudioWidget {
                     <div class="vnccs-ps-library-repo-meta">${Number(repo.pose_count || 0)} poses · ${Number(repo.animation_count || 0)} animations · last publish ${this.escapeHtml(lastPublish)} · ${this.escapeHtml(lastResult)}</div>
                 </div>
                 <div class="vnccs-ps-library-repo-actions">
-                    <button class="vnccs-ps-library-repo-action primary publish">Publish</button>
-                    ${repo.publish_repo_id ? '<button class="vnccs-ps-library-repo-action relink">Change target</button>' : ''}
+                    <button class="vnccs-ps-library-repo-action primary publish" ${this._localPoseRepositoryPublishActive ? "disabled" : ""}>Publish</button>
+                    ${repo.publish_repo_id ? `<button class="vnccs-ps-library-repo-action relink" ${this._localPoseRepositoryPublishActive ? "disabled" : ""}>Change target</button>` : ''}
                 </div>
                 ${this.repositoryProgressMarkup()}
             </div>
@@ -10758,11 +10829,20 @@ class PoseStudioWidget {
         `;
 
         const modeEl = modal.querySelector('.vnccs-ps-publish-mode');
+        const repoEl = modal.querySelector('.vnccs-ps-publish-repo');
         const privateRow = modal.querySelector('.vnccs-ps-publish-private-row');
+        let previousMode = current.publish_repo_id ? "existing" : "create";
+        let existingRepoDraft = current.publish_repo_id || "";
+        let newRepoDraft = "";
         const syncMode = () => {
+            if (previousMode === "existing") existingRepoDraft = repoEl.value.trim();
+            else newRepoDraft = repoEl.value.trim();
+            repoEl.value = modeEl.value === "create" ? newRepoDraft : existingRepoDraft;
+            repoEl.placeholder = modeEl.value === "create" ? "owner/new-repository" : "owner/repository";
             privateRow.style.display = modeEl.value === "create" ? "" : "none";
+            previousMode = modeEl.value;
         };
-        modeEl.value = current.publish_repo_id ? "existing" : "create";
+        modeEl.value = previousMode;
         modeEl.onchange = syncMode;
         syncMode();
 
@@ -10792,16 +10872,29 @@ class PoseStudioWidget {
     }
 
     async runLocalPoseRepositoryPublish(payload) {
+        const repoId = String(payload?.repo_id || "").trim();
+        if (!repoId) {
+            this.showRepositoryNotice("Repository id is required.", true);
+            return;
+        }
+        if (this._localPoseRepositoryPublishActive) {
+            this.showRepositoryNotice("A local Pose Library publish is already running.", true);
+            return;
+        }
+
+        this._localPoseRepositoryPublishActive = true;
         const progressKey = "local:publish";
         const taskId = this.createRepositoryTaskId("repo-publish");
-        const progress = this.createInlineRepositoryProgress(progressKey, "Publishing local library to Hugging Face...");
+        const progress = this.createInlineRepositoryProgress(progressKey, `Publishing local library to ${repoId}...`);
+        this.setRepositoryProgressState(progressKey, { repoId });
+        this.renderPoseRepositorySettings();
         let pollTimer = null;
         try {
             pollTimer = setInterval(() => this.pollRepositoryProgress(taskId, progress), 350);
             const res = await fetch('/vnccs/pose_library/repositories/local/publish', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ ...payload, task_id: taskId }),
+                body: JSON.stringify({ ...payload, repo_id: repoId, task_id: taskId }),
             });
             await this.pollRepositoryProgress(taskId, progress);
             const data = await res.json().catch(() => ({}));
@@ -10823,27 +10916,92 @@ class PoseStudioWidget {
             this.renderPoseRepositorySettings();
         } finally {
             if (pollTimer) clearInterval(pollTimer);
+            this._localPoseRepositoryPublishActive = false;
+            this.renderPoseRepositorySettings();
             progress.close();
+        }
+    }
+
+    normalizePoseRepositoryInput(value) {
+        const raw = String(value || "").trim();
+        if (!/^https?:\/\//i.test(raw)) return raw.replace(/^\/+|\/+$/g, "");
+        try {
+            const url = new URL(raw);
+            if (!['huggingface.co', 'www.huggingface.co'].includes(url.hostname.toLowerCase())) return "";
+            const parts = url.pathname.split('/').filter(Boolean).map(decodeURIComponent);
+            if (parts.length < 2 || parts[0] === 'datasets' || parts[0] === 'spaces') return "";
+            return `${parts[0]}/${parts[1]}`;
+        } catch (_err) {
+            return "";
         }
     }
 
     async addPoseRepository() {
         const input = this.librarySettingsEl?.querySelector('.vnccs-ps-library-repo-input');
-        const repoId = input?.value.trim();
+        const repoId = this.normalizePoseRepositoryInput(input?.value);
         if (!repoId) return;
+        const previousRepositories = [...(this.poseRepositories || [])];
+        const taskId = this.createRepositoryTaskId("repo-add");
+        const progressKey = `repo:${repoId}`;
+        this.poseRepositories = [
+            ...previousRepositories,
+            {
+                repo_id: repoId,
+                title: repoId,
+                enabled: true,
+                status: "syncing",
+                pose_count: 0,
+                animation_count: 0,
+            },
+        ];
+        this.renderPoseRepositorySettings();
+        const progress = this.createInlineRepositoryProgress(progressKey, `Adding and downloading ${repoId}...`);
+        let pollTimer = null;
         try {
+            pollTimer = setInterval(() => this.pollRepositoryProgress(taskId, progress), 350);
             const res = await fetch('/vnccs/pose_library/repositories/add', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ repo_id: repoId }),
+                body: JSON.stringify({ repo_id: repoId, task_id: taskId }),
             });
-            const data = await res.json();
+            await this.pollRepositoryProgress(taskId, progress);
+            const data = await res.json().catch(() => ({}));
             if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
-            input.value = '';
+            if (input) input.value = '';
             this.poseRepositories = data.repositories || [];
             this.renderPoseRepositorySettings();
+            const refreshed = data.refreshed || {};
+            if (refreshed.status === "error") {
+                const message = refreshed.last_error || `Failed to download ${repoId}`;
+                progress.update({ status: "error", progress: 100, message });
+                this.showRepositoryNotice(`Repository was added, but its data could not be downloaded: ${message}`, true);
+            } else {
+                progress.update({
+                    status: "success",
+                    progress: 100,
+                    message: refreshed.git_error
+                        ? `${repoId} downloaded through HTTP after Git clone failed.`
+                        : `${repoId} added: ${Number(refreshed.downloaded_count || 0)} downloaded, ${Number(refreshed.skipped_count || 0)} unchanged.`,
+                    git_error: refreshed.git_error || "",
+                    transport: refreshed.transport || "",
+                });
+                if (refreshed.git_error) {
+                    this.showRepositoryNotice("Git clone failed; the repository was downloaded through the slower HTTP fallback. Open Git diagnostics below.");
+                } else {
+                    this.clearRepositoryNotice();
+                }
+            }
+            await this.refreshLibrary(true);
+            if (refreshed.status !== "error" && !refreshed.git_error) {
+                await this.toggleLibrarySettings(false);
+            }
         } catch (err) {
+            this.poseRepositories = previousRepositories;
+            this.renderPoseRepositorySettings();
             this.showRepositoryNotice(`Failed to add repository: ${err?.message || err}`, true);
+        } finally {
+            if (pollTimer) clearInterval(pollTimer);
+            progress.close();
         }
     }
 
@@ -10864,6 +11022,10 @@ class PoseStudioWidget {
                 <div class="vnccs-ps-library-repo-progress-track">
                     <div class="vnccs-ps-library-repo-progress-fill"></div>
                 </div>
+                <details class="vnccs-ps-library-repo-progress-diagnostic" hidden>
+                    <summary>Git clone failed — HTTP fallback active</summary>
+                    <pre></pre>
+                </details>
             </div>
         `;
     }
@@ -10899,9 +11061,15 @@ class PoseStudioWidget {
         const messageEl = progress.querySelector('.vnccs-ps-library-repo-progress-message');
         const percentEl = progress.querySelector('.vnccs-ps-library-repo-progress-percent');
         const fillEl = progress.querySelector('.vnccs-ps-library-repo-progress-fill');
+        const diagnosticEl = progress.querySelector('.vnccs-ps-library-repo-progress-diagnostic');
         if (messageEl) messageEl.textContent = state.message || "Working...";
         if (percentEl) percentEl.textContent = `${Math.round(percent)}%`;
         if (fillEl) fillEl.style.width = `${percent}%`;
+        if (diagnosticEl) {
+            diagnosticEl.hidden = !state.git_error;
+            const diagnosticText = diagnosticEl.querySelector('pre');
+            if (diagnosticText) diagnosticText.textContent = state.git_error || "";
+        }
     }
 
     createInlineRepositoryProgress(key, initialText = "Starting...") {
@@ -10921,6 +11089,8 @@ class PoseStudioWidget {
                 if (status.status) patch.status = status.status;
                 if (status.message) patch.message = status.message;
                 if (status.progress !== undefined) patch.progress = status.progress;
+                if (Object.prototype.hasOwnProperty.call(status, "git_error")) patch.git_error = status.git_error || "";
+                if (Object.prototype.hasOwnProperty.call(status, "transport")) patch.transport = status.transport || "";
                 this.setRepositoryProgressState(key, patch);
             },
             close: (delay = 1600) => {
@@ -11020,8 +11190,15 @@ class PoseStudioWidget {
                 progress: 100,
                 message: refreshed.status === "error"
                     ? `Error: ${refreshed.last_error || "refresh failed"}`
-                    : `Repository sync complete: ${Number(refreshed.downloaded_count || 0)} downloaded, ${Number(refreshed.skipped_count || 0)} unchanged, ${Number(refreshed.removed_count || 0)} removed.`,
+                    : refreshed.git_error
+                        ? `Repository sync completed through HTTP after Git clone failed.`
+                        : `Repository sync complete: ${Number(refreshed.downloaded_count || 0)} downloaded, ${Number(refreshed.skipped_count || 0)} unchanged, ${Number(refreshed.removed_count || 0)} removed.`,
+                git_error: refreshed.git_error || "",
+                transport: refreshed.transport || "",
             });
+            if (refreshed.git_error) {
+                this.showRepositoryNotice("Git clone failed; the repository was downloaded through the slower HTTP fallback. Open Git diagnostics below.");
+            }
             await this.refreshLibrary(true);
         } finally {
             if (pollTimer) clearInterval(pollTimer);
@@ -11603,6 +11780,13 @@ class PoseStudioWidget {
         try {
             this.captureActiveCharacterRuntime();
             this.syncSharedTimelineFromActive();
+            const savedSAMProjection = (
+                !animationMode
+                && this._samCameraModeActive
+                && this._samCamDisplayActive
+            )
+                ? normalizeSAMProjectionFrame(this._samCamStoredProjectionFrame)
+                : null;
             const savePrompt = String(metadata.prompt ?? this.getPosePrompt(this.activeTab) ?? "");
             const scenePrompts = [...this.posePrompts];
             while (scenePrompts.length <= this.activeTab) scenePrompts.push("");
@@ -11620,15 +11804,28 @@ class PoseStudioWidget {
                     serialized.poses[this.activeTab] = serialized.poses[this.activeTab] || {};
                     serialized.poses[this.activeTab].prompt = savePrompt;
                 }
+                // A library pose is one point on the pose axis, even when the
+                // scene contains several characters. Pose sets are exported
+                // separately with the explicit `type: "pose_set"` format.
+                if (!animationMode) {
+                    const selectedPose = serialized.poses[this.activeTab]
+                        || serialized.poses[0]
+                        || {};
+                    if (character.id === this.activeCharacterId && savedSAMProjection) {
+                        selectedPose.sam_projection = JSON.parse(JSON.stringify(savedSAMProjection));
+                    }
+                    serialized.poses = [selectedPose];
+                }
                 return serialized;
             });
             const sceneBase = {
+                type: animationMode ? "pose_animation" : "scene_pose",
                 schema_version: 3,
                 active_character_id: this.activeCharacterId,
                 characters: sceneCharacters,
                 timeline: { ...this.sharedTimeline },
-                activeTab: this.activeTab,
-                pose_prompts: scenePrompts,
+                activeTab: animationMode ? this.activeTab : 0,
+                pose_prompts: animationMode ? scenePrompts : [savePrompt],
                 camera: {
                     yaw_deg: this.exportParams.cam_yaw_deg || 0,
                     pitch_deg: this.exportParams.cam_pitch_deg || 0,
@@ -11654,6 +11851,9 @@ class PoseStudioWidget {
             } else {
                 const pose = this.stripSceneCameraFromPose(this.viewer.getPose());
                 pose.cameraParams = this.currentCameraParams();
+                if (savedSAMProjection) {
+                    pose.sam_projection = JSON.parse(JSON.stringify(savedSAMProjection));
+                }
                 pose.prompt = savePrompt;
                 assetData = { ...pose, ...sceneBase, prompt: pose.prompt };
             }
@@ -11693,21 +11893,25 @@ class PoseStudioWidget {
     }
 
     applyLibraryPoseFraming(cameraParams) {
-        const character = this.getActiveCharacter();
-        if (!character) throw new Error("Cannot apply pose framing without an active character.");
         if (!this.viewer?.sceneCameraTarget) {
             throw new Error("Cannot apply pose framing before the model camera target is ready.");
-        }
-
-        const yaw = Number(cameraParams.yaw_deg);
-        const pitch = Number(cameraParams.pitch_deg);
-        if (!Number.isFinite(yaw) || !Number.isFinite(pitch)) {
-            throw new TypeError("Pose framing requires finite camera angles.");
         }
         const transform = cameraFramingToCharacterTransform(
             cameraParams,
             this.viewer.sceneCameraTarget,
         );
+        this.applyLibraryPoseTransform(transform, cameraParams);
+    }
+
+    applyLibraryPoseTransform(transformSource, cameraParams = {}) {
+        const character = this.getActiveCharacter();
+        if (!character) throw new Error("Cannot apply pose transform without an active character.");
+        const transform = normalizeCharacterTransform(transformSource);
+        const yaw = Number(cameraParams.yaw_deg ?? 0);
+        const pitch = Number(cameraParams.pitch_deg ?? 0);
+        if (!Number.isFinite(yaw) || !Number.isFinite(pitch)) {
+            throw new TypeError("Pose framing requires finite camera angles.");
+        }
         character.transform = transform;
 
         if (this.isAnimationMode()) {
@@ -11747,6 +11951,29 @@ class PoseStudioWidget {
             transform,
         });
         this.syncCameraWidgets();
+        this.applyCameraToViewer(true);
+        this.viewer.setCameraParams(this.currentCameraParams());
+    }
+
+    applyLibrarySAMProjection(frameSource) {
+        const frame = normalizeSAMProjectionFrame(frameSource);
+        if (!frame) throw new TypeError("Library pose contains an invalid SAM projection camera.");
+        const cameraParams = this.currentCameraParams();
+        const storedParams = {
+            cam_zoom: cameraParams.zoom,
+            cam_offset_x: cameraParams.offset_x,
+            cam_offset_y: cameraParams.offset_y,
+            cam_yaw_deg: cameraParams.yaw_deg,
+            cam_pitch_deg: cameraParams.pitch_deg,
+        };
+        this._samCamPreParams = { ...storedParams };
+        this._samCamStoredParams = { ...storedParams };
+        this._samCamStoredProjectionFrame = frame;
+        this._samCameraModeActive = true;
+        this._samCamBannerVisible = true;
+        this._samCamDisplayActive = true;
+        this.viewer.setSAMProjectionCameraFrame(frame);
+        this._updateSAMCameraBanner();
         this.applyCameraToViewer(true);
         this.viewer.setCameraParams(this.currentCameraParams());
     }
@@ -11823,7 +12050,10 @@ class PoseStudioWidget {
         await this.hydrateCharacterSceneModels({ showOverlay: true, recenterViewport: false });
         this.animationTimeline?.setState(this.animationState);
         this.resetAnimationHistory();
-        this.setInterfaceMode("studio", { sync: false });
+        // Loading a pose is not an interface navigation action. Pose Manager
+        // and its detail view stay open; animations are the sole library asset
+        // type that intentionally opens the Studio timeline.
+        if (animation) this.setInterfaceMode("studio", { sync: false });
         this.setEditorMode(animation ? "animation" : "image", { sync: false });
         if (animation) this.applyAnimationFrame(this.sharedTimeline.currentFrame, { transient: true });
         else {
@@ -11835,6 +12065,48 @@ class PoseStudioWidget {
         this.syncCharacterEditorControls();
         this.renderCharactersUI();
         this.syncToNode(false, { skipCapture: true, skipAnimationHistory: true });
+    }
+
+    loadPoseSetAsset(asset) {
+        const sourcePoses = Array.isArray(asset) ? asset : asset?.poses;
+        if (!Array.isArray(sourcePoses) || !sourcePoses.length) {
+            throw new Error("Pose set does not contain poses.");
+        }
+
+        this.setEditorMode("image", { sync: false });
+        this.clearSAMCameraMode();
+        const activeCharacter = this.getActiveCharacter();
+        this.poses = sourcePoses.map(sourcePose => {
+            const pose = JSON.parse(JSON.stringify(sourcePose || {}));
+            const savedCamera = pose.cameraParams;
+            this.stripSceneCameraFromPose(pose);
+            pose.cameraParams = resolveCaptureCameraParams(
+                savedCamera,
+                this.currentCameraParams(),
+            );
+            return pose;
+        });
+        if (activeCharacter) activeCharacter.poses = this.poses;
+        for (const character of this.characters) {
+            if (character === activeCharacter) continue;
+            if (!Array.isArray(character.poses)) character.poses = [];
+            while (character.poses.length < this.poses.length) character.poses.push({});
+            while (character.poses.length > this.poses.length) character.poses.pop();
+        }
+        this.posePrompts = this.poses.map(pose => String(pose?.prompt || ""));
+        this.poseCaptures = [];
+        this.lightingPrompts = [];
+        this.activeTab = 0;
+        this.ensurePoseCameraParams();
+        this.restoreActivePoseCameraParams({ updateViewer: false });
+        this.updateTabs();
+        if (this.viewer?.isInitialized?.()) {
+            this.viewer.setPose(this.poses[0], true);
+            this.updateCharacterScene({ poseIndex: 0 });
+            this.updateRotationSliders();
+        }
+        this.updateCaptureCameraPreview();
+        this.syncToNode(true);
     }
 
     loadAnimationLibraryAsset(asset) {
@@ -11901,26 +12173,59 @@ class PoseStudioWidget {
             if (!res.ok) throw new Error(data?.error || `HTTP ${res.status}`);
 
             if (data.pose && this.viewer) {
+                const isPoseSet = data.pose?.type === "pose_set"
+                    && Array.isArray(data.pose?.poses);
                 const assetType = data.asset_type === "animation" || data.pose?.animation
                     ? "animation"
                     : "pose";
-                if (Array.isArray(data.pose.characters) && data.pose.characters.length) {
+                const activeScenePose = assetType === "pose"
+                    ? extractActivePoseFromSceneAsset(data.pose)
+                    : null;
+                const activeSceneTransform = activeScenePose
+                    ? extractActiveCharacterTransformFromSceneAsset(data.pose)
+                    : null;
+                if (isPoseSet) {
+                    this.loadPoseSetAsset(data.pose);
+                } else if (
+                    assetType === "animation"
+                    && Array.isArray(data.pose.characters)
+                    && data.pose.characters.length
+                ) {
                     await this.loadCharacterSceneLibraryAsset(data.pose, {
                         animation: assetType === "animation",
                     });
                 } else if (assetType === "animation") {
                     this.loadAnimationLibraryAsset(data.pose);
                 } else {
-                    const poseSource = JSON.parse(JSON.stringify(data.pose));
+                    const poseSource = JSON.parse(JSON.stringify(activeScenePose || data.pose));
                     const savedFraming = (
                         poseSource.cameraParams
                         && typeof poseSource.cameraParams === "object"
                     )
                         ? { ...poseSource.cameraParams }
                         : null;
+                    const savedSAMProjection = normalizeSAMProjectionFrame(
+                        poseSource.sam_projection
+                        ?? data.pose?.sam_projection
+                        ?? data.pose?.camera?.sam_projection,
+                    );
+                    const savedAngles = {
+                        yaw_deg: savedFraming?.yaw_deg ?? data.pose?.camera?.yaw_deg ?? 0,
+                        pitch_deg: savedFraming?.pitch_deg ?? data.pose?.camera?.pitch_deg ?? 0,
+                    };
                     const pose = this.stripSceneCameraFromPose(poseSource);
                     this.viewer.setPose(pose, true);
-                    if (savedFraming) this.applyLibraryPoseFraming(savedFraming);
+                    if (activeSceneTransform) {
+                        // v3 scene poses already store the final character-space
+                        // placement. Re-running it through the legacy camera-pivot
+                        // conversion shifts and rescales the character on every load.
+                        this.applyLibraryPoseTransform(activeSceneTransform, savedAngles);
+                    } else if (savedFraming) {
+                        this.applyLibraryPoseFraming(savedFraming);
+                    }
+                    if (savedSAMProjection) {
+                        this.applyLibrarySAMProjection(savedSAMProjection);
+                    }
                     if (this.isAnimationMode()) {
                         this.animationState.basePose.prompt = pose.prompt ?? this.animationState.basePose.prompt ?? "";
                     } else {
@@ -13723,16 +14028,27 @@ class PoseStudioWidget {
         this.captureActiveCharacterRuntime();
         this.syncSharedTimelineFromActive();
         const animationCanCapture = animationMode && fullCapture;
+        const poseManagerInterface = (
+            this.interfaceMode === "manager"
+            || this.interfaceMode === "managerDetail"
+        );
         const requestedDebugExecution = (
             !animationMode
             && fullCapture
             && options.executionCapture === true
+            && !poseManagerInterface
             && this.exportParams.debugMode
         );
         const debugPose = requestedDebugExecution
             ? this.selectRandomDebugLibraryPose()
             : null;
         const isDebugExecution = requestedDebugExecution && !!debugPose;
+        const reusePoseManagerCaptures = (
+            !animationMode
+            && fullCapture
+            && options.executionCapture === true
+            && poseManagerInterface
+        );
         // PNG encoding is synchronous (`canvas.toDataURL`) and can occupy the
         // main thread for hundreds of milliseconds. Normal UI edits only need to
         // persist pose/settings data; execution explicitly requests fresh captures
@@ -13743,6 +14059,7 @@ class PoseStudioWidget {
         const skipCapture = options.skipCapture === true
             || !captureExplicitlyRequested
             || (animationMode && !animationCanCapture)
+            || reusePoseManagerCaptures
             || (options.skipCapture !== false && this.interfaceMode === "manager" && !fullCapture);
         const capturePoses = isDebugExecution
             ? [debugPose]
@@ -13765,6 +14082,23 @@ class PoseStudioWidget {
         if (!this.poseCaptures) this.poseCaptures = [];
         if (!this.lightingPrompts) this.lightingPrompts = [];
         this.ensurePosePrompts();
+
+        if (options.executionCapture === true) {
+            this._executionCaptureSnapshot = null;
+            this._executionLightingPromptSnapshot = null;
+        }
+        if (reusePoseManagerCaptures) {
+            const managerCapturesReady = this.poseCaptures.length === outputCount
+                && this.poseCaptures.every(capture => typeof capture === "string" && capture.length > 0);
+            if (!managerCapturesReady) {
+                throw new Error("Pose Manager previews are not ready; RUN cannot use incomplete cards.");
+            }
+            // RUN in Pose Manager is a byte-for-byte snapshot of the images
+            // already displayed in its cards. It must never invoke capture(),
+            // camera fitting, or any other render-time reinterpretation.
+            this._executionCaptureSnapshot = this.poseCaptures.slice();
+            this._executionLightingPromptSnapshot = this.lightingPrompts.slice();
+        }
 
         // Any animation edit invalidates the previous widget-rendered sequence.
         // A fresh full capture always renders every frame through viewer.capture().
@@ -13849,7 +14183,6 @@ class PoseStudioWidget {
                             currentCaptureCamera,
                             animationMode,
                         );
-
                         // Lighting Toggle
                         if (isOriginalLighting) {
                             this.viewer.updateLights([{ type: 'ambient', color: '#ffffff', intensity: 1.0 }]);
@@ -14461,6 +14794,14 @@ app.registerExtension({
             const widgetData = JSON.parse(poseWidget.value);
             const animationCacheReady = await node.studioWidget.flushAnimationCacheUpload();
             const syncFileId = syncToken ? `${nodeId}_${syncToken}` : nodeId;
+            const capturedImages = node.studioWidget._executionCaptureSnapshot
+                || node.studioWidget.poseCaptures
+                || [];
+            const capturedLightingPrompts = node.studioWidget._executionLightingPromptSnapshot
+                || node.studioWidget.lightingPrompts
+                || [];
+            node.studioWidget._executionCaptureSnapshot = null;
+            node.studioWidget._executionLightingPromptSnapshot = null;
             const payload = {
                 ...widgetData,
                 node_id: syncFileId,
@@ -14471,8 +14812,8 @@ app.registerExtension({
                 animation: animationCacheReady
                     ? widgetData.animation
                     : node.studioWidget.buildSceneAnimationCachePayload(),
-                captured_images: node.studioWidget.poseCaptures || [],
-                lighting_prompts: node.studioWidget.lightingPrompts || []
+                captured_images: capturedImages,
+                lighting_prompts: capturedLightingPrompts
             };
 
             return fetch('/vnccs/pose_sync/upload_capture', {


### PR DESCRIPTION
# Version 0.6.2
## Pose Library Repository Sync, Publishing, and Pose Manager Reliability

### New Features

*   **Fast external Pose Library synchronization**: Public Hugging Face pose repositories now use a one-shot shallow Git clone instead of downloading every changed file through a separate HTTP request.
    *   The complete repository is transferred with `git clone --depth 1 --single-branch --no-tags`, providing a substantial speedup for libraries containing hundreds or thousands of small pose and preview files.
    *   The clone exists only in the operating system's temporary directory on the machine running ComfyUI. It is used as the import source and removed immediately after synchronization, without creating a nested Git checkout in `custom_nodes`, PoseLibrary, or `ComfyUI/user`.
    *   Manifest paths, file boundaries, declared SHA-256 hashes, size limits, symbolic links, and Git LFS/Xet pointers are validated before files are imported into PoseLibrary.
    *   Private repositories and unsupported Git/LFS transfers continue through the authenticated bounded HTTP path.

*   **Automatic repository installation**: Adding a Pose Library repository is now a complete single action.
    *   Both `owner/repository` identifiers and Hugging Face repository URLs are accepted.
    *   Clicking Add registers the repository, immediately downloads its manifest, poses, animations, and previews, refreshes the library, and makes the new assets available without another user action.
    *   Inline progress reports the current transfer, file count, imported, unchanged, and removed totals.

*   **Second default Pose Library repository**: Added [`Totemistyk/General_Poses_PoseStudio`](https://huggingface.co/Totemistyk/General_Poses_PoseStudio) as the enabled second built-in repository after `MIUProject/VNCCS_PoseLibrary_Main`.
    *   Existing installations receive it automatically after updating and restarting the node.
    *   Its project title is fixed as **General Poses PoseStudio**, independently of generic legacy titles stored in a remote manifest.

### Improvements

*   **Reliable local-library publishing**: Publishing now binds every operation to the repository selected in the current dialog.
    *   Switching between Create New and Use Existing keeps separate input drafts and cannot silently retain the previous target.
    *   Create New requires and creates exactly the requested repository, while malformed requests can no longer fall back to the previously saved repository.
    *   The active target is shown throughout upload, concurrent publish attempts are blocked, and the saved repository link changes only after the requested publish succeeds.

*   **Explicit pose versus pose-set semantics**: Multi-character scene data and Pose Manager pose sets now use separate axes and separate loading paths.
    *   A scene containing `characters[]` remains one library pose even when a character contains runtime `poses[]`; only an asset explicitly marked `type: "pose_set"` replaces the complete Pose Manager list.
    *   Loading a single library pose updates the selected pose without deleting the other Pose Manager entries or switching the interface to Studio.
    *   Loading an animation remains the only library operation that automatically switches to Studio and its animation timeline.
    *   Saving Current Pose stores only the selected pose for every scene character; All Poses (Set) remains the explicit path for exporting the complete set.

*   **Pose Manager preview and execution consistency**: Shape changes now produce one authoritative set of visible pose images.
    *   Age, head size, and other supported mesh changes restart preview generation from the first card after the updated model is ready.
    *   Every deformed pose is fitted and centered independently, and captures wait for the real skin texture before replacing a card.
    *   RUN in Pose Manager uploads an immutable snapshot of the images already displayed in the cards. It performs no second camera fit or render reinterpretation that could change their scale or position.
    *   Execution fails explicitly if a required Pose Manager card is incomplete instead of substituting a differently framed image.

*   **Library camera and scene preservation**: Static library poses retain the framing that was visible when they were saved.
    *   Scene-format poses restore the active character's exact saved transform rather than applying the legacy camera-pivot conversion a second time.
    *   SAM projection FOV and camera position are normalized, serialized, published, downloaded, and restored alongside ordinary pose camera data.
    *   Legacy flat poses continue to use the compatible camera-framing conversion path.

### Fixes

*   **Repository identity**: Fixed different third-party repositories inheriting the same generic `VNCCS Pose Library` title.
*   **Stale publication target**: Fixed publish progress initially displaying the old repository and fixed Create New uploads that could create an empty repository while sending files to the previous target.
*   **Repository installation timing**: Fixed newly added repositories remaining empty until a later enable, refresh, or restart action.
*   **Pose Manager mode stability**: Fixed loading a static multi-character pose switching the UI back to standard Pose Studio.
*   **Pose Manager set replacement**: Fixed a single scene pose being mistaken for a pose set and replacing the complete current pose list.
*   **Pose Manager RUN framing**: Fixed execution recapturing correctly fitted cards with neutral or stale camera values, causing poses to become tiny, oversized, cropped, or displaced.
*   **Saved pose framing**: Fixed library poses losing SAM projection zoom and camera position between save, publication, download, and reload.
*   **Reset scope**: Reset now restores all head, limb, hand, foot, shoulder, hip, and spine mesh-proportion controls while leaving gender, age, weight, muscle, height, and other character attributes unchanged.

### Packaging and Documentation

*   Bumped the package version to `0.6.2`.
*   Expanded Pose Library backend, publication, Git transport, character-schema, camera-framing, Pose Manager, and widget-hardening regression coverage.