### PR TITLE
0.6.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+# Version 0.6.4
+## PoseStudio Male Anatomy Visibility Control
+
+### New Features
+
+*   **Opt-in genital visibility for male characters**: Added a **Show Genitals** checkbox to PoseStudio's **Gender Settings** section.
+    *   The control is available when **Male** is selected and is unchecked by default.
+    *   The setting is stored independently for each character and preserved in PoseStudio scene and workflow data.
+
+### Improvements
+
+*   **Safer default character display**: Male genital geometry is now excluded from the rendered model unless **Show Genitals** is explicitly enabled.
+*   **Backward-compatible workflow loading**: Existing workflows and library scenes that do not contain the new `show_genitals` setting open with genital visibility disabled.
+*   **Immediate topology updates**: Enabling or disabling the option updates the live character mesh without requiring PoseStudio or the node to be reloaded.
+
+### Validation
+
+*   Added regression coverage for the default hidden state, explicit male opt-in, female exclusion, and the PoseStudio checkbox integration.
+
 # Version 0.6.3
 ## PoseStudio SAM 3D Body Retargeting and Video Stability
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs-utils"
 description = "VNCCS utility nodes: Pose Studio, UniCanvas, and 3D Factory."
-version = "0.6.3"
+version = "0.6.4"
 license = {file = "LICENSE"} 
 
 dependencies = [

--- a/tests/test_pose_morph_runtime.mjs
+++ b/tests/test_pose_morph_runtime.mjs
@@ -8,6 +8,7 @@ import { gunzipSync } from "node:zlib";
 import {
     buildModelIndices,
     calculateMorphFactors,
+    modelUsesGenitals,
     parseMorphPack,
     solveMorph,
 } from "../web/vnccs_pose_morph_runtime.mjs";
@@ -109,4 +110,11 @@ test("gender topology and precomputed skin weights are valid", () => {
         }
         assert.ok(Math.abs(total - 1) < 1e-5, `skin weights are not normalized at vertex ${vertex}`);
     }
+});
+
+test("male genitals are hidden unless explicitly enabled", () => {
+    assert.equal(modelUsesGenitals({ gender: 1 }), false);
+    assert.equal(modelUsesGenitals({ gender: 1, show_genitals: false }), false);
+    assert.equal(modelUsesGenitals({ gender: 1, show_genitals: true }), true);
+    assert.equal(modelUsesGenitals({ gender: 0, show_genitals: true }), false);
 });

--- a/tests/test_widget_hardening.mjs
+++ b/tests/test_widget_hardening.mjs
@@ -66,6 +66,16 @@ test("Pose Studio library launcher uses the concise product name", () => {
     assert.doesNotMatch(poseStudioSource, /Pose Library Gallery/);
 });
 
+test("Pose Studio exposes male genitals only through an opt-in checkbox", () => {
+    assert.match(poseStudioSource, /show_genitals: false/);
+    assert.match(poseStudioSource, /genitalsLabel\.innerText = "Show Genitals"/);
+    assert.match(poseStudioSource, /this\.genderFields\.show_genitals = \{ field: genitalsField, gender: "male" \}/);
+    assert.match(
+        poseStudioSource,
+        /this\.meshParams\.show_genitals = genitalsCheckbox\.checked;\s*this\.onMeshParamsChanged\("show_genitals"\)/,
+    );
+});
+
 
 test("Pose Library create-new publishing cannot retain or silently reuse the old target", () => {
     const modalStart = poseStudioSource.indexOf("showPublishLocalRepositoryModal(forceConfigure = false)");

--- a/web/vnccs_pose_morph_runtime.mjs
+++ b/web/vnccs_pose_morph_runtime.mjs
@@ -259,7 +259,7 @@ function solveLandmarks(data, vertices) {
 }
 
 export function modelUsesGenitals(params = {}) {
-    return Number(params.gender ?? 0.5) >= 0.99;
+    return params.show_genitals === true && Number(params.gender ?? 0.5) >= 0.99;
 }
 
 export function buildModelIndices(data, includeGenitals) {

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -413,6 +413,23 @@ const STYLES = `
     align-items: center;
 }
 
+.vnccs-ps-checkbox-field {
+    flex-direction: row;
+    align-items: center;
+    gap: 7px;
+    min-height: 20px;
+}
+
+.vnccs-ps-checkbox-field input[type="checkbox"] {
+    margin: 0;
+    accent-color: var(--ps-accent);
+    cursor: pointer;
+}
+
+.vnccs-ps-checkbox-field .vnccs-ps-label {
+    cursor: pointer;
+}
+
 /* Slider */
 .vnccs-ps-slider-wrap {
     display: flex;
@@ -4093,6 +4110,7 @@ class PoseStudioWidget {
             // Female-specific
             breast_size: 0.5, firmness: 0.5,
             // Male-specific
+            show_genitals: false,
             penis_len: 0.5, penis_circ: 0.5, penis_test: 0.5,
             // Visual modifiers (client-side bone scaling)
             ...DEFAULT_POSE_STUDIO_MESH_PROPORTIONS,
@@ -4726,6 +4744,23 @@ class PoseStudioWidget {
             { key: "penis_circ", label: "Girth", min: 0, max: 1, step: 0.01, def: 0.5 },
             { key: "penis_test", label: "Testicles", min: 0, max: 1, step: 0.01, def: 0.5 }
         ];
+
+        const genitalsField = document.createElement("label");
+        genitalsField.className = "vnccs-ps-field vnccs-ps-checkbox-field";
+        const genitalsCheckbox = document.createElement("input");
+        genitalsCheckbox.type = "checkbox";
+        genitalsCheckbox.checked = this.meshParams.show_genitals === true;
+        const genitalsLabel = document.createElement("span");
+        genitalsLabel.className = "vnccs-ps-label";
+        genitalsLabel.innerText = "Show Genitals";
+        genitalsCheckbox.addEventListener("change", () => {
+            this.meshParams.show_genitals = genitalsCheckbox.checked;
+            this.onMeshParamsChanged("show_genitals");
+        });
+        genitalsField.append(genitalsCheckbox, genitalsLabel);
+        genderSection.content.appendChild(genitalsField);
+        this.genitalsCheckbox = genitalsCheckbox;
+        this.genderFields.show_genitals = { field: genitalsField, gender: "male" };
 
         for (const s of maleSliders) {
             const field = this.createSliderField(s.label, s.key, s.min, s.max, s.step, s.def, this.meshParams);
@@ -13147,7 +13182,7 @@ class PoseStudioWidget {
         return [
             "age", "gender", "weight", "muscle", "height",
             "breast_size", "firmness",
-            "penis_len", "penis_circ", "penis_test",
+            "show_genitals", "penis_len", "penis_circ", "penis_test",
         ].includes(key);
     }
 
@@ -13567,6 +13602,10 @@ class PoseStudioWidget {
     updateGenderVisibility() {
         if (!this.genderFields) return;
         const isFemale = this.meshParams.gender < 0.5;
+
+        if (this.genitalsCheckbox) {
+            this.genitalsCheckbox.checked = this.meshParams.show_genitals === true;
+        }
 
         for (const [key, info] of Object.entries(this.genderFields)) {
             if (info.gender === "female") {


### PR DESCRIPTION
# Version 0.6.4
## PoseStudio Male Anatomy Visibility Control

### New Features

*   **Opt-in genital visibility for male characters**: Added a **Show Genitals** checkbox to PoseStudio's **Gender Settings** section.
    *   The control is available when **Male** is selected and is unchecked by default.
    *   The setting is stored independently for each character and preserved in PoseStudio scene and workflow data.

### Improvements

*   **Safer default character display**: Male genital geometry is now excluded from the rendered model unless **Show Genitals** is explicitly enabled.
*   **Backward-compatible workflow loading**: Existing workflows and library scenes that do not contain the new `show_genitals` setting open with genital visibility disabled.
*   **Immediate topology updates**: Enabling or disabling the option updates the live character mesh without requiring PoseStudio or the node to be reloaded.