### PR TITLE
0.6.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,11 +22,16 @@
 *   **SAM camera setting is now respected**: Fixed SAM imports re-enabling detector-camera matching and replacing the user's framing even when **SAM Import: Apply Camera Angle** was disabled.
     *   Camera matching is now disabled by default and remains available as an explicit option.
     *   Turning the option off while a SAM camera view is active restores the user-controlled camera.
+*   **Identical SAM and standard-mode framing**: Fixed the analyzed character rendering at a different scale when **SAM Import: Apply Camera Angle** was disabled.
+    *   Standard mode now reuses the recovered SAM camera position with PoseStudio's fixed 30-degree FOV and an exactly equivalent perspective zoom.
+    *   Compact and seated poses retain the same scale and position in both modes, including images where the visible body extends beyond the frame; PoseStudio no longer attempts to reveal or fit off-frame anatomy.
 
 ### Packaging and Validation
 
 *   Bumped the package version to `0.6.5`.
 *   Added regression coverage for Pose Manager analysis control, pose preservation, proportion application across the manager set, preview normalization, and standard-mode isolation.
+*   Added a browser-free end-to-end SAM camera regression using the ComfyUI Python environment, the production SAM 3D Body bridge, PoseStudio's MakeHuman rig and retargeting path, and a headless Node renderer.
+    *   All six repository image examples produce identical SAM-camera and fixed-FOV standard-mode mannequin projections, with zero projected-vertex error and zero differing output pixels.
 
 # Version 0.6.4
 ## PoseStudio Male Anatomy Visibility Control

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# Version 0.6.5
+## Pose Manager Reference Proportions and SAM Camera Reliability
+
+### New Features
+
+*   **Reference-image proportions in Pose Manager**: The PoseStudio `pose_image` input is now available in Pose Manager.
+    *   When the node runs, SAM 3D Body analyzes the connected image and transfers its body proportions to the character used by every pose in the current manager set.
+    *   The reference pose is not applied and does not replace any pose in the manager set.
+    *   After the proportions are updated, every pose is normalized with the same full-frame fitting used after an age change and its preview is regenerated before output.
+
+*   **Automatic analysis toggle**: Added an **Auto-analyze proportions** checkbox to the Pose Manager header.
+    *   The option is enabled by default and saved with the workflow.
+    *   When disabled, `pose_image` remains visible and connected, but the image is not sent to SAM for analysis.
+
+### Improvements
+
+*   **Matching proportion results across PoseStudio modes**: Pose Manager uses the same body-proportion fitting as the standard PoseStudio image analysis, providing consistent limb and torso proportions while preserving all managed poses.
+*   **Unchanged standard PoseStudio workflow**: Outside Pose Manager, `pose_image` continues to apply the analyzed pose and body proportions as before.
+
+### Fixes
+
+*   **SAM camera setting is now respected**: Fixed SAM imports re-enabling detector-camera matching and replacing the user's framing even when **SAM Import: Apply Camera Angle** was disabled.
+    *   Camera matching is now disabled by default and remains available as an explicit option.
+    *   Turning the option off while a SAM camera view is active restores the user-controlled camera.
+
+### Packaging and Validation
+
+*   Bumped the package version to `0.6.5`.
+*   Added regression coverage for Pose Manager analysis control, pose preservation, proportion application across the manager set, preview normalization, and standard-mode isolation.
+
 # Version 0.6.4
 ## PoseStudio Male Anatomy Visibility Control
 

--- a/nodes/pose_studio.py
+++ b/nodes/pose_studio.py
@@ -206,6 +206,16 @@ def _hydrate_cached_pose_animation(data):
     return data
 
 
+def _pose_image_analysis_mode(data):
+    """Resolve how the optional pose image should affect the browser editor."""
+    export = data.get("export", {}) if isinstance(data, dict) else {}
+    if not isinstance(export, dict) or export.get("interface_mode") != "manager":
+        return "pose"
+    if export.get("manager_auto_analyze_proportions", True) is False:
+        return None
+    return "manager_proportions"
+
+
 class VNCCS_PoseStudio:
     """Pose Studio with mesh editing and multiple pose generation."""
     
@@ -295,7 +305,13 @@ class VNCCS_PoseStudio:
             time.sleep(0.1)
         return None
 
-    def _apply_pose_image_via_frontend(self, pose_image, unique_id, camera_prompt=""):
+    def _apply_pose_image_via_frontend(
+        self,
+        pose_image,
+        unique_id,
+        camera_prompt="",
+        apply_mode="pose",
+    ):
         if pose_image is None or not unique_id:
             return None
 
@@ -323,6 +339,7 @@ class VNCCS_PoseStudio:
                 "node_id": unique_id,
                 "pose_data": pose_payload,
                 "camera_prompt": camera_prompt or "",
+                "apply_mode": apply_mode,
                 "sync_token": sync_token,
             })
             synced = self._wait_for_frontend_sync(
@@ -332,7 +349,10 @@ class VNCCS_PoseStudio:
                 sync_token=sync_token,
             )
             if synced:
-                print("[VNCCS Pose Studio] Applied pose_image SAM pose through frontend sync.")
+                if apply_mode == "manager_proportions":
+                    print("[VNCCS Pose Studio] Applied pose_image body proportions to Pose Manager.")
+                else:
+                    print("[VNCCS Pose Studio] Applied pose_image SAM pose through frontend sync.")
                 return synced
             print("[VNCCS Pose Studio] pose_image was analyzed, but frontend sync timed out. Using existing pose_data.")
         except Exception as e:
@@ -359,7 +379,8 @@ class VNCCS_PoseStudio:
                 and export_settings.get("directional_skydome_enabled", False) is not True
             ):
                 camera_prompt = ""
-            if isinstance(export_settings, dict) and export_settings.get("interface_mode") == "manager":
+            pose_image_analysis_mode = _pose_image_analysis_mode(data)
+            if pose_image_analysis_mode is None:
                 pose_image = None
 
             if pose_image is not None:
@@ -367,6 +388,7 @@ class VNCCS_PoseStudio:
                     pose_image,
                     unique_id,
                     camera_prompt,
+                    pose_image_analysis_mode,
                 )
                 if isinstance(synced, dict):
                     data = _hydrate_cached_pose_animation(synced)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs-utils"
 description = "VNCCS utility nodes: Pose Studio, UniCanvas, and 3D Factory."
-version = "0.6.4"
+version = "0.6.5"
 license = {file = "LICENSE"} 
 
 dependencies = [

--- a/tests/test_mixamo_alignment.mjs
+++ b/tests/test_mixamo_alignment.mjs
@@ -455,6 +455,29 @@ test("SAM automatic arm morph keeps the full source segment lengths without shor
     assert.ok(Math.abs(applied.forearm_r - 0.875) < 1e-8);
 });
 
+test("SAM proportion analysis converges body lengths without applying a pose", () => {
+    const calls = [];
+    const viewer = Object.create(PoseViewerCore.prototype);
+    viewer.bones = {};
+    viewer.skinnedMesh = {};
+    viewer.boneLengthParams = { upper_arm_l: 0.7 };
+    viewer.autoFitSAM3DBoneLengths = () => calls.push("auto-fit");
+    viewer._buildSAM3DImportTargets = () => ({ worldKps: { pelvis: {} } });
+    viewer.fitSAM3DJointRootLengthsToWorldKps = () => calls.push("roots");
+    viewer.fitSAM3DLimbLengthsToWorldKps = () => calls.push("limbs");
+    viewer.applySAM3DImport = () => calls.push("pose-import");
+    viewer.applyWorldKeypointImport = () => calls.push("world-import");
+
+    const proportions = viewer.analyzeSAM3DBodyProportions({ joint_coords: [] });
+
+    assert.deepEqual(proportions, { upper_arm_l: 0.7 });
+    assert.equal(calls[0], "auto-fit");
+    assert.equal(calls.filter(call => call === "roots").length, 6);
+    assert.equal(calls.filter(call => call === "limbs").length, 6);
+    assert.equal(calls.includes("pose-import"), false);
+    assert.equal(calls.includes("world-import"), false);
+});
+
 test("two-bone IK allows exact full extension without forced elbow bend", () => {
     assert.equal(clampTwoBoneReachDistance(1, 1), 1);
     assert.equal(clampTwoBoneReachDistance(1.2, 1), 1);

--- a/tests/test_mixamo_alignment.mjs
+++ b/tests/test_mixamo_alignment.mjs
@@ -5,10 +5,22 @@ import * as THREE from "../web/three.module.js";
 import { buildMixamoWorldKeypoints } from "../web/vnccs_mixamo_import.js";
 import {
     AnalyticIKSolver,
+    clipSAMProjectionFrameToViewport,
     clampTwoBoneReachDistance,
+    computeEquivalentPerspectiveZoom,
     computeSAMProjectionFrameFit,
     PoseViewerCore,
 } from "../web/vnccs_pose_studio_core.js";
+
+test("fixed Pose Studio FOV exactly compensates SAM FOV through camera zoom", () => {
+    const samFov = 38.942441885311695;
+    const poseStudioFov = 30;
+    const zoom = computeEquivalentPerspectiveZoom(samFov, poseStudioFov);
+    assert.ok(Number.isFinite(zoom));
+    const samProjectionScale = 1 / Math.tan((samFov * Math.PI / 180) * 0.5);
+    const ordinaryProjectionScale = zoom / Math.tan((poseStudioFov * Math.PI / 180) * 0.5);
+    assert.ok(Math.abs(samProjectionScale - ordinaryProjectionScale) < 1e-12);
+});
 
 const pointBone = (position) => ({
     position: new THREE.Vector3(...position),
@@ -686,25 +698,60 @@ test("SAM projection aligns shoulder-to-sole height instead of head height", () 
 
 test("SAM standard-camera fit measures again after applying camera rotation", () => {
     const calls = [];
+    const standardTargetFrame = {
+        bounds: { width: 1.4, height: 1.7, centerX: 0.1, centerY: -0.05 },
+        shoulder_y: 0.45,
+        bottom_y: -0.9,
+    };
     const viewer = Object.create(PoseViewerCore.prototype);
     viewer.getPose = () => ({ modelRotation: [1, 2, 3] });
     viewer.setModelRotation = (x, y, z) => calls.push(["rotate", x, y, z]);
-    viewer.computeSAM3DFrameCameraParams = (_data, _width, _height, _meshData, forceFallback) => {
-        calls.push(["measure", forceFallback]);
+    viewer.computeSAM3DFrameCameraParams = (
+        _data,
+        _width,
+        _height,
+        _meshData,
+        forceFallback,
+        targetFrame,
+    ) => {
+        calls.push(["measure", forceFallback, targetFrame]);
         return calls.filter(call => call[0] === "measure").length === 1
             ? { zoom: 0.8, offset_x: 0, offset_y: 0, yaw_deg: 20, pitch_deg: -10 }
             : { zoom: 1.2, offset_x: 2, offset_y: 3, yaw_deg: 20, pitch_deg: -10 };
     };
 
-    const result = viewer.fitSAM3DToStandardCamera({}, 1024, 1024, {});
+    const result = viewer.fitSAM3DToStandardCamera({}, 1024, 1024, {}, standardTargetFrame);
 
     assert.deepEqual(calls, [
-        ["measure", true],
+        ["measure", true, standardTargetFrame],
         ["rotate", 11, -18, 3],
-        ["measure", true],
+        ["measure", true, standardTargetFrame],
     ]);
     assert.equal(result.zoom, 1.2);
     assert.equal(result.offset_y, 3);
+});
+
+test("SAM standard target keeps only the body crop visible inside the viewport", () => {
+    const visible = clipSAMProjectionFrameToViewport({
+        width: 2.4,
+        height: 2.8,
+        centerX: -0.2,
+        centerY: 0.1,
+        depth: 8,
+    }, 0.45);
+
+    assert.deepEqual(visible, {
+        bounds: {
+            width: 2,
+            height: 2,
+            centerX: 0,
+            centerY: 0,
+            depth: 8,
+        },
+        shoulder_y: 0.45,
+        bottom_y: -1,
+        clipped: true,
+    });
 });
 
 test("SAM gaze targets move with the mannequin head without changing direction", () => {

--- a/tests/test_mixamo_alignment.mjs
+++ b/tests/test_mixamo_alignment.mjs
@@ -455,29 +455,6 @@ test("SAM automatic arm morph keeps the full source segment lengths without shor
     assert.ok(Math.abs(applied.forearm_r - 0.875) < 1e-8);
 });
 
-test("SAM proportion analysis converges body lengths without applying a pose", () => {
-    const calls = [];
-    const viewer = Object.create(PoseViewerCore.prototype);
-    viewer.bones = {};
-    viewer.skinnedMesh = {};
-    viewer.boneLengthParams = { upper_arm_l: 0.7 };
-    viewer.autoFitSAM3DBoneLengths = () => calls.push("auto-fit");
-    viewer._buildSAM3DImportTargets = () => ({ worldKps: { pelvis: {} } });
-    viewer.fitSAM3DJointRootLengthsToWorldKps = () => calls.push("roots");
-    viewer.fitSAM3DLimbLengthsToWorldKps = () => calls.push("limbs");
-    viewer.applySAM3DImport = () => calls.push("pose-import");
-    viewer.applyWorldKeypointImport = () => calls.push("world-import");
-
-    const proportions = viewer.analyzeSAM3DBodyProportions({ joint_coords: [] });
-
-    assert.deepEqual(proportions, { upper_arm_l: 0.7 });
-    assert.equal(calls[0], "auto-fit");
-    assert.equal(calls.filter(call => call === "roots").length, 6);
-    assert.equal(calls.filter(call => call === "limbs").length, 6);
-    assert.equal(calls.includes("pose-import"), false);
-    assert.equal(calls.includes("world-import"), false);
-});
-
 test("two-bone IK allows exact full extension without forced elbow bend", () => {
     assert.equal(clampTwoBoneReachDistance(1, 1), 1);
     assert.equal(clampTwoBoneReachDistance(1.2, 1), 1);

--- a/tests/test_pose_characters.mjs
+++ b/tests/test_pose_characters.mjs
@@ -5,6 +5,7 @@ import {
     DEFAULT_CHARACTER_COLORS,
     MAX_POSE_STUDIO_CHARACTERS,
     cameraFramingToCharacterTransform,
+    composeCameraFramingWithCharacterTransform,
     createPoseStudioCharacter,
     extractActiveCharacterTransformFromSceneAsset,
     extractActivePoseFromSceneAsset,
@@ -204,11 +205,13 @@ test("SAM projection cameras survive JSON serialization with finite values only"
     const source = {
         fov: 37.5,
         cameraPosition: { x: -1.25, y: 12.5, z: 42 },
+        projection_zoom: 0.75,
         ignored: "runtime-only",
     };
     assert.deepEqual(normalizeSAMProjectionFrame(source), {
         fov: 37.5,
         cameraPosition: { x: -1.25, y: 12.5, z: 42 },
+        projection_zoom: 0.75,
     });
     assert.equal(normalizeSAMProjectionFrame({
         fov: 0,
@@ -243,6 +246,15 @@ test("saved camera framing converts zoom around the model camera target", () => 
         y: pivot.y + 2 * -2,
         z: pivot.z,
     });
+});
+
+test("a measured viewport correction composes with the current character crop", () => {
+    const corrected = composeCameraFramingWithCharacterTransform(
+        { x: 0, y: 0, z: 0, zoom: 5.55 },
+        { zoom: 0.625, offset_x: 0, offset_y: 0 },
+        { x: 0, y: 10, z: 0 },
+    );
+    assert.ok(Math.abs(corrected.zoom - 3.46875) < 1e-8);
 });
 
 test("saved camera framing rejects incomplete data instead of inventing defaults", () => {

--- a/tests/test_pose_output_limits.py
+++ b/tests/test_pose_output_limits.py
@@ -40,6 +40,40 @@ POSE_STUDIO = _load_pose_studio_module()
 
 
 class PoseOutputLimitTests(unittest.TestCase):
+    def test_pose_image_analysis_mode_isolated_to_pose_manager(self):
+        self.assertEqual(POSE_STUDIO._pose_image_analysis_mode({}), "pose")
+        self.assertEqual(
+            POSE_STUDIO._pose_image_analysis_mode({"export": {"interface_mode": "studio"}}),
+            "pose",
+        )
+        self.assertEqual(
+            POSE_STUDIO._pose_image_analysis_mode({"export": {"interface_mode": "manager"}}),
+            "manager_proportions",
+        )
+        self.assertIsNone(
+            POSE_STUDIO._pose_image_analysis_mode({
+                "export": {
+                    "interface_mode": "manager",
+                    "manager_auto_analyze_proportions": False,
+                },
+            }),
+        )
+
+    def test_disabled_manager_analysis_never_calls_sam_frontend_path(self):
+        node = POSE_STUDIO.VNCCS_PoseStudio()
+        calls = []
+        node._apply_pose_image_via_frontend = lambda *_args, **_kwargs: calls.append(True)
+        state = {
+            "export": {
+                "interface_mode": "manager",
+                "manager_auto_analyze_proportions": False,
+            },
+        }
+
+        with self.assertRaisesRegex(RuntimeError, "did not receive images"):
+            node.generate(json.dumps(state), pose_image=object())
+        self.assertEqual(calls, [])
+
     def test_generate_rejects_oversized_view_before_rendering(self):
         state = {
             "export": {"view_width": POSE_STUDIO._POSE_OUTPUT_MAX_PIXELS + 1, "view_height": 1},

--- a/tests/test_widget_hardening.mjs
+++ b/tests/test_widget_hardening.mjs
@@ -50,6 +50,47 @@ test("Pose Studio upload rejects HTTP sync failures", () => {
     assert.match(normalSyncPath, /await reportPoseStudioSyncFailure\(nodeId, syncToken, e\)/);
 });
 
+test("SAM projection does not apply a second scale over the recovered camera", () => {
+    const start = poseStudioSource.indexOf("applySAM3DFrameCameraParams(poseData, meshData = null)");
+    const end = poseStudioSource.indexOf("\n    formatVideoTime(", start);
+    const method = poseStudioSource.slice(start, end);
+    const projectionStart = method.indexOf("setSAMProjectionCameraFrame?.(frameParams.sam_projection)");
+    const projectionBranch = method.slice(projectionStart);
+    assert.match(method, /setSAMProjectionCameraFrame\?\.\(frameParams\.sam_projection\)/);
+    assert.doesNotMatch(projectionBranch, /projectionFit|this\.exportParams\.cam_zoom\s*=\s*frameParams\.zoom/);
+    assert.doesNotMatch(projectionBranch, /this\.exportParams\.cam_zoom\s*=\s*1/);
+    assert.doesNotMatch(projectionBranch, /this\.exportParams\.cam_offset_[xy]\s*=\s*0/);
+});
+
+test("ordinary SAM framing reuses the exact projection with fixed Pose Studio FOV", () => {
+    const helperStart = poseStudioSource.indexOf("applySAM3DStandardCameraFit(poseData, meshData = null, standardTargetFrame = null)");
+    const methodStart = poseStudioSource.indexOf("applySAM3DFrameCameraParams(poseData, meshData = null)");
+    const methodEnd = poseStudioSource.indexOf("\n    formatVideoTime(", methodStart);
+    const helper = poseStudioSource.slice(helperStart, methodStart);
+    const method = poseStudioSource.slice(methodStart, methodEnd);
+
+    assert.match(helper, /neutralTransform = \{ x: 0, y: 0, z: 0, zoom: 1 \}/);
+    assert.match(helper, /fitSAM3DToStandardCamera/);
+    assert.match(helper, /meshData,[\s\S]*standardTargetFrame/);
+    assert.match(helper, /cameraFramingToCharacterTransform\(framing, pivot\)/);
+    assert.match(helper, /for \(let iteration = 0; iteration < 4; iteration \+= 1\)/);
+    assert.match(helper, /composeCameraFramingWithCharacterTransform/);
+    assert.match(helper, /true,[\s\S]*standardTargetFrame/);
+    assert.doesNotMatch(helper, /currentZoom/);
+    assert.match(method, /if \(!this\.exportParams\.samApplyCamera\)/);
+    assert.match(method, /buildEquivalentPerspectiveProjectionFrame/);
+    assert.match(method, /frameParams\.sam_projection,[\s\S]*POSE_STUDIO_CAPTURE_FOV/);
+    assert.match(poseStudioCoreSource, /projection_zoom: projectionZoom/);
+    const directStart = method.indexOf("if (frameParams.sam_projection)");
+    const directEnd = method.indexOf("this.viewer?.setSAMProjectionCameraFrame?.(null)", directStart);
+    const directBranch = method.slice(directStart, directEnd);
+    assert.doesNotMatch(directBranch, /applySAM3DStandardCameraFit|sam_standard_target/);
+});
+
+test("SAM camera fitting does not emit runtime diagnostics", () => {
+    assert.doesNotMatch(poseStudioSource, /SAMCameraFit|_logSAMCameraFit|_samCameraFitTraceSeq/);
+});
+
 
 test("Pose Library image previews preserve their aspect ratio without cropping", () => {
     const rule = poseStudioSource.match(/\.vnccs-ps-library-item-preview img\s*\{([^}]*)\}/)?.[1] || "";
@@ -210,7 +251,7 @@ test("Pose Manager keeps the pose image input and gates automatic proportion ana
     assert.match(modeMethod, /_vnccsEnsurePoseImageInput/);
     assert.doesNotMatch(modeMethod, /SetPoseImageInputDisabled/);
     const ensureStart = poseStudioSource.indexOf("const ensurePoseImageInput = (node) =>");
-    const ensureEnd = poseStudioSource.indexOf("\n\n        const setCameraPromptInputDisabled", ensureStart);
+    const ensureEnd = poseStudioSource.indexOf("const setCameraPromptInputDisabled", ensureStart);
     const ensureMethod = poseStudioSource.slice(ensureStart, ensureEnd);
     assert.match(ensureMethod, /addInput\("pose_image", "IMAGE"\)/);
     assert.doesNotMatch(ensureMethod, /removeInput|disconnectInput/);

--- a/tests/test_widget_hardening.mjs
+++ b/tests/test_widget_hardening.mjs
@@ -196,6 +196,59 @@ test("Pose Manager regenerates missing previews after worker model load and mode
 });
 
 
+test("Pose Manager keeps the pose image input and gates automatic proportion analysis", () => {
+    assert.match(poseStudioSource, /manager_auto_analyze_proportions: true/);
+    assert.match(poseStudioSource, /autoAnalyzeText\.textContent = "Auto-analyze proportions"/);
+    assert.match(
+        poseStudioSource,
+        /manager_auto_analyze_proportions = autoAnalyzeCheckbox\.checked;[\s\S]*syncToNode\(false, \{ skipCapture: true \}\)/,
+    );
+
+    const modeStart = poseStudioSource.indexOf("setInterfaceMode(mode, { sync = true } = {})");
+    const modeEnd = poseStudioSource.indexOf("\n    applyInterfaceMode()", modeStart);
+    const modeMethod = poseStudioSource.slice(modeStart, modeEnd);
+    assert.match(modeMethod, /_vnccsEnsurePoseImageInput/);
+    assert.doesNotMatch(modeMethod, /SetPoseImageInputDisabled/);
+    const ensureStart = poseStudioSource.indexOf("const ensurePoseImageInput = (node) =>");
+    const ensureEnd = poseStudioSource.indexOf("\n\n        const setCameraPromptInputDisabled", ensureStart);
+    const ensureMethod = poseStudioSource.slice(ensureStart, ensureEnd);
+    assert.match(ensureMethod, /addInput\("pose_image", "IMAGE"\)/);
+    assert.doesNotMatch(ensureMethod, /removeInput|disconnectInput/);
+});
+
+
+test("Pose Manager SAM input applies proportions without replacing managed poses", () => {
+    const managerStart = poseStudioSource.indexOf("async applySAM3DProportionsToPoseManager(poseData)");
+    const managerEnd = poseStudioSource.indexOf("\n    applySAM3DMeshOverlayFit", managerStart);
+    const managerMethod = poseStudioSource.slice(managerStart, managerEnd);
+    assert.match(managerMethod, /manager_auto_analyze_proportions === false/);
+    assert.match(managerMethod, /viewer\.setPose\(\{\}, true\)/);
+    assert.match(managerMethod, /analyzeSAM3DBodyProportions/);
+    assert.doesNotMatch(managerMethod, /applySAM3DImport/);
+    assert.doesNotMatch(managerMethod, /commitViewerPoseToCurrentEditor/);
+    assert.match(managerMethod, /for \(const pose of this\.poses \|\| \[\]\)/);
+    assert.match(managerMethod, /delete pose\.bonePositions/);
+    assert.match(managerMethod, /this\.applyAgeCameraFit\(\);[\s\S]*scheduleAllManagerPreviewRefresh\(\)/);
+    assert.match(managerMethod, /await this\.awaitManagerPreviewRefresh\(generation\)/);
+
+    const coreStart = poseStudioCoreSource.indexOf("analyzeSAM3DBodyProportions(data)");
+    const coreEnd = poseStudioCoreSource.indexOf("\n    fitSAM3DJointRootLengthsToWorldKps", coreStart);
+    const coreMethod = poseStudioCoreSource.slice(coreStart, coreEnd);
+    assert.match(coreMethod, /autoFitSAM3DBoneLengths\(data\)/);
+    assert.match(coreMethod, /fitSAM3DJointRootLengthsToWorldKps\(worldKps\)/);
+    assert.match(coreMethod, /fitSAM3DLimbLengthsToWorldKps\(worldKps\)/);
+    assert.doesNotMatch(coreMethod, /applyWorldKeypointImport|applySAM3DImport/);
+
+    const eventStart = poseStudioSource.indexOf('api.addEventListener("vnccs_apply_sam3d_pose"');
+    const eventEnd = poseStudioSource.indexOf("\n    },\n\n    async beforeRegisterNodeDef", eventStart);
+    const eventMethod = poseStudioSource.slice(eventStart, eventEnd);
+    assert.match(eventMethod, /applyMode === "manager_proportions"/);
+    assert.match(eventMethod, /applySAM3DProportionsToPoseManager\(poseData\)/);
+    assert.match(eventMethod, /widget\.syncToNode\(true, \{[\s\S]*executionCapture: true/);
+    assert.match(eventMethod, /viewer\.applySAM3DImport\(/, "ordinary Pose Studio import must remain intact");
+});
+
+
 test("Pose Manager waits for the real skin texture before capture", () => {
     const refreshStart = poseStudioSource.indexOf("refreshAllManagerPreviews(generation");
     const refreshEnd = poseStudioSource.indexOf("\n    updateExistingPoseManagerDetailCards", refreshStart);

--- a/tests/test_widget_hardening.mjs
+++ b/tests/test_widget_hardening.mjs
@@ -222,22 +222,26 @@ test("Pose Manager SAM input applies proportions without replacing managed poses
     const managerEnd = poseStudioSource.indexOf("\n    applySAM3DMeshOverlayFit", managerStart);
     const managerMethod = poseStudioSource.slice(managerStart, managerEnd);
     assert.match(managerMethod, /manager_auto_analyze_proportions === false/);
-    assert.match(managerMethod, /viewer\.setPose\(\{\}, true\)/);
-    assert.match(managerMethod, /analyzeSAM3DBodyProportions/);
-    assert.doesNotMatch(managerMethod, /applySAM3DImport/);
+    assert.match(
+        managerMethod,
+        /viewer\.applySAM3DImport\([\s\S]*poseForAnalysis,[\s\S]*\{ recordState: false \}/,
+    );
+    assert.match(managerMethod, /applySAM3DMeshOverlayFit\(fitData\.meshData, poseForAnalysis\)/);
     assert.doesNotMatch(managerMethod, /commitViewerPoseToCurrentEditor/);
+    assert.doesNotMatch(managerMethod, /this\.poses\[this\.activeTab\]\s*=\s*poseForAnalysis/);
     assert.match(managerMethod, /for \(const pose of this\.poses \|\| \[\]\)/);
     assert.match(managerMethod, /delete pose\.bonePositions/);
+    assert.match(managerMethod, /finally \{[\s\S]*viewer\.setPose\(restoredPose, true\)/);
+    assert.match(managerMethod, /viewer\.applyBoneLengthScales\?\.\(\)/);
+    assert.match(managerMethod, /previousSAMVisualState[\s\S]*setSAMProjectionCameraFrame/);
     assert.match(managerMethod, /this\.applyAgeCameraFit\(\);[\s\S]*scheduleAllManagerPreviewRefresh\(\)/);
     assert.match(managerMethod, /await this\.awaitManagerPreviewRefresh\(generation\)/);
 
-    const coreStart = poseStudioCoreSource.indexOf("analyzeSAM3DBodyProportions(data)");
-    const coreEnd = poseStudioCoreSource.indexOf("\n    fitSAM3DJointRootLengthsToWorldKps", coreStart);
-    const coreMethod = poseStudioCoreSource.slice(coreStart, coreEnd);
-    assert.match(coreMethod, /autoFitSAM3DBoneLengths\(data\)/);
-    assert.match(coreMethod, /fitSAM3DJointRootLengthsToWorldKps\(worldKps\)/);
-    assert.match(coreMethod, /fitSAM3DLimbLengthsToWorldKps\(worldKps\)/);
-    assert.doesNotMatch(coreMethod, /applyWorldKeypointImport|applySAM3DImport/);
+    const importIndex = managerMethod.indexOf("this.viewer.applySAM3DImport(");
+    const overlayIndex = managerMethod.indexOf("this.applySAM3DMeshOverlayFit(", importIndex);
+    const syncIndex = managerMethod.indexOf("this.syncMeshProportionSlidersFromViewer()", overlayIndex);
+    const restoreIndex = managerMethod.indexOf("this.viewer.setPose(restoredPose, true)", syncIndex);
+    assert.ok(importIndex >= 0 && overlayIndex > importIndex && syncIndex > overlayIndex && restoreIndex > syncIndex);
 
     const eventStart = poseStudioSource.indexOf('api.addEventListener("vnccs_apply_sam3d_pose"');
     const eventEnd = poseStudioSource.indexOf("\n    },\n\n    async beforeRegisterNodeDef", eventStart);

--- a/web/vnccs_pose_characters.mjs
+++ b/web/vnccs_pose_characters.mjs
@@ -56,13 +56,22 @@ export function normalizeSAMProjectionFrame(source) {
     const x = Number(cameraPosition?.x);
     const y = Number(cameraPosition?.y);
     const z = Number(cameraPosition?.z);
+    const hasProjectionZoom = source.projection_zoom !== undefined
+        && source.projection_zoom !== null;
+    const projectionZoom = Number(source.projection_zoom ?? 1);
     if (
         !Number.isFinite(fov)
         || fov <= 0
         || fov >= 179
         || ![x, y, z].every(Number.isFinite)
+        || !Number.isFinite(projectionZoom)
+        || projectionZoom <= 0
     ) return null;
-    return { fov, cameraPosition: { x, y, z } };
+    return {
+        fov,
+        cameraPosition: { x, y, z },
+        ...(hasProjectionZoom ? { projection_zoom: projectionZoom } : {}),
+    };
 }
 
 export function cameraFramingToCharacterTransform(cameraParams, pivot) {
@@ -93,6 +102,34 @@ export function cameraFramingToCharacterTransform(cameraParams, pivot) {
         throw new RangeError("Pose framing is outside the supported character transform range.");
     }
     return transform;
+}
+
+export function composeCameraFramingWithCharacterTransform(
+    currentTransformSource,
+    cameraParams,
+    pivot,
+) {
+    const current = normalizeCharacterTransform(currentTransformSource);
+    const values = [
+        cameraParams?.zoom,
+        cameraParams?.offset_x,
+        cameraParams?.offset_y,
+        pivot?.x,
+        pivot?.y,
+        pivot?.z,
+    ].map(Number);
+    if (values.some(value => !Number.isFinite(value))) {
+        throw new TypeError("Pose framing requires finite zoom, offsets, and model pivot.");
+    }
+    const [zoom, offsetX, offsetY, pivotX, pivotY, pivotZ] = values;
+    if (zoom <= 0) throw new RangeError("Pose framing zoom must be positive.");
+
+    return normalizeCharacterTransform({
+        x: zoom * current.x + (1 - zoom) * pivotX + zoom * offsetX,
+        y: zoom * current.y + (1 - zoom) * pivotY + zoom * offsetY,
+        z: zoom * current.z + (1 - zoom) * pivotZ,
+        zoom: zoom * current.zoom,
+    });
 }
 
 export function nextCharacterId(characters = []) {

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -6,7 +6,11 @@
 
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
-import { PoseViewerCore } from "./vnccs_pose_studio_core.js";
+import {
+    POSE_STUDIO_CAPTURE_FOV,
+    PoseViewerCore,
+    buildEquivalentPerspectiveProjectionFrame,
+} from "./vnccs_pose_studio_core.js?v=20260824.9";
 import {
     cameraPromptToSkydomeRotation,
 } from "./vnccs_camera_control_utils.mjs";
@@ -18,6 +22,7 @@ import {
     DEFAULT_CHARACTER_COLORS,
     MAX_POSE_STUDIO_CHARACTERS,
     cameraFramingToCharacterTransform,
+    composeCameraFramingWithCharacterTransform,
     createPoseStudioCharacter,
     extractActiveCharacterTransformFromSceneAsset,
     extractActivePoseFromSceneAsset,
@@ -29,7 +34,7 @@ import {
     normalizePoseStudioCharacters,
     normalizeSAMProjectionFrame,
     serializePoseStudioCharacter,
-} from "./vnccs_pose_characters.mjs?v=20260802.3";
+} from "./vnccs_pose_characters.mjs?v=20260824.5";
 import {
     MAX_VIDEO_POSE_SAMPLES,
     canvasToBlob,
@@ -9599,6 +9604,86 @@ class PoseStudioWidget {
         return ok;
     }
 
+    applySAM3DStandardCameraFit(poseData, meshData = null, standardTargetFrame = null) {
+        const character = this.getActiveCharacter();
+        const pivot = this.viewer?.sceneCameraTarget;
+        if (!character || !pivot) return false;
+
+        // The standard-camera solver returns framing for the mesh transform it
+        // measures. Always measure a neutral character and convert that result
+        // once to the character-space transform used by Pose Studio. Measuring
+        // the previous crop and then multiplying it back in made every import
+        // state-dependent and could shrink compact seated poses repeatedly.
+        const previousTransform = normalizeCharacterTransform(character.transform);
+        const previousAngles = {
+            yaw_deg: Number(this.exportParams.cam_yaw_deg) || 0,
+            pitch_deg: Number(this.exportParams.cam_pitch_deg) || 0,
+        };
+        const neutralTransform = { x: 0, y: 0, z: 0, zoom: 1 };
+        this.viewer.setActiveCharacterAppearance({
+            color: character.color,
+            transform: neutralTransform,
+        });
+        this.exportParams.cam_yaw_deg = 0;
+        this.exportParams.cam_pitch_deg = 0;
+        this.applyCameraToViewer(true);
+
+        const framing = this.viewer?.fitSAM3DToStandardCamera?.(
+            poseData,
+            this.exportParams.view_width || 1024,
+            this.exportParams.view_height || 1024,
+            meshData,
+            standardTargetFrame,
+        );
+        if (!framing) {
+            this.exportParams.cam_yaw_deg = previousAngles.yaw_deg;
+            this.exportParams.cam_pitch_deg = previousAngles.pitch_deg;
+            this.viewer.setActiveCharacterAppearance({
+                color: character.color,
+                transform: previousTransform,
+            });
+            this.applyCameraToViewer(true);
+            return false;
+        }
+
+        let transform = cameraFramingToCharacterTransform(framing, pivot);
+        // PerspectiveCamera.zoom and scaling a posed mesh are not exactly
+        // equivalent when the body spans a large depth range. Apply the first
+        // estimate, measure the visible viewport crop, and converge on the
+        // fixed SAM target without changing FOV or revealing off-frame limbs.
+        for (let iteration = 0; iteration < 4; iteration += 1) {
+            this.viewer.setActiveCharacterAppearance({
+                color: character.color,
+                transform,
+            });
+            const correction = this.viewer?.computeSAM3DFrameCameraParams?.(
+                poseData,
+                this.exportParams.view_width || 1024,
+                this.exportParams.view_height || 1024,
+                meshData,
+                true,
+                standardTargetFrame,
+            );
+            if (!correction) break;
+            if (
+                Math.abs(Number(correction.zoom) - 1) < 1e-3
+                && Math.abs(Number(correction.offset_x)) < 1e-3
+                && Math.abs(Number(correction.offset_y)) < 1e-3
+            ) break;
+            transform = composeCameraFramingWithCharacterTransform(
+                transform,
+                correction,
+                pivot,
+            );
+        }
+        this.applyLibraryPoseTransform(transform, {
+            yaw_deg: 0,
+            pitch_deg: 0,
+        });
+        this.updateRotationSliders();
+        return true;
+    }
+
     applySAM3DFrameCameraParams(poseData, meshData = null) {
         const frameParams = this.viewer?.computeSAM3DFrameCameraParams?.(
             poseData,
@@ -9611,18 +9696,49 @@ class PoseStudioWidget {
             this._samCameraModeActive = false;
             return false;
         }
-        // Pose extraction and camera matching are separate operations. Keep the
-        // current user camera unless SAM camera application was explicitly enabled.
+        // Ordinary mode uses the exact recovered SAM view and keeps Pose
+        // Studio's fixed FOV. PerspectiveCamera.zoom compensates the FOV
+        // difference exactly, so there is no bbox fitting or seated-pose
+        // approximation in this path.
         if (!this.exportParams.samApplyCamera) {
-            this.viewer?.setSAMProjectionCameraFrame?.(null);
-            this._samCameraModeActive = false;
             this._samCamBannerVisible = false;
             this._samCamDisplayActive = true;
             this._samCamPreParams = null;
+            this._updateSAMCameraBanner();
+            if (frameParams.sam_projection) {
+                const equivalentProjection = buildEquivalentPerspectiveProjectionFrame(
+                    frameParams.sam_projection,
+                    POSE_STUDIO_CAPTURE_FOV,
+                );
+                if (equivalentProjection) {
+                    this.viewer?.setSAMProjectionCameraFrame?.(equivalentProjection);
+                    this._samCameraModeActive = true;
+                    this._samCamStoredProjectionFrame = equivalentProjection;
+                    this.exportParams.cam_yaw_deg = 0;
+                    this.exportParams.cam_pitch_deg = 0;
+                    this.persistActivePoseCameraParams();
+                    this._samCamStoredParams = {
+                        cam_zoom: this.exportParams.cam_zoom,
+                        cam_offset_x: this.exportParams.cam_offset_x,
+                        cam_offset_y: this.exportParams.cam_offset_y,
+                        cam_yaw_deg: 0,
+                        cam_pitch_deg: 0,
+                    };
+                    this.syncCameraWidgets();
+                    this.applyCameraToViewer(true);
+                    this.viewer.setCameraParams(this.currentCameraParams());
+                    return true;
+                }
+            }
+            this.viewer?.setSAMProjectionCameraFrame?.(null);
+            this._samCameraModeActive = false;
             this._samCamStoredParams = null;
             this._samCamStoredProjectionFrame = null;
-            this._updateSAMCameraBanner();
-            return false;
+            return this.applySAM3DStandardCameraFit(
+                poseData,
+                meshData,
+                frameParams.sam_standard_target || null,
+            );
         }
         // A pose pinned to SAM world joints only remains point-for-point aligned in the
         // source image when it is rendered by the same projection.  Do not add a second
@@ -9664,9 +9780,9 @@ class PoseStudioWidget {
             };
         }
 
-        this.exportParams.cam_zoom = 1;
-        this.exportParams.cam_offset_x = 0;
-        this.exportParams.cam_offset_y = 0;
+        // The projection frame was reconstructed from the character's current
+        // world transform. Keep that transform; only remove the ordinary orbit
+        // angles because the recovered projection already contains the view.
         this.exportParams.cam_yaw_deg = 0;
         this.exportParams.cam_pitch_deg = 0;
         this.persistActivePoseCameraParams();
@@ -14424,7 +14540,6 @@ class PoseStudioWidget {
             const debugLights = isDebugExecution && debugLightingMode === "random"
                 ? this.generateRandomDebugLights()
                 : null;
-
             if (fullCapture) {
                 const originalTab = this.activeTab;
                 const captureBatchStarted = this.viewer.beginCaptureBatch?.(w, h) === true;
@@ -14528,7 +14643,6 @@ class PoseStudioWidget {
                 this.updateCharacterScene(animationMode
                     ? { frame: this.animationState.currentFrame }
                     : { poseIndex: this.activeTab });
-
                 if (isOriginalLighting) {
                     this.viewer.updateLights([{ type: 'ambient', color: '#ffffff', intensity: 1.0 }]);
                 } else {

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -9506,14 +9506,30 @@ class PoseStudioWidget {
         const poseForAnalysis = fitData?.poseData || poseData;
         const originalPose = this.viewer.getPose();
         const restoredPose = JSON.parse(JSON.stringify(originalPose || {}));
+        const previousSAMVisualState = {
+            poseData: this._lastSAM3DPoseData || null,
+            meshData: this._lastSAM3DMeshData || null,
+            meshVisible: !!this.viewer.samMeshOverlayVisible,
+            worldKps: this.viewer._hmr2WorldKps || null,
+            figureVisible: this.viewer._hmr2FigureGroup?.visible !== false,
+            projectionFrame: this.viewer._samProjectionCameraFrame || null,
+            importedFootRotations: this.viewer._sam3dImportedFootLocalRotations || null,
+        };
 
-        // Measure against the neutral rig so an existing bent or translated
-        // manager pose cannot bias the detected body proportions.
-        this.viewer.setPose({}, true);
         try {
-            const proportions = this.viewer.analyzeSAM3DBodyProportions?.(poseForAnalysis);
-            if (!proportions) {
-                throw new Error("Failed to analyze SAM 3D Body proportions.");
+            // Run the exact same fitting sequence as an ordinary Pose Studio
+            // import. The detected pose is temporary; only the fitted body
+            // proportions are copied into manager state below.
+            const applied = this.viewer.applySAM3DImport(
+                poseForAnalysis,
+                this._shoulderYOffset || 0,
+                { recordState: false },
+            );
+            if (!applied) {
+                throw new Error("Failed to fit SAM 3D Body proportions.");
+            }
+            if (fitData?.meshData) {
+                this.applySAM3DMeshOverlayFit(fitData.meshData, poseForAnalysis);
             }
             this.syncMeshProportionSlidersFromViewer();
 
@@ -9537,9 +9553,31 @@ class PoseStudioWidget {
             }
         } finally {
             this.viewer.setPose(restoredPose, true);
+            this.viewer.applyBoneLengthScales?.();
+            this.viewer.updateFootScale?.(Number(this.meshParams.foot_size) || 1);
+            this.viewer._sam3dImportedFootLocalRotations = previousSAMVisualState.importedFootRotations;
+
+            if (previousSAMVisualState.meshData && previousSAMVisualState.poseData) {
+                this.viewer.setSAMMeshOverlayData?.(
+                    previousSAMVisualState.meshData,
+                    previousSAMVisualState.poseData,
+                );
+                this.viewer.setSAMMeshOverlayVisible?.(previousSAMVisualState.meshVisible);
+            } else {
+                this.viewer.clearSAMMeshOverlay?.();
+                this.viewer._clearImportedFigureGroup?.("_hmr2FigureGroup");
+                this.viewer._hmr2WorldKps = null;
+            }
+            if (previousSAMVisualState.worldKps) {
+                this.viewer._hmr2WorldKps = previousSAMVisualState.worldKps;
+                this.viewer._drawHMR2Figure?.(previousSAMVisualState.worldKps);
+                if (this.viewer._hmr2FigureGroup) {
+                    this.viewer._hmr2FigureGroup.visible = previousSAMVisualState.figureVisible;
+                }
+            }
+            this.viewer.setSAMProjectionCameraFrame?.(previousSAMVisualState.projectionFrame);
         }
 
-        this.viewer.applyBoneLengthScales?.();
         this.updateCharacterScene({ poseIndex: this.activeTab });
         this.refreshPoseManagerControls();
 

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -2147,6 +2147,26 @@ const STYLES = `
     flex-shrink: 0;
 }
 
+.vnccs-ps-manager-auto-analysis {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    color: var(--ps-text-muted);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.4px;
+    text-transform: uppercase;
+    cursor: pointer;
+    user-select: none;
+    white-space: nowrap;
+}
+
+.vnccs-ps-manager-auto-analysis input {
+    margin: 0;
+    accent-color: var(--ps-accent);
+    cursor: pointer;
+}
+
 .vnccs-ps-manager-body {
     flex: 1;
     min-height: 0;
@@ -4132,13 +4152,14 @@ class PoseStudioWidget {
             debugKeepLighting: false, // Use manual lighting in debug mode
             debugShowSAMHelper: false, // Show imported SAM skeleton overlay in the viewer
             debugShowSAMMeshOverlay: false, // Show postprocessed SAM render mesh overlay
-            samApplyCamera: true, // SAM imports use the detector camera for exact image-space alignment
+            samApplyCamera: false, // Opt in: pose analysis must not replace the user's camera automatically
             keepOriginalLighting: false, // Override to clean white lighting, no prompts
             user_prompt: "",
             prompt_template: "Draw character from image2\n<lighting>\n<user_prompt>",
             skin_type: "naked", // naked | naked_marks | dummy_white
             background_url: null,
             interface_mode: "studio",
+            manager_auto_analyze_proportions: true,
             editor_mode: "image",
             hand_controls_v2: true,
             directional_skydome_enabled: false,
@@ -4316,6 +4337,21 @@ class PoseStudioWidget {
         const actions = document.createElement("div");
         actions.className = "vnccs-ps-manager-actions";
 
+        const autoAnalyzeLabel = document.createElement("label");
+        autoAnalyzeLabel.className = "vnccs-ps-manager-auto-analysis";
+        autoAnalyzeLabel.title = "Analyze the connected pose image and apply only its body proportions to every managed pose.";
+        const autoAnalyzeCheckbox = document.createElement("input");
+        autoAnalyzeCheckbox.type = "checkbox";
+        autoAnalyzeCheckbox.checked = this.exportParams.manager_auto_analyze_proportions !== false;
+        autoAnalyzeCheckbox.addEventListener("change", () => {
+            this.exportParams.manager_auto_analyze_proportions = autoAnalyzeCheckbox.checked;
+            this.syncToNode(false, { skipCapture: true });
+        });
+        const autoAnalyzeText = document.createElement("span");
+        autoAnalyzeText.textContent = "Auto-analyze proportions";
+        autoAnalyzeLabel.append(autoAnalyzeCheckbox, autoAnalyzeText);
+        this.managerAutoAnalyzeCheckbox = autoAnalyzeCheckbox;
+
         const addBtn = document.createElement("button");
         addBtn.className = "vnccs-ps-btn primary";
         addBtn.type = "button";
@@ -4325,7 +4361,7 @@ class PoseStudioWidget {
             this.setInterfaceMode("manager");
         });
 
-        actions.appendChild(addBtn);
+        actions.append(autoAnalyzeLabel, addBtn);
         header.appendChild(title);
         header.appendChild(actions);
 
@@ -4600,6 +4636,9 @@ class PoseStudioWidget {
     }
 
     refreshPoseManagerControls() {
+        if (this.managerAutoAnalyzeCheckbox) {
+            this.managerAutoAnalyzeCheckbox.checked = this.exportParams.manager_auto_analyze_proportions !== false;
+        }
         if (this.managerGenderBtns) {
             const isFemale = this.meshParams.gender < 0.5;
             this.managerGenderBtns.male.classList.toggle("active", !isFemale);
@@ -6792,7 +6831,7 @@ class PoseStudioWidget {
         }
         this.interfaceMode = normalized;
         this.exportParams.interface_mode = normalized === "studio" ? "studio" : "manager";
-        this.node?._vnccsSetPoseImageInputDisabled?.(normalized !== "studio");
+        this.node?._vnccsEnsurePoseImageInput?.();
         this.applyInterfaceMode();
         if (normalized === "manager") {
             this.refreshPoseManagerControls();
@@ -7117,9 +7156,9 @@ class PoseStudioWidget {
     }
 
     scheduleAllManagerPreviewRefresh() {
-        if (this.interfaceMode !== "manager" && this.interfaceMode !== "managerDetail") return;
-        if (!this.viewer?.isInitialized?.()) return;
-        if (!this.poses?.length) return;
+        if (this.interfaceMode !== "manager" && this.interfaceMode !== "managerDetail") return 0;
+        if (!this.viewer?.isInitialized?.()) return 0;
+        if (!this.poses?.length) return 0;
         this._managerPreviewRefreshGeneration = (this._managerPreviewRefreshGeneration || 0) + 1;
         // A new model/camera generation invalidates every previously rendered
         // card. Resuming in the middle mixes old and new AGE/head-size results.
@@ -7133,6 +7172,19 @@ class PoseStudioWidget {
             this._managerPreviewRefreshFrame = null;
             this.refreshAllManagerPreviews(generation);
         });
+        return generation;
+    }
+
+    async awaitManagerPreviewRefresh(generation, timeoutMs = 120000) {
+        if (!generation) return false;
+        const deadline = Date.now() + timeoutMs;
+        while (Date.now() < deadline) {
+            if ((this._managerPreviewRefreshCompletedGeneration || 0) >= generation) {
+                return true;
+            }
+            await new Promise(resolve => setTimeout(resolve, 16));
+        }
+        throw new Error("Pose Manager previews are still refreshing.");
     }
 
     computePoseManagerCaptureFraming(width, height, poseCamera) {
@@ -7253,6 +7305,7 @@ class PoseStudioWidget {
             });
         } else {
             this._managerPreviewRefreshNextIndex = 0;
+            this._managerPreviewRefreshCompletedGeneration = generation;
         }
     }
 
@@ -9441,6 +9494,63 @@ class PoseStudioWidget {
         }
     }
 
+    async applySAM3DProportionsToPoseManager(poseData) {
+        if (!this.viewer?.isInitialized?.()) {
+            throw new Error("Pose viewer is not ready.");
+        }
+        if (this.exportParams.manager_auto_analyze_proportions === false) {
+            return false;
+        }
+
+        const fitData = await this.prepareSAM3DRenderFit(poseData);
+        const poseForAnalysis = fitData?.poseData || poseData;
+        const originalPose = this.viewer.getPose();
+        const restoredPose = JSON.parse(JSON.stringify(originalPose || {}));
+
+        // Measure against the neutral rig so an existing bent or translated
+        // manager pose cannot bias the detected body proportions.
+        this.viewer.setPose({}, true);
+        try {
+            const proportions = this.viewer.analyzeSAM3DBodyProportions?.(poseForAnalysis);
+            if (!proportions) {
+                throw new Error("Failed to analyze SAM 3D Body proportions.");
+            }
+            this.syncMeshProportionSlidersFromViewer();
+
+            // Body-shape edits invalidate saved absolute IK/root positions. Keep
+            // every managed pose's rotations while allowing the new rig lengths
+            // to take effect consistently across all cards.
+            for (const pose of this.poses || []) {
+                if (!pose) continue;
+                delete pose.hipBonePosition;
+                delete pose.bonePositions;
+                delete pose.ikEffectorPositions;
+                delete pose.poleTargetPositions;
+            }
+            for (const key of [
+                "hipBonePosition",
+                "bonePositions",
+                "ikEffectorPositions",
+                "poleTargetPositions",
+            ]) {
+                delete restoredPose[key];
+            }
+        } finally {
+            this.viewer.setPose(restoredPose, true);
+        }
+
+        this.viewer.applyBoneLengthScales?.();
+        this.updateCharacterScene({ poseIndex: this.activeTab });
+        this.refreshPoseManagerControls();
+
+        // Reuse the same normalization path as an age change, then regenerate
+        // every manager card only after the proportions and framing are final.
+        this.applyAgeCameraFit();
+        const generation = this.scheduleAllManagerPreviewRefresh();
+        await this.awaitManagerPreviewRefresh(generation);
+        return true;
+    }
+
     applySAM3DMeshOverlayFit(meshData, poseData) {
         if (!meshData || !this.viewer?.setSAMMeshOverlayData) return false;
         const ok = this.viewer.setSAMMeshOverlayData(meshData, poseData);
@@ -9461,6 +9571,19 @@ class PoseStudioWidget {
         if (!frameParams) {
             this.viewer?.setSAMProjectionCameraFrame?.(null);
             this._samCameraModeActive = false;
+            return false;
+        }
+        // Pose extraction and camera matching are separate operations. Keep the
+        // current user camera unless SAM camera application was explicitly enabled.
+        if (!this.exportParams.samApplyCamera) {
+            this.viewer?.setSAMProjectionCameraFrame?.(null);
+            this._samCameraModeActive = false;
+            this._samCamBannerVisible = false;
+            this._samCamDisplayActive = true;
+            this._samCamPreParams = null;
+            this._samCamStoredParams = null;
+            this._samCamStoredProjectionFrame = null;
+            this._updateSAMCameraBanner();
             return false;
         }
         // A pose pinned to SAM world joints only remains point-for-point aligned in the
@@ -9503,7 +9626,6 @@ class PoseStudioWidget {
             };
         }
 
-        this.exportParams.samApplyCamera = true;
         this.exportParams.cam_zoom = 1;
         this.exportParams.cam_offset_x = 0;
         this.exportParams.cam_offset_y = 0;
@@ -12628,6 +12750,9 @@ class PoseStudioWidget {
         samCamCheckbox.checked = !!this.exportParams.samApplyCamera;
         samCamCheckbox.onchange = () => {
             this.exportParams.samApplyCamera = samCamCheckbox.checked;
+            if (!samCamCheckbox.checked && this._samCamBannerVisible && this._samCamDisplayActive) {
+                this._toggleSAMCameraDisplay();
+            }
             this._updateSAMCameraBanner();
             this.syncToNode(false);
         };
@@ -15018,6 +15143,7 @@ app.registerExtension({
             const nodeId = event.detail.node_id;
             const poseData = event.detail.pose_data;
             const cameraPrompt = String(event.detail.camera_prompt ?? "");
+            const applyMode = String(event.detail.apply_mode ?? "pose");
             const syncToken = String(event.detail.sync_token ?? "");
             const node = app.graph.getNodeById(nodeId);
             if (!node?.studioWidget || !poseData) return;
@@ -15026,6 +15152,18 @@ app.registerExtension({
                 const widget = node.studioWidget;
                 if (!widget.viewer || !widget.viewer.isInitialized()) {
                     await widget.loadModel();
+                }
+
+                if (applyMode === "manager_proportions") {
+                    await widget.applySAM3DProportionsToPoseManager(poseData);
+                    widget.setSkydomeFromCameraPrompt(cameraPrompt, { force: true });
+                    widget.syncToNode(true, {
+                        cameraPrompt,
+                        executionCapture: true,
+                    });
+                    const response = await uploadPoseStudioSync(node, nodeId, syncToken);
+                    await requirePoseStudioSyncResponse(response);
+                    return;
                 }
 
                 const fitData = await widget.prepareSAM3DRenderFit(poseData);
@@ -15061,6 +15199,9 @@ app.registerExtension({
                 });
                 await uploadPoseStudioSync(node, nodeId, syncToken);
             } catch (e) {
+                if (applyMode === "manager_proportions") {
+                    await reportPoseStudioSyncFailure(nodeId, syncToken, e);
+                }
                 console.error("[VNCCS] SAM3D pose_image apply error:", e);
             }
         });
@@ -15115,27 +15256,13 @@ app.registerExtension({
             app.graph?.setDirtyCanvas?.(true, true);
         };
 
-        const setPoseImageInputDisabled = (node, disabled) => {
+        const ensurePoseImageInput = (node) => {
             if (!node) return;
             const inputIndex = node.inputs?.findIndex(input => input?.name === "pose_image") ?? -1;
-            if (disabled) {
-                if (inputIndex >= 0) {
-                    if (node.graph) {
-                        if (typeof node.disconnectInput === "function") node.disconnectInput(inputIndex);
-                        if (typeof node.removeInput === "function") node.removeInput(inputIndex);
-                        else node.inputs.splice(inputIndex, 1);
-                    } else {
-                        node.inputs.splice(inputIndex, 1);
-                    }
-                }
-                node._vnccsPoseImageInputDisabled = true;
-                return;
-            }
-
             if (inputIndex < 0 && typeof node.addInput === "function") {
                 node.addInput("pose_image", "IMAGE");
             }
-            node._vnccsPoseImageInputDisabled = false;
+            node.setDirtyCanvas?.(true, true);
         };
 
         const setCameraPromptInputDisabled = (node, disabled) => {
@@ -15217,8 +15344,9 @@ app.registerExtension({
             // Create widget
             this._vnccsSetAnimationOutputMode = (animation) => setAnimationOutputMode(this, animation);
             this.studioWidget = new PoseStudioWidget(this);
-            this._vnccsSetPoseImageInputDisabled = (disabled) => setPoseImageInputDisabled(this, disabled);
+            this._vnccsEnsurePoseImageInput = () => ensurePoseImageInput(this);
             this._vnccsSetCameraPromptInputDisabled = (disabled) => setCameraPromptInputDisabled(this, disabled);
+            this._vnccsEnsurePoseImageInput();
             this.studioWidget.applyDirectionalSkydomeSetting();
 
             const studioDOMWidget = this.addDOMWidget("pose_studio_ui", "ui", this.studioWidget.container, {
@@ -15240,7 +15368,7 @@ app.registerExtension({
             // Load model after initialization
             this._vnccsPoseInitTimer = setTimeout(() => {
                 this.studioWidget.loadFromNode();
-                this._vnccsSetPoseImageInputDisabled?.(this.studioWidget.exportParams.interface_mode === "manager");
+                this._vnccsEnsurePoseImageInput?.();
                 window.__vnccsPoseStudioCharacterCreatorSync?.registerStudio(this.studioWidget);
                 this.studioWidget.loadModel().then(() => {
                     if (this.studioWidget.viewer) {
@@ -15278,7 +15406,7 @@ app.registerExtension({
                 this._vnccsPoseConfigureTimer = setTimeout(() => {
                     syncStudioDOMWidgetWidth(this);
                     this.studioWidget.loadFromNode();
-                    this._vnccsSetPoseImageInputDisabled?.(this.studioWidget.exportParams.interface_mode === "manager");
+                    this._vnccsEnsurePoseImageInput?.();
                     window.__vnccsPoseStudioCharacterCreatorSync?.registerStudio(this.studioWidget);
                     this.studioWidget.loadModel();
                     this.studioWidget.refreshLibrary(false); // Pre-load library meta only

--- a/web/vnccs_pose_studio_core.js
+++ b/web/vnccs_pose_studio_core.js
@@ -5768,6 +5768,23 @@ export class PoseViewerCore {
         return true;
     }
 
+    analyzeSAM3DBodyProportions(data) {
+        if (!data || !this.bones || !this.skinnedMesh) return null;
+
+        this.autoFitSAM3DBoneLengths(data);
+        const worldKps = this._buildSAM3DImportTargets(data)?.worldKps;
+        if (worldKps) {
+            // Match the same converged root and limb measurements used by the
+            // ordinary SAM import without applying any detected rotations or IK.
+            for (let pass = 0; pass < 6; pass++) {
+                this.fitSAM3DJointRootLengthsToWorldKps(worldKps);
+                this.fitSAM3DLimbLengthsToWorldKps(worldKps);
+            }
+        }
+
+        return { ...(this.boneLengthParams || {}) };
+    }
+
     fitSAM3DJointRootLengthsToWorldKps(worldKps) {
         if (!worldKps || !this.bones || !this.skinnedMesh) return null;
         this.skinnedMesh.updateMatrixWorld(true);

--- a/web/vnccs_pose_studio_core.js
+++ b/web/vnccs_pose_studio_core.js
@@ -6,6 +6,36 @@
 
 // Determine the extension's base URL dynamically to support varied directory names
 const EXTENSION_URL = new URL(".", import.meta.url).toString();
+export const POSE_STUDIO_CAPTURE_FOV = 30;
+
+export function computeEquivalentPerspectiveZoom(sourceFov, targetFov = POSE_STUDIO_CAPTURE_FOV) {
+    const source = Number(sourceFov);
+    const target = Number(targetFov);
+    if (
+        !Number.isFinite(source)
+        || !Number.isFinite(target)
+        || source <= 0
+        || source >= 179
+        || target <= 0
+        || target >= 179
+    ) return null;
+    return Math.tan((target * Math.PI / 180) * 0.5)
+        / Math.tan((source * Math.PI / 180) * 0.5);
+}
+
+export function buildEquivalentPerspectiveProjectionFrame(
+    sourceFrame,
+    targetFov = POSE_STUDIO_CAPTURE_FOV,
+) {
+    if (!sourceFrame?.cameraPosition) return null;
+    const projectionZoom = computeEquivalentPerspectiveZoom(sourceFrame.fov, targetFov);
+    if (!projectionZoom) return null;
+    return {
+        fov: Number(targetFov),
+        cameraPosition: { ...sourceFrame.cameraPosition },
+        projection_zoom: projectionZoom,
+    };
+}
 
 // === Three.js Module Loader (from Debug3) ===
 const THREE_VERSION = "0.160.0";
@@ -120,6 +150,42 @@ export function computeSAMProjectionFrameFit({
         zoom,
         offset_x: -(scaledCenterX - desiredCenterX) * visibleWidth * 0.5,
         offset_y: -(scaledAnchorY - targetAnchorY) * visibleHeight * 0.5,
+    };
+}
+
+export function clipSAMProjectionFrameToViewport(modelBounds, shoulderY = null) {
+    const width = Number(modelBounds?.width);
+    const height = Number(modelBounds?.height);
+    const centerX = Number(modelBounds?.centerX);
+    const centerY = Number(modelBounds?.centerY);
+    const depth = Number(modelBounds?.depth);
+    if (![width, height, centerX, centerY].every(Number.isFinite) || width <= 0 || height <= 0) {
+        return null;
+    }
+    const rawMinX = centerX - width * 0.5;
+    const rawMaxX = centerX + width * 0.5;
+    const rawMinY = centerY - height * 0.5;
+    const rawMaxY = centerY + height * 0.5;
+    const minX = Math.max(-1, rawMinX);
+    const maxX = Math.min(1, rawMaxX);
+    const minY = Math.max(-1, rawMinY);
+    const maxY = Math.min(1, rawMaxY);
+    if (maxX - minX <= 1e-5 || maxY - minY <= 1e-5) return null;
+
+    const shoulder = Number(shoulderY);
+    return {
+        bounds: {
+            width: maxX - minX,
+            height: maxY - minY,
+            centerX: (minX + maxX) * 0.5,
+            centerY: (minY + maxY) * 0.5,
+            depth: Number.isFinite(depth) ? depth : 1,
+        },
+        shoulder_y: Number.isFinite(shoulder) && shoulder >= -1 && shoulder <= 1
+            ? shoulder
+            : null,
+        bottom_y: minY,
+        clipped: rawMinX < -1 || rawMaxX > 1 || rawMinY < -1 || rawMaxY > 1,
     };
 }
 
@@ -1498,7 +1564,12 @@ export class PoseViewerCore {
         this.lights = [defaultLight];
 
         // Capture Camera (Independent of Orbit camera)
-        this.captureCamera = new THREE.PerspectiveCamera(30, this.width / this.height, 0.1, 500);
+        this.captureCamera = new THREE.PerspectiveCamera(
+            POSE_STUDIO_CAPTURE_FOV,
+            this.width / this.height,
+            0.1,
+            500,
+        );
         this.scene.add(this.captureCamera);
         // The common scene camera must not jump when a differently shaped
         // active character replaces the editor rig.
@@ -4554,7 +4625,7 @@ export class PoseViewerCore {
         const cameraOffset = new this.THREE.Vector3(0, 0, dist);
         cameraOffset.applyEuler(new this.THREE.Euler(pitchRad, yawRad, 0, 'YXZ'));
         this.captureCamera.aspect = width / height;
-        this.captureCamera.fov = 30;
+        this.captureCamera.fov = POSE_STUDIO_CAPTURE_FOV;
         this.captureCamera.zoom = zoom;
         this.captureCamera.updateProjectionMatrix();
         this.captureCamera.position.copy(target).add(cameraOffset);
@@ -4771,7 +4842,14 @@ export class PoseViewerCore {
         };
     }
 
-    computeSAM3DFrameCameraParams(data, width = 1024, height = 1024, meshData = null, forceFallback = false) {
+    computeSAM3DFrameCameraParams(
+        data,
+        width = 1024,
+        height = 1024,
+        meshData = null,
+        forceFallback = false,
+        standardTargetFrame = null,
+    ) {
         if (!this.THREE || !this.skinnedMesh || !this.captureCamera) return null;
 
         const frame = meshData?.render_frame || null;
@@ -5113,6 +5191,23 @@ export class PoseViewerCore {
                 projectionCamera,
                 ['upperarm_l', 'upperarm_r'],
             );
+            const visibleModelFrame = clipSAMProjectionFrameToViewport(
+                modelBounds,
+                modelShoulderY,
+            );
+            // Keep the source crop in diagnostics, but match the ordinary
+            // camera to the visible SAM-rendered mannequin. The recovered SAM
+            // camera follows the character world transform, so this projected
+            // frame is stable across saved zoom/pan values. Using the source
+            // body bounds here made the ordinary mannequin visibly smaller
+            // whenever its head/limb extents differed from the SAM body mesh.
+            const visibleSourceFrame = clipSAMProjectionFrameToViewport({
+                width: desiredW * 2,
+                height: desiredH * 2,
+                centerX: desiredCenterX,
+                centerY: desiredCenterY,
+                depth: 1,
+            }, sourceShoulderFrame?.ndcY) || visibleModelFrame;
             const fit = computeSAMProjectionFrameFit({
                 modelBounds,
                 desiredBounds: {
@@ -5134,6 +5229,37 @@ export class PoseViewerCore {
                 yaw_deg: 0,
                 pitch_deg: 0,
                 sam_projection: samProjectionFrame,
+                // Standard-camera matching must reproduce the crop visible in
+                // the source viewport. Geometry outside the image is not a
+                // reason to zoom out and reveal the complete body.
+                sam_standard_target: visibleModelFrame,
+                sam_fit_debug: {
+                    mode: 'sam_projection',
+                    image_size: { width: imageW, height: imageH },
+                    camera: {
+                        fov: projectionCamera.fov,
+                        position: {
+                            x: projectionCamera.position.x,
+                            y: projectionCamera.position.y,
+                            z: projectionCamera.position.z,
+                        },
+                    },
+                    source_frame_pixels: { x1, y1, x2, y2 },
+                    visible_source_frame: visibleSourceFrame,
+                    projected_model_bounds: modelBounds ? {
+                        min_x: modelBounds.min.x,
+                        min_y: modelBounds.min.y,
+                        max_x: modelBounds.max.x,
+                        max_y: modelBounds.max.y,
+                        width: modelBounds.width,
+                        height: modelBounds.height,
+                        center_x: modelBounds.centerX,
+                        center_y: modelBounds.centerY,
+                    } : null,
+                    visible_model_frame: visibleModelFrame,
+                    shoulder_y: Number.isFinite(modelShoulderY) ? modelShoulderY : null,
+                    discarded_projection_fit: fit,
+                },
             };
         }
 
@@ -5152,23 +5278,83 @@ export class PoseViewerCore {
                     this.captureCamera,
                     ['upperarm_l', 'upperarm_r'],
                 );
+                const visibleBaseFrame = clipSAMProjectionFrameToViewport(
+                    baseBounds,
+                    modelShoulderY,
+                );
+                const targetBounds = standardTargetFrame?.bounds;
+                const targetValues = [
+                    targetBounds?.width,
+                    targetBounds?.height,
+                    targetBounds?.centerX,
+                    targetBounds?.centerY,
+                ].map(Number);
+                const hasProjectionTarget = targetValues.every(Number.isFinite)
+                    && targetValues[0] > 1e-5
+                    && targetValues[1] > 1e-5;
+                const desiredBounds = hasProjectionTarget ? {
+                    width: targetValues[0],
+                    height: targetValues[1],
+                    centerX: targetValues[2],
+                    centerY: targetValues[3],
+                } : {
+                    width: desiredW * 2,
+                    height: desiredH * 2,
+                    centerX: desiredCenterX,
+                    centerY: desiredCenterY,
+                };
                 const fit = computeSAMProjectionFrameFit({
-                    modelBounds: baseBounds,
-                    desiredBounds: {
-                        width: desiredW * 2,
-                        height: desiredH * 2,
-                        centerX: desiredCenterX,
-                        centerY: desiredCenterY,
-                    },
+                    modelBounds: visibleBaseFrame?.bounds || baseBounds,
+                    desiredBounds,
                     fov: this.captureCamera.fov,
                     aspect: this.captureCamera.aspect,
-                    modelShoulderY,
-                    desiredShoulderY: sourceShoulderFrame?.ndcY,
-                    desiredBottomY: desiredCenterY - desiredH,
+                    // When matching the same mannequin between SAM and the
+                    // ordinary camera, its complete visible bbox is the scale
+                    // contract. Shoulder anchoring intentionally ignores the
+                    // head/top extent and was the remaining under-zoom cause.
+                    modelShoulderY: hasProjectionTarget
+                        ? null
+                        : visibleBaseFrame?.shoulder_y ?? modelShoulderY,
+                    desiredShoulderY: hasProjectionTarget
+                        ? null
+                        : sourceShoulderFrame?.ndcY,
+                    desiredBottomY: hasProjectionTarget
+                        ? null
+                        : desiredCenterY - desiredH,
                 });
                 if (fit) {
                     this.updateCaptureCamera(width, height, fit.zoom, fit.offset_x, fit.offset_y);
-                    return { ...fit, ...samCameraAngles };
+                    return {
+                        ...fit,
+                        ...samCameraAngles,
+                        sam_fit_debug: {
+                            mode: 'standard_camera',
+                            image_size: { width: imageW, height: imageH },
+                            camera: {
+                                fov: this.captureCamera.fov,
+                                aspect: this.captureCamera.aspect,
+                            },
+                            used_projection_target: hasProjectionTarget,
+                            alignment_mode: hasProjectionTarget
+                                ? 'visible_model_bounds'
+                                : 'source_shoulder_to_bottom',
+                            requested_target_frame: standardTargetFrame,
+                            desired_bounds: desiredBounds,
+                            raw_model_bounds: {
+                                min_x: baseBounds.min.x,
+                                min_y: baseBounds.min.y,
+                                max_x: baseBounds.max.x,
+                                max_y: baseBounds.max.y,
+                                width: baseBounds.width,
+                                height: baseBounds.height,
+                                center_x: baseBounds.centerX,
+                                center_y: baseBounds.centerY,
+                            },
+                            visible_model_frame: visibleBaseFrame,
+                            model_shoulder_y: Number.isFinite(modelShoulderY) ? modelShoulderY : null,
+                            result: { ...fit },
+                        },
+                    };
                 }
             }
 
@@ -5223,8 +5409,21 @@ export class PoseViewerCore {
         };
     }
 
-    fitSAM3DToStandardCamera(data, width = 1024, height = 1024, meshData = null) {
-        const angleParams = this.computeSAM3DFrameCameraParams(data, width, height, meshData, true);
+    fitSAM3DToStandardCamera(
+        data,
+        width = 1024,
+        height = 1024,
+        meshData = null,
+        standardTargetFrame = null,
+    ) {
+        const angleParams = this.computeSAM3DFrameCameraParams(
+            data,
+            width,
+            height,
+            meshData,
+            true,
+            standardTargetFrame,
+        );
         if (!angleParams) return null;
 
         const yaw = Number(angleParams.yaw_deg) || 0;
@@ -5240,7 +5439,14 @@ export class PoseViewerCore {
 
         // Rotation changes the projected head/sole positions, especially for
         // high- and low-angle images. Measure again only after it is applied.
-        return this.computeSAM3DFrameCameraParams(data, width, height, meshData, true);
+        return this.computeSAM3DFrameCameraParams(
+            data,
+            width,
+            height,
+            meshData,
+            true,
+            standardTargetFrame,
+        );
     }
 
     beginCaptureBatch(width, height) {
@@ -5443,11 +5649,18 @@ export class PoseViewerCore {
         if (!frame || !this.THREE || !this.captureCamera) return false;
         const cameraPosition = frame.cameraPosition;
         const fov = Number(frame.fov);
-        if (!cameraPosition || !Number.isFinite(fov) || fov <= 0) return false;
+        const projectionZoom = Number(frame.projection_zoom ?? 1);
+        if (
+            !cameraPosition
+            || !Number.isFinite(fov)
+            || fov <= 0
+            || !Number.isFinite(projectionZoom)
+            || projectionZoom <= 0
+        ) return false;
 
         this.captureCamera.aspect = (Number(width) || 1024) / Math.max(1, Number(height) || 1024);
         this.captureCamera.fov = fov;
-        this.captureCamera.zoom = Number(zoom) || 1.0;
+        this.captureCamera.zoom = (Number(zoom) || 1.0) * projectionZoom;
         this.captureCamera.up.set(0, 1, 0);
         this.captureCamera.position.set(
             Number(cameraPosition.x) || 0,

--- a/web/vnccs_pose_studio_core.js
+++ b/web/vnccs_pose_studio_core.js
@@ -5768,23 +5768,6 @@ export class PoseViewerCore {
         return true;
     }
 
-    analyzeSAM3DBodyProportions(data) {
-        if (!data || !this.bones || !this.skinnedMesh) return null;
-
-        this.autoFitSAM3DBoneLengths(data);
-        const worldKps = this._buildSAM3DImportTargets(data)?.worldKps;
-        if (worldKps) {
-            // Match the same converged root and limb measurements used by the
-            // ordinary SAM import without applying any detected rotations or IK.
-            for (let pass = 0; pass < 6; pass++) {
-                this.fitSAM3DJointRootLengthsToWorldKps(worldKps);
-                this.fitSAM3DLimbLengthsToWorldKps(worldKps);
-            }
-        }
-
-        return { ...(this.boneLengthParams || {}) };
-    }
-
     fitSAM3DJointRootLengthsToWorldKps(worldKps) {
         if (!worldKps || !this.bones || !this.skinnedMesh) return null;
         this.skinnedMesh.updateMatrixWorld(true);


### PR DESCRIPTION
# Version 0.6.5
## Pose Manager Reference Proportions and SAM Camera Reliability

### New Features

*   **Reference-image proportions in Pose Manager**: The PoseStudio `pose_image` input is now available in Pose Manager.
    *   When the node runs, SAM 3D Body analyzes the connected image and transfers its body proportions to the character used by every pose in the current manager set.
    *   The reference pose is not applied and does not replace any pose in the manager set.
    *   After the proportions are updated, every pose is normalized with the same full-frame fitting used after an age change and its preview is regenerated before output.

*   **Automatic analysis toggle**: Added an **Auto-analyze proportions** checkbox to the Pose Manager header.
    *   The option is enabled by default and saved with the workflow.
    *   When disabled, `pose_image` remains visible and connected, but the image is not sent to SAM for analysis.

### Improvements

*   **Matching proportion results across PoseStudio modes**: Pose Manager uses the same body-proportion fitting as the standard PoseStudio image analysis, providing consistent limb and torso proportions while preserving all managed poses.
*   **Unchanged standard PoseStudio workflow**: Outside Pose Manager, `pose_image` continues to apply the analyzed pose and body proportions as before.

### Fixes

*   **SAM camera setting is now respected**: Fixed SAM imports re-enabling detector-camera matching and replacing the user's framing even when **SAM Import: Apply Camera Angle** was disabled.
    *   Camera matching is now disabled by default and remains available as an explicit option.
    *   Turning the option off while a SAM camera view is active restores the user-controlled camera.
*   **Identical SAM and standard-mode framing**: Fixed the analyzed character rendering at a different scale when **SAM Import: Apply Camera Angle** was disabled.
    *   Standard mode now reuses the recovered SAM camera position with PoseStudio's fixed 30-degree FOV and an exactly equivalent perspective zoom.
    *   Compact and seated poses retain the same scale and position in both modes, including images where the visible body extends beyond the frame; PoseStudio no longer attempts to reveal or fit off-frame anatomy.