### PR TITLE
0.6.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+# Version 0.6.3
+## PoseStudio SAM 3D Body Retargeting and Video Stability
+
+### Improvements
+
+*   **Stable SAM video proportions**: Video analysis now estimates body proportions across the sequence, selects robust median measurements, and retargets every frame onto one fixed MakeHuman rig.
+    *   Hip placement, limb lengths, and character proportions no longer pulse between independently fitted frames.
+    *   The final pass preserves SAM's dense joint rotations instead of replacing head and foot orientation with ambiguous image-space landmark alignment.
+*   **SAM mocap-compatible frame recovery**: An isolated frame without a valid body detection now holds the previous valid pose instead of aborting the complete video import.
+*   **Complete pose persistence**: PoseStudio now stores and restores the bone-local translations produced by SAM retargeting, including pelvis and upper-leg placement, across pose commits, tab changes, scene serialization, and playback.
+
+### Fixes
+
+*   **Missing feet during video playback**: Fixed pose-derived foot bone scale accumulating across frames and eventually collapsing the rendered feet.
+*   **Rear-view head flips**: Fixed dense SAM head rotations being overwritten by eye-midpoint alignment, which could turn the head backward and rotate it by 180 degrees when the subject faced away from the camera.
+*   **Standing leg alignment**: Fixed saved and reapplied SAM poses losing translated hip-root positions, which caused the legs to drift apart or no longer match the analyzed image.
+*   **Video pose jitter**: Fixed each frame changing the shared character rig before playback, a major source of visible jumping even when the underlying SAM detections were consistent.
+*   **Morph compatibility**: Body-shape edits now invalidate stale SAM bone translations before the character is rebuilt, preventing imported offsets from leaking into a newly proportioned mesh.
+
+### Validation
+
+*   Added regression coverage for translated-bone serialization, fixed-rig video retargeting, missing-frame fallback, foot-scale stability, and rear-view head orientation.
+*   Validated the standalone analysis and playback path with the repository's image samples and all 73 frames of its test video using the ComfyUI environment, without launching the ComfyUI server.
+*   The SAM 3D Body model and its inference results are unchanged; these fixes are limited to PoseStudio's pose application, persistence, and video playback behavior.
+
 # Version 0.6.2
 ## Pose Library Repository Sync, Publishing, and Pose Manager Reliability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs-utils"
 description = "VNCCS utility nodes: Pose Studio, UniCanvas, and 3D Factory."
-version = "0.6.2"
+version = "0.6.3"
 license = {file = "LICENSE"} 
 
 dependencies = [

--- a/tests/test_mixamo_alignment.mjs
+++ b/tests/test_mixamo_alignment.mjs
@@ -521,6 +521,76 @@ test("SAM import fits body proportions before building IK targets", () => {
     assert.ok(calls.indexOf("build-targets") < calls.indexOf("world-import"));
 });
 
+test("repeated SAM video imports reset pose-derived foot scale", () => {
+    const footLeft = new THREE.Bone();
+    const footRight = new THREE.Bone();
+    footLeft.name = "foot_l";
+    footRight.name = "foot_r";
+    footLeft.scale.setScalar(0.01);
+    footRight.scale.setScalar(0.02);
+
+    const viewer = Object.create(PoseViewerCore.prototype);
+    viewer.THREE = THREE;
+    viewer.bones = { foot_l: footLeft, foot_r: footRight };
+    viewer.boneList = [footLeft, footRight];
+    viewer.footScale = 1.25;
+    viewer.initialBoneStates = {
+        foot_l: { position: footLeft.position.clone() },
+        foot_r: { position: footRight.position.clone() },
+    };
+    viewer.skinnedMesh = {
+        rotation: { set() {} },
+        updateMatrixWorld() {},
+    };
+    viewer.skeleton = { update() {} };
+    viewer.recordState = () => {};
+    viewer.autoFitSAM3DBoneLengths = () => {};
+    viewer._buildSAM3DImportTargets = () => ({ worldKps: { pelvis: {} } });
+    viewer._applySAM3DRotationImport = () => false;
+    const startingScales = [];
+    viewer.applyWorldKeypointImport = () => {
+        startingScales.push([footLeft.scale.x, footRight.scale.x]);
+        footLeft.scale.multiplyScalar(0.5);
+        footRight.scale.multiplyScalar(0.5);
+        return true;
+    };
+
+    assert.equal(viewer.applySAM3DImport({}, 0, { recordState: false }), true);
+    assert.equal(viewer.applySAM3DImport({}, 0, { recordState: false }), true);
+    assert.deepEqual(startingScales, [[1.25, 1.25], [1.25, 1.25]]);
+});
+
+test("dense SAM rotations are not overwritten by rear-view head and foot point fitting", () => {
+    const viewer = Object.create(PoseViewerCore.prototype);
+    viewer.THREE = THREE;
+    viewer.bones = {};
+    viewer.boneList = [];
+    viewer.initialBoneStates = {};
+    viewer.skinnedMesh = { rotation: { set() {} }, updateMatrixWorld() {} };
+    viewer.skeleton = { update() {} };
+    viewer.recordState = () => {};
+    viewer.autoFitSAM3DBoneLengths = () => {};
+    viewer._buildSAM3DImportTargets = () => ({ worldKps: { pelvis: {} } });
+    viewer._applySAM3DRotationImport = () => true;
+    let importOptions = null;
+    viewer.applyWorldKeypointImport = (_worldKps, options) => {
+        importOptions = options;
+        return true;
+    };
+
+    assert.equal(viewer.applySAM3DImport({}, 0, { recordState: false }), true);
+    assert.equal(importOptions.alignHead, false, "MHR head rotation must remain authoritative");
+    assert.equal(importOptions.alignFeet, true, "image import keeps exact foot surface fitting by default");
+
+    assert.equal(viewer.applySAM3DImport({}, 0, {
+        recordState: false,
+        alignHead: false,
+        alignFeet: false,
+    }), true);
+    assert.equal(importOptions.alignHead, false);
+    assert.equal(importOptions.alignFeet, false, "stable video pass must preserve foot geometry and SAM rotation");
+});
+
 test("SAM projection matches mannequin head and feet to the source height", () => {
     const modelBounds = {
         width: 0.72,

--- a/tests/test_pose_character_regressions.mjs
+++ b/tests/test_pose_character_regressions.mjs
@@ -310,6 +310,40 @@ test("setPose restores shaped bone positions before applying rotations", () => {
     assert.match(resetBlock, /else if \(initialRest\) b\.position\.copy\(initialRest\)/);
 });
 
+test("pose serialization preserves SAM joint-root translations across commit", () => {
+    const getPoseMethod = methodSource(
+        poseStudioCoreSource,
+        "getPose()",
+        "\n    recordState()",
+    );
+    assert.match(getPoseMethod, /const bonePositions = \{\}/);
+    assert.match(getPoseMethod, /b\.position\.distanceToSquared\(restPosition\)/);
+    assert.match(getPoseMethod, /bonePositions\[b\.name\] = \[b\.position\.x, b\.position\.y, b\.position\.z\]/);
+
+    const setPoseMethod = methodSource(
+        poseStudioCoreSource,
+        "setPose(pose, preserveCamera = false)",
+        "\n    resetPose()",
+    );
+    assert.match(setPoseMethod, /const bonePositions = pose\.bonePositions \|\| \{\}/);
+    assert.match(setPoseMethod, /for \(const \[bName, position\] of Object\.entries\(bonePositions\)\)/);
+    assert.match(setPoseMethod, /bone\.position\.set\(values\[0\], values\[1\], values\[2\]\)/);
+});
+
+test("video SAM import re-solves rotations on one median-proportion rig", () => {
+    const importMethod = methodSource(
+        poseStudioSource,
+        "async importVideoPoseSegment(video, plan, {",
+        "\n    async showVideoImportModal(",
+    );
+    assert.match(importMethod, /stableVideoBoneLengthParams\(/);
+    assert.match(importMethod, /boneLengthSamples\.push/);
+    assert.match(importMethod, /fitBoneLengths: false,[\s\S]*placeHipRoots: false,[\s\S]*alignHead: false,[\s\S]*alignFeet: false,[\s\S]*recordState: false/);
+    assert.match(importMethod, /rotations captured while the[\s\S]*skeleton changes per frame are intentionally discarded/);
+    assert.match(importMethod, /Reusing previous SAM pose for video frame/);
+    assert.match(importMethod, /reusedPoseCount/);
+});
+
 
 test("live body morph recalculates skin bind data in neutral character space", () => {
     const morphMethod = methodSource(

--- a/tests/test_video_import.mjs
+++ b/tests/test_video_import.mjs
@@ -12,6 +12,7 @@ import {
     fitVideoTimelineSelection,
     isLikelyVideoFile,
     reduceVideoPoseKeyframes,
+    stableVideoBoneLengthParams,
     stabilizeVideoPoseSequence,
     videoKeyedFrameIndices,
     zoomVideoTimelineViewport,
@@ -151,6 +152,22 @@ test("fixed video key intervals skip pose parsing but preserve the full timeline
     assert.equal(state.fps, 12);
     assert.deepEqual(state.tracks.wrist_l.keys.map(key => key.frame), capture.frameIndices);
     assert.ok(quaternionDistanceDegrees(evaluateAnimationFrame(state, 23).bones.wrist_l, [0, 23, 0]) < 1e-6);
+});
+
+test("video body proportions use a robust median instead of the last frame", () => {
+    const stable = stableVideoBoneLengthParams([
+        { hip_l: 0.51, thigh_l: 0.48 },
+        { hip_l: 0.95, thigh_l: 0.50 },
+        { hip_l: 0.52, thigh_l: 0.49 },
+    ], { hip_l: 0.5, thigh_l: 0.5, shin_l: 0.47 });
+    assert.deepEqual(stable, { hip_l: 0.52, thigh_l: 0.49, shin_l: 0.47 });
+});
+
+test("video body proportion median averages even samples and clamps slider values", () => {
+    assert.deepEqual(stableVideoBoneLengthParams([
+        { hip_l: -2 },
+        { hip_l: 4 },
+    ]), { hip_l: 1 });
 });
 
 test("quaternion stabilization suppresses an isolated wrist jump", () => {

--- a/web/vnccs_pose_characters.mjs
+++ b/web/vnccs_pose_characters.mjs
@@ -202,6 +202,7 @@ export function extractActivePoseFromSceneAsset(data = {}) {
     // those values as compatibility fallbacks for partially wrapped assets.
     for (const key of [
         "bones",
+        "bonePositions",
         "hipBonePosition",
         "ikEffectorPositions",
         "poleTargetPositions",

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -44,6 +44,7 @@ import {
     isLikelyVideoFile,
     reduceVideoPoseKeyframes,
     seekVideo,
+    stableVideoBoneLengthParams,
     stabilizeVideoPoseSequence,
     waitForVideoMetadata,
     zoomVideoTimelineViewport,
@@ -9551,12 +9552,16 @@ class PoseStudioWidget {
         if (!plan || plan.duration <= 0 || !plan.times?.length) throw new Error("Select a non-empty video segment.");
 
         const originalPose = this.viewer.getPose();
+        const originalBoneLengthParams = { ...(this.viewer.boneLengthParams || {}) };
         const originalCameraParams = this.currentCameraParams();
         const prompt = this.getPosePrompt(this.activeTab);
         const captureCanvas = document.createElement("canvas");
         const poses = [];
+        const poseSamples = [];
+        const boneLengthSamples = [];
         let lastPoseData = null;
         let lastMeshData = null;
+        let reusedPoseCount = 0;
         const fixedStep = Math.max(1, Math.floor(Number(keyframeStep) || 2));
         // Adaptive reduction needs the dense source motion to decide which
         // joints/frames are redundant. Fixed-step mode can skip parsing every
@@ -9587,26 +9592,48 @@ class PoseStudioWidget {
                     progress: ((index + 0.15) / captureSchedule.sampleCount) * 95,
                     phase: "pose",
                 });
-                const poseData = await this.requestSAM3DPoseForImage(frameBlob, {
-                    taskId,
-                    signal,
-                    fileName: `video_frame_${String(sourceFrame).padStart(5, "0")}.jpg`,
-                });
-                const fitData = await this.prepareSAM3DRenderFit(poseData, {
-                    signal,
-                    reportError: false,
-                });
+                let poseData;
+                let reusedPreviousPose = false;
+                try {
+                    poseData = await this.requestSAM3DPoseForImage(frameBlob, {
+                        taskId,
+                        signal,
+                        fileName: `video_frame_${String(sourceFrame).padStart(5, "0")}.jpg`,
+                    });
+                } catch (error) {
+                    if (error?.name === "AbortError" || !lastPoseData) throw error;
+                    // Match the SAM mocap exporter contract: an isolated missed
+                    // detection holds the previous valid pose instead of
+                    // aborting the complete clip.
+                    console.warn(`[VNCCS] Reusing previous SAM pose for video frame ${sourceFrame}:`, error);
+                    poseData = lastPoseData;
+                    reusedPreviousPose = true;
+                    reusedPoseCount += 1;
+                    onProgress?.({
+                        index,
+                        count: captureSchedule.sampleCount,
+                        time,
+                        progress: ((index + 0.5) / captureSchedule.sampleCount) * 95,
+                        phase: "reuse",
+                    });
+                }
+                const fitData = reusedPreviousPose
+                    ? { poseData, meshData: lastMeshData }
+                    : await this.prepareSAM3DRenderFit(poseData, {
+                        signal,
+                        reportError: false,
+                    });
                 const poseForImport = fitData?.poseData || poseData;
                 const applied = this.viewer.applySAM3DImport(
                     poseForImport,
-                    this._shoulderYOffset || 0
+                    this._shoulderYOffset || 0,
+                    { recordState: false },
                 );
                 if (!applied) throw new Error(`Failed to apply captured pose at ${this.formatVideoTime(time)}.`);
                 if (fitData?.meshData) this.applySAM3DMeshOverlayFit(fitData.meshData, poseForImport);
 
-                const capturedPose = this.stripSceneCameraFromPose(this.viewer.getPose());
-                capturedPose.prompt = prompt;
-                poses.push(capturedPose);
+                poseSamples.push(poseForImport);
+                boneLengthSamples.push({ ...(this.viewer.boneLengthParams || {}) });
                 lastPoseData = poseForImport;
                 lastMeshData = fitData?.meshData || null;
                 onProgress?.({
@@ -9625,7 +9652,56 @@ class PoseStudioWidget {
                 ));
             }
 
-            if (poses.length < 2) throw new Error("Video capture produced fewer than two pose frames.");
+            if (poseSamples.length < 2) throw new Error("Video capture produced fewer than two pose frames.");
+            const stableBoneLengths = stableVideoBoneLengthParams(
+                boneLengthSamples,
+                originalBoneLengthParams,
+            );
+            for (const [group, value] of Object.entries(stableBoneLengths)) {
+                this.viewer.updateBoneLengthScale?.(group, value);
+            }
+
+            // Re-solve every sample on one fixed rig. The first pass above
+            // estimates robust body proportions; rotations captured while the
+            // skeleton changes per frame are intentionally discarded.
+            for (let index = 0; index < poseSamples.length; index++) {
+                if (signal?.aborted) throw new DOMException("Video import cancelled.", "AbortError");
+                const applied = this.viewer.applySAM3DImport(
+                    poseSamples[index],
+                    this._shoulderYOffset || 0,
+                    {
+                        fitBoneLengths: false,
+                        placeHipRoots: false,
+                        alignHead: false,
+                        alignFeet: false,
+                        recordState: false,
+                    },
+                );
+                if (!applied) {
+                    throw new Error(`Failed to reapply captured pose ${index + 1} on the stable video rig.`);
+                }
+                const capturedPose = this.stripSceneCameraFromPose(this.viewer.getPose());
+                capturedPose.prompt = prompt;
+                poses.push(capturedPose);
+                onProgress?.({
+                    index: index + 1,
+                    count: poseSamples.length,
+                    time: captureSchedule.times[index],
+                    progress: 95 + ((index + 1) / poseSamples.length) * 2,
+                    phase: "retarget",
+                });
+                if (index % 8 === 7) {
+                    await new Promise(resolve => (
+                        typeof requestAnimationFrame === "function"
+                            ? requestAnimationFrame(() => resolve())
+                            : setTimeout(resolve, 0)
+                    ));
+                }
+            }
+            if (lastMeshData && lastPoseData) {
+                this.viewer.setSAMMeshOverlayData?.(lastMeshData, lastPoseData);
+                this.viewer.setSAMMeshOverlayVisible?.(!!this.exportParams.debugShowSAMMeshOverlay);
+            }
             onProgress?.({
                 index: poses.length,
                 count: poses.length,
@@ -9668,9 +9744,13 @@ class PoseStudioWidget {
                 ),
                 keyedTrackCount: Object.keys(this.animationState.tracks || {}).length,
                 omittedTrackCount: reduction?.omittedTrackCount || 0,
+                reusedPoseCount,
             };
         } catch (error) {
             if (this.container?.isConnected && this.viewer?.isInitialized?.()) {
+                for (const [group, value] of Object.entries(originalBoneLengthParams)) {
+                    this.viewer.updateBoneLengthScale?.(group, value);
+                }
                 this.viewer.setPose?.(originalPose);
                 this.applyCameraToViewer(true);
                 this.viewer.setCameraParams?.(originalCameraParams);
@@ -13011,9 +13091,13 @@ class PoseStudioWidget {
                     for (let i = 0; i < this.poses.length; i++) {
                         if (this.poses[i]) {
                             delete this.poses[i].hipBonePosition;
+                            delete this.poses[i].bonePositions;
                             delete this.poses[i].ikEffectorPositions;
                             delete this.poses[i].poleTargetPositions;
                         }
+                    }
+                    if (this.animationState?.basePose) {
+                        delete this.animationState.basePose.bonePositions;
                     }
                 }
 

--- a/web/vnccs_pose_studio_core.js
+++ b/web/vnccs_pose_studio_core.js
@@ -3611,6 +3611,7 @@ export class PoseViewerCore {
 
     getPose() {
         const bones = {};
+        const bonePositions = {};
         for (const b of this.boneList) {
             const rot = b.rotation;
             if (Math.abs(rot.x) > 1e-4 || Math.abs(rot.y) > 1e-4 || Math.abs(rot.z) > 1e-4) {
@@ -3619,6 +3620,12 @@ export class PoseViewerCore {
                     rot.y * 180 / Math.PI,
                     rot.z * 180 / Math.PI
                 ];
+            }
+            const shapedRest = this.shapedBoneRestPositions?.[b.name];
+            const initialRest = this.initialBoneStates?.[b.name]?.position;
+            const restPosition = shapedRest || initialRest;
+            if (restPosition && b.position.distanceToSquared(restPosition) > 1e-10) {
+                bonePositions[b.name] = [b.position.x, b.position.y, b.position.z];
             }
         }
 
@@ -3654,6 +3661,9 @@ export class PoseViewerCore {
 
         return {
             bones,
+            // SAM IK may translate joint roots (notably the two hip sockets).
+            // These local offsets are pose data and must survive editor commit.
+            bonePositions,
             modelRotation: [this.modelRotation.x, this.modelRotation.y, this.modelRotation.z],
             camera: {
                 posX: this.camera.position.x,
@@ -3714,6 +3724,7 @@ export class PoseViewerCore {
         if (!pose) return;
 
         const bones = pose.bones || {};
+        const bonePositions = pose.bonePositions || {};
         const modelRot = pose.modelRotation || [0, 0, 0];
         const ikPositions = pose.ikEffectorPositions || {};
 
@@ -3736,6 +3747,15 @@ export class PoseViewerCore {
                     rot[2] * Math.PI / 180
                 );
             }
+        }
+
+        // Restore pose translations after resetting to the shaped skeleton.
+        // A body-shape edit removes this field before pose reapplication.
+        for (const [bName, position] of Object.entries(bonePositions)) {
+            const bone = this.bones[bName];
+            if (!bone || !Array.isArray(position) || position.length < 3) continue;
+            const values = position.slice(0, 3).map(Number);
+            if (values.every(Number.isFinite)) bone.position.set(values[0], values[1], values[2]);
         }
 
         // Apply model rotation
@@ -4413,6 +4433,12 @@ export class PoseViewerCore {
                 (Number(rotation[1]) || 0) * Math.PI / 180,
                 (Number(rotation[2]) || 0) * Math.PI / 180,
             );
+        }
+        for (const [name, position] of Object.entries(pose?.bonePositions || {})) {
+            const bone = entry.bones[name];
+            if (!bone || !Array.isArray(position) || position.length < 3) continue;
+            const values = position.slice(0, 3).map(Number);
+            if (values.every(Number.isFinite)) bone.position.set(values[0], values[1], values[2]);
         }
         for (const [chainKey, position] of Object.entries(pose?.hipBonePosition || {})) {
             const definition = IK_CHAINS[chainKey];
@@ -5671,7 +5697,9 @@ export class PoseViewerCore {
             this._drawHMR2Figure(worldKps);
         }
         this._applyImportPelvisAndTorso(worldKps, options.shoulderYOffset || 0);
-        this._placeSAM3DHipRoots(importTargets.worldKps || worldKps);
+        if (options.placeHipRoots !== false) {
+            this._placeSAM3DHipRoots(importTargets.worldKps || worldKps);
+        }
         this._applySAM3DTargetIK(importTargets, {
             includeSpine: options.includeSpine !== false,
             normalizeLimbs: options.normalizeLimbs !== false,
@@ -8093,10 +8121,10 @@ export class PoseViewerCore {
         }
     }
 
-    applySAM3DImport(data, shoulderYOffset = 0) {
+    applySAM3DImport(data, shoulderYOffset = 0, options = {}) {
         if (!this.THREE || !this.bones || !this.skinnedMesh) return false;
 
-        this.recordState();
+        if (options.recordState !== false) this.recordState();
         this._sam3dImportedFootLocalRotations = null;
         this.modelRotation = { x: 0, y: 0, z: 0 };
         if (this.skinnedMesh) {
@@ -8110,13 +8138,29 @@ export class PoseViewerCore {
                 bone.position.copy(this.initialBoneStates[bone.name].position);
             }
         }
+        // Foot surface fitting changes foot bone scale. It is derived from one
+        // pose and must never be multiplied into the next video sample.
+        const configuredFootScale = Number(this.footScale);
+        const baseFootScale = Number.isFinite(configuredFootScale) && configuredFootScale > 0
+            ? configuredFootScale
+            : 1.0;
+        for (const footName of ['foot_l', 'foot_r']) {
+            this.bones?.[footName]?.scale?.set?.(baseFootScale, baseFootScale, baseFootScale);
+        }
         this.skinnedMesh.updateMatrixWorld(true);
         if (this.skeleton) this.skeleton.update();
 
         // Match the mannequin's limb proportions to the fitted SAM skeleton
         // before building IK targets. Position/scale differences should be
         // handled by body proportions and camera framing, not knee flexion.
-        this.autoFitSAM3DBoneLengths(data);
+        if (options.fitBoneLengths !== false) {
+            this.autoFitSAM3DBoneLengths(data);
+        } else {
+            // Video frames share one character rig. Reapply the already chosen
+            // proportions after the pose reset instead of deriving a new body
+            // shape from every independently analysed frame.
+            this.applyBoneLengthScales();
+        }
 
         const importTargets = this._buildSAM3DImportTargets(data);
         const worldKps = importTargets?.worldKps;
@@ -8141,6 +8185,12 @@ export class PoseViewerCore {
                 normalizeLimbs: true,
                 normalizeArms: true,
                 normalizeLegs: true,
+                placeHipRoots: options.placeHipRoots !== false,
+                // Dense MHR rotations already carry the head orientation. The
+                // eye midpoint is not a compatible head-pivot target and can
+                // tip/flip the MakeHuman head on rear views.
+                alignHead: options.alignHead ?? !usedRotationImport,
+                alignFeet: options.alignFeet !== false,
                 footLocalRotations: this._sam3dImportedFootLocalRotations,
             });
         }

--- a/web/vnccs_video_import.mjs
+++ b/web/vnccs_video_import.mjs
@@ -30,6 +30,38 @@ function finiteNumber(value, fallback = 0) {
     return Number.isFinite(number) ? number : fallback;
 }
 
+/**
+ * A video describes one performer, not a new body shape on every frame.
+ * Use a per-parameter median so pose-dependent joint-regressor noise and an
+ * occasional bad frame cannot make the character's proportions pulse.
+ */
+export function stableVideoBoneLengthParams(samples = [], fallback = {}) {
+    const validSamples = Array.isArray(samples) ? samples.filter(Boolean) : [];
+    const names = new Set(Object.keys(fallback || {}));
+    for (const sample of validSamples) {
+        for (const name of Object.keys(sample || {})) names.add(name);
+    }
+
+    const stable = {};
+    for (const name of names) {
+        const values = validSamples
+            .map(sample => Number(sample?.[name]))
+            .filter(Number.isFinite)
+            .sort((a, b) => a - b);
+        if (!values.length) {
+            const fallbackValue = Number(fallback?.[name]);
+            if (Number.isFinite(fallbackValue)) stable[name] = Math.max(0, Math.min(1, fallbackValue));
+            continue;
+        }
+        const middle = Math.floor(values.length / 2);
+        const value = values.length % 2
+            ? values[middle]
+            : (values[middle - 1] + values[middle]) * 0.5;
+        stable[name] = Math.max(0, Math.min(1, value));
+    }
+    return stable;
+}
+
 export function isLikelyVideoFile(file) {
     if (!file) return false;
     if (String(file.type || "").toLowerCase().startsWith("video/")) return true;


### PR DESCRIPTION
# Version 0.6.3
## PoseStudio SAM 3D Body Retargeting and Video Stability

### Improvements

*   **Stable SAM video proportions**: Video analysis now estimates body proportions across the sequence, selects robust median measurements, and retargets every frame onto one fixed MakeHuman rig.
    *   Hip placement, limb lengths, and character proportions no longer pulse between independently fitted frames.
    *   The final pass preserves SAM's dense joint rotations instead of replacing head and foot orientation with ambiguous image-space landmark alignment.
*   **SAM mocap-compatible frame recovery**: An isolated frame without a valid body detection now holds the previous valid pose instead of aborting the complete video import.
*   **Complete pose persistence**: PoseStudio now stores and restores the bone-local translations produced by SAM retargeting, including pelvis and upper-leg placement, across pose commits, tab changes, scene serialization, and playback.

### Fixes

*   **Missing feet during video playback**: Fixed pose-derived foot bone scale accumulating across frames and eventually collapsing the rendered feet.
*   **Rear-view head flips**: Fixed dense SAM head rotations being overwritten by eye-midpoint alignment, which could turn the head backward and rotate it by 180 degrees when the subject faced away from the camera.
*   **Standing leg alignment**: Fixed saved and reapplied SAM poses losing translated hip-root positions, which caused the legs to drift apart or no longer match the analyzed image.
*   **Video pose jitter**: Fixed each frame changing the shared character rig before playback, a major source of visible jumping even when the underlying SAM detections were consistent.
*   **Morph compatibility**: Body-shape edits now invalidate stale SAM bone translations before the character is rebuilt, preventing imported offsets from leaking into a newly proportioned mesh.

### Validation

*   Added regression coverage for translated-bone serialization, fixed-rig video retargeting, missing-frame fallback, foot-scale stability, and rear-view head orientation.
*   Validated the standalone analysis and playback path with the repository's image samples and all 73 frames of its test video using the ComfyUI environment, without launching the ComfyUI server.
*   The SAM 3D Body model and its inference results are unchanged; these fixes are limited to PoseStudio's pose application, persistence, and video playback behavior.