### PR TITLE
Add selected joint rotation controls to Pose Studio

### DIFF
--- a/tests/test_pose_character_regressions.mjs
+++ b/tests/test_pose_character_regressions.mjs
@@ -21,6 +21,44 @@ const methodSource = (source, signature, nextSignature) => {
     return source.slice(start, end);
 };
 
+
+test("selected bone rotation relay reports local radians", () => {
+    const relayMethod = methodSource(
+        poseStudioCoreSource,
+        "\n    _emitSelectedBoneRotationChange()",
+        "\n    setSelectedBoneRotation(",
+    );
+    assert.match(relayMethod, /const callback = this\.options\?\.onSelectedBoneRotationChange/);
+    assert.match(relayMethod, /const bone = this\.selectedBone/);
+    assert.match(relayMethod, /boneName: bone\?\.name \|\| null/);
+    assert.match(relayMethod, /x: bone\.rotation\.x/);
+    assert.match(relayMethod, /y: bone\.rotation\.y/);
+    assert.match(relayMethod, /z: bone\.rotation\.z/);
+});
+
+
+test("selected bone rotation setter applies local radians", () => {
+    const setterMethod = methodSource(
+        poseStudioCoreSource,
+        "setSelectedBoneRotation(axis, radians, {",
+        "\n    selectBone(",
+    );
+    assert.match(setterMethod, /recordState = true/);
+    assert.match(setterMethod, /dispatchPoseChange = true/);
+    assert.match(setterMethod, /\['x', 'y', 'z'\]\.includes\(axis\)/);
+    assert.match(setterMethod, /Number\.isFinite\(value\)/);
+    assert.match(setterMethod, /bone\.rotation\[axis\] = value/);
+
+    const assignment = setterMethod.indexOf("bone.rotation[axis] = value");
+    const updateEffectors = setterMethod.indexOf("this.updateIKEffectorPositions()", assignment);
+    const relay = setterMethod.indexOf("this._emitSelectedBoneRotationChange()", updateEffectors);
+    const render = setterMethod.indexOf("this.requestRender()", relay);
+    const dispatch = setterMethod.indexOf("this.dispatchPoseChange()", render);
+    assert.ok(assignment >= 0 && updateEffectors > assignment);
+    assert.ok(relay > updateEffectors && render > relay);
+    assert.ok(dispatch > render);
+});
+
 test("Pose Studio imports one strict version of its transform-track modules", () => {
     assert.match(
         poseStudioSource,

--- a/tests/test_pose_widget_bootstrap.mjs
+++ b/tests/test_pose_widget_bootstrap.mjs
@@ -205,7 +205,9 @@ test("Pose Studio constructs its DOM widget and hides pose_data during node boot
                 }
                 if (specifier === "./vnccs_pose_studio_core.js") {
                     class FakePoseViewerCore {
-                        constructor() {
+                        constructor(_canvas, options = {}) {
+                            this.options = options;
+                            this.selectedBone = null;
                             return new Proxy(this, {
                                 get(target, property) {
                                     if (property in target) return target[property];
@@ -290,6 +292,36 @@ test("Pose Studio constructs its DOM widget and hides pose_data during node boot
     assert.equal(poseWidget.computeSize()[1], -4);
 
     const studio = node.studioWidget;
+    assert.ok(studio.selectedJointSection, "Selected Joint section must be mounted");
+    assert.equal(studio.selectedJointSection.hidden, true);
+
+    studio.viewer.selectedBone = {
+        name: "upper_arm.L",
+        rotation: { x: 0.25, y: -0.5, z: 1.25 },
+    };
+    studio.viewer.options.onBoneSelectionChange({
+        boneName: "upper_arm.L",
+        previousBoneName: null,
+        source: "viewer",
+    });
+    assert.equal(studio.selectedJointSection.hidden, false);
+    assert.equal(studio.selectedJointName.textContent, "upper_arm.L");
+    assert.equal(studio.selectedJointSliders.x.value.textContent, "0.250 rad");
+    assert.equal(studio.selectedJointSliders.y.value.textContent, "-0.500 rad");
+    assert.equal(studio.selectedJointSliders.z.value.textContent, "1.250 rad");
+
+    studio.viewer.selectedBone.rotation.x = -0.75;
+    studio.viewer.options.onSelectedBoneRotationChange();
+    assert.equal(studio.selectedJointSliders.x.value.textContent, "-0.750 rad");
+
+    studio.viewer.selectedBone = null;
+    studio.viewer.options.onBoneSelectionChange({
+        boneName: null,
+        previousBoneName: "upper_arm.L",
+        source: "viewer",
+    });
+    assert.equal(studio.selectedJointSection.hidden, true);
+
     studio.exportParams.editor_mode = "image";
     studio.poses = [
         {

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -5875,6 +5875,81 @@ class PoseStudioWidget {
         rightSidebar.appendChild(charactersSection.el);
         this.renderCharactersUI();
 
+        const selectedJointSection = this.createSection("Selected Joint", true);
+        this.selectedJointSection = selectedJointSection.el;
+        this.selectedJointSliders = {};
+
+        this.selectedJointName = document.createElement("div");
+        this.selectedJointName.className = "vnccs-ps-label";
+        this.selectedJointName.style.marginBottom = "8px";
+        selectedJointSection.content.appendChild(this.selectedJointName);
+
+        ['x', 'y', 'z'].forEach(axis => {
+            const field = document.createElement("div");
+            field.className = "vnccs-ps-field";
+
+            const labelRow = document.createElement("div");
+            labelRow.className = "vnccs-ps-label-row";
+
+            const label = document.createElement("span");
+            label.className = "vnccs-ps-label";
+            label.textContent = axis.toUpperCase();
+
+            const valueRow = document.createElement("div");
+            valueRow.style.display = "flex";
+            valueRow.style.alignItems = "center";
+            valueRow.style.gap = "6px";
+
+            const value = document.createElement("span");
+            value.className = "vnccs-ps-value";
+            value.textContent = "0.000 rad";
+
+            const resetBtn = document.createElement("button");
+            resetBtn.className = "vnccs-ps-reset-btn";
+            resetBtn.innerHTML = "↺";
+            resetBtn.title = "Reset to 0 rad";
+
+            const wrap = document.createElement("div");
+            wrap.className = "vnccs-ps-slider-wrap";
+
+            const slider = document.createElement("input");
+            slider.type = "range";
+            slider.className = "vnccs-ps-slider";
+            slider.min = String(-Math.PI);
+            slider.max = String(Math.PI);
+            slider.step = "0.001";
+            slider.value = "0";
+
+            slider.addEventListener("focus", () => {
+                this.viewer?.recordState();
+            });
+            slider.addEventListener("input", () => {
+                const radians = Number(slider.value);
+                value.textContent = `${radians.toFixed(3)} rad`;
+                this.viewer?.setSelectedBoneRotation(axis, radians, {
+                    recordState: false,
+                    dispatchPoseChange: false,
+                });
+            });
+            slider.addEventListener("change", () => {
+                this.viewer?.dispatchPoseChange();
+            });
+            resetBtn.addEventListener("click", event => {
+                event.stopPropagation();
+                this.viewer?.setSelectedBoneRotation(axis, 0);
+            });
+
+            valueRow.append(value, resetBtn);
+            labelRow.append(label, valueRow);
+            wrap.appendChild(slider);
+            field.append(labelRow, wrap);
+            selectedJointSection.content.appendChild(field);
+            this.selectedJointSliders[axis] = { slider, value };
+        });
+
+        this.selectedJointSection.hidden = true;
+        rightSidebar.appendChild(this.selectedJointSection);
+
     }
 
     _setupFinalUI() {
@@ -5909,13 +5984,18 @@ class PoseStudioWidget {
                 this.showHandControlPopover(side);
             },
             onBoneSelectionChange: ({ boneName, source }) => {
+                this.refreshSelectedJointControls();
                 if (source === "external" || !this.isAnimationMode()) return;
                 this.animationTimeline?.notifyActiveTrack?.(
                     boneName || MODEL_ROTATION_TRACK,
                     { reveal: true },
                 );
             },
+            onSelectedBoneRotationChange: () => {
+                this.refreshSelectedJointControls();
+            },
             onPoseChange: (pose) => {
+                this.refreshSelectedJointControls();
                 // Return params request logic mapped into direct assignment beforehand 
                 this.viewer.setCameraParams({
                     ...this.currentCameraParams()
@@ -13876,6 +13956,27 @@ class PoseStudioWidget {
                 info.label.innerText = `${r[axis]}°`;
             }
         });
+        this.refreshSelectedJointControls();
+    }
+
+    refreshSelectedJointControls() {
+        if (!this.selectedJointSection) return;
+
+        const bone = this.viewer?.selectedBone || null;
+        this.selectedJointSection.hidden = !bone;
+        if (!bone) return;
+
+        this.selectedJointName.textContent = bone.name;
+        for (const axis of ['x', 'y', 'z']) {
+            const controls = this.selectedJointSliders?.[axis];
+            if (!controls) continue;
+            const radians = Math.atan2(
+                Math.sin(bone.rotation[axis]),
+                Math.cos(bone.rotation[axis]),
+            );
+            controls.slider.value = String(radians);
+            controls.value.textContent = `${radians.toFixed(3)} rad`;
+        }
     }
 
     updateGenderVisibility() {

--- a/web/vnccs_pose_studio_core.js
+++ b/web/vnccs_pose_studio_core.js
@@ -1063,6 +1063,7 @@ export class PoseViewerCore {
             onHandHover: null,
             onHandActivate: null,
             onBoneSelectionChange: null,
+            onSelectedBoneRotationChange: null,
 
             syncMode: 'end',
             skinMode: 'flat_color',
@@ -1551,6 +1552,7 @@ export class PoseViewerCore {
                 // FK rotation - update all effector positions to follow bones
                 this.updateIKEffectorPositions();
             }
+            this._emitSelectedBoneRotationChange();
             this.requestRender();
         });
 
@@ -2290,6 +2292,40 @@ export class PoseViewerCore {
         } finally {
             this._emittingBoneSelectionChange = false;
         }
+    }
+
+    _emitSelectedBoneRotationChange() {
+        const callback = this.options?.onSelectedBoneRotationChange;
+        if (typeof callback !== 'function') return;
+
+        const bone = this.selectedBone;
+        callback({
+            boneName: bone?.name || null,
+            rotation: bone ? {
+                x: bone.rotation.x,
+                y: bone.rotation.y,
+                z: bone.rotation.z,
+            } : null,
+        });
+    }
+
+    setSelectedBoneRotation(axis, radians, {
+        recordState = true,
+        dispatchPoseChange = true,
+    } = {}) {
+        const bone = this.selectedBone;
+        const value = Number(radians);
+        if (!bone || !['x', 'y', 'z'].includes(axis) || !Number.isFinite(value)) return false;
+
+        if (recordState) this.recordState();
+        bone.rotation[axis] = value;
+        bone.updateMatrixWorld(true);
+        this.skeleton?.update();
+        this.updateIKEffectorPositions();
+        this._emitSelectedBoneRotationChange();
+        this.requestRender();
+        if (dispatchPoseChange) this.dispatchPoseChange();
+        return true;
     }
 
     selectBone(bone, { source = 'viewer' } = {}) {


### PR DESCRIPTION
## Motivation

Pose Studio currently provides no numerical feedback for joint rotations. This makes precise pose adjustments difficult, especially when trying to create symmetric and consistent poses across matching joints.

## Summary

- Add a Selected Joint section to the Pose Studio sidebar
- Show local X, Y, and Z rotation values in radians
- Keep the controls synchronized with gizmo rotation changes
- Apply slider and

 reset-button changes back to the selected joint
- Hide the section when no joint is selected

## Preview

![Selected joint rotation controls](https://github.com/user-attachments/assets/c8cbaca5-41f4-4ec7-8ca4-70f44ca4cfef)
The preview demonstrates joint selection, gizmo synchronization, slider-based rotation.

## Testing

- Added regression coverage for selected-joint rotation updates
- Added widget bootstrap coverage for selection visibility and rotation synchronization
- Ran the Pose Studio regression and widget bootstrap tests successfully

## Notes

The implementation is additive and does not replace or modify existing Pose Studio controls or workflows. The only adjustment to existing test infrastructure is extending the `FakePoseViewerCore` stub to retain the constructor callbacks used by the new bootstrap coverage.