### PR TITLE
0.6.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,67 @@
+# Version 0.6.6
+## 3D Factory Interior Planning, Camera Paths, and Production Editing
+
+### New Features
+
+*   **Top-down interior Plan mode**: Added a dedicated orthographic workspace for designing interiors directly in the 3D Factory viewport.
+    *   Walls, rectangular rooms, wall openings, and saved cameras use press-drag-release creation with live geometry previews.
+    *   The configurable plan grid supports independent visibility, spacing, major-line intervals, and optional snapping to the grid, angles, wall endpoints, wall midpoints, and orthogonal directions.
+    *   Plan navigation includes corrected two-axis panning, mouse-wheel zoom, persistent framing, live room movement, shift selection, and scale-correct marquee selection inside zoomed ComfyUI nodes.
+
+*   **Persistent architectural scenes**: Added floor levels, walls, rooms, floors, ceilings, doors, windows, empty openings, materials, and complete structure transforms to saved scenes and workflow state.
+    *   A room is edited as one envelope: its perimeter walls, floor, and ceiling move, resize, change level, visibility, lock state, height, thickness, and material together.
+    *   Wall endpoints, height, thickness, elevation offset, side materials, cap materials, and attached openings remain editable after creation.
+    *   Opening controls are constrained by the host wall and prevent overlaps or geometry outside the available wall span.
+    *   Buildings are optional hierarchy containers. New blank scenes contain no synthetic `Building 1`; moving or rotating an existing building transforms its architecture, assigned Gaussian objects, cameras, paths, and lights as one unit. Deleting it removes its architecture and safely unassigns or reassigns the remaining scene objects without creating a replacement building.
+
+*   **Architectural materials and textures**: Added reusable solid, glass, and uploaded texture materials for wall sides, wall caps, floors, ceilings, and window panes.
+    *   JPEG, PNG, and WebP textures are validated, converted to scene-owned PNG assets, exposed through bounded scene routes, and support UV scale and rotation.
+
+*   **Production camera workflow**: Reworked viewport and saved-camera control for precise scene navigation and repeatable shots.
+    *   The Cameras panel now contains perspective, front, right, and top projections plus adjustable mouse-wheel zoom speed for both large scenes and close interior work.
+    *   In-place FPV look preserves camera position and world-up orientation, while framing commands establish an explicit orbit target instead of implicitly rotating around the world origin.
+    *   Saved cameras can be placed and aimed in Plan mode, entered non-destructively, updated from the current view, assigned to levels or buildings, and edited through exact position, rotation, FOV, and focus-distance fields.
+    *   Added persistent camera paths with editable points, timing, linear or centripetal Catmull-Rom interpolation, easing, optional constant-speed traversal, looping, playback, and exact per-point camera values.
+
+*   **Floor-aware object placement**: Added one-action surface dropping for individual or grouped selections.
+    *   Objects stop on the active floor or on the highest colliding object beneath them instead of passing through scene geometry.
+    *   Automatic, custom-box, and disabled collision proxies are available per object, including control over whether an object can support other objects.
+
+*   **Local point lights and occlusion shadows**: Added scene-owned spherical point lights with editable position, level, building, color, strength, range, visibility, and shadow casting.
+    *   Light helpers are selectable objects in Plan and 3D views but are excluded from current-view and saved-camera exports.
+    *   Directional and local lights now cast configurable occlusion shadows from closed architectural geometry and opaque Gaussian collision proxies, while transmissive objects and glass openings allow light through.
+    *   Low, Medium, High, and Ultra shadow presets use bounded active-light budgets and tuned bias values to control browser cost while keeping distant wall lighting stable.
+
+*   **Viewport-only interior cutaway**: Added separate Plan and 3D cutaway state that hides ceilings and the nearest horizontally blocking wall for interior editing.
+    *   Cutaway never changes scene data and is automatically disabled during camera and node-output captures, so exported views retain the complete architecture.
+
+### Workflow and UX Improvements
+
+*   **Task-oriented workspace layout**: Reorganized the editor into Generate/Cameras tabs on the left, a clear central viewport, and Objects/Inspector/Export tabs on the right, removing controls that previously competed with the viewport.
+*   **Unified scene selection**: Gaussian objects, rooms, walls, openings, buildings, saved cameras, and local lights participate in consistent selection, visibility, locking, inspection, and object-tree workflows.
+    *   Plan Select mode supports shift-additive selection and drag marquee selection across rooms, architecture, Gaussian objects, cameras, and lights.
+    *   Copy, paste, Delete/Backspace, Undo, and Redo are scoped to the active Factory editor and ignore text, numeric, select, and content-editable controls.
+    *   Copied rooms retain their perimeter walls and openings; pasted architecture, cameras, lights, and Gaussian objects receive independent IDs and a visible placement offset.
+*   **Live precision Inspector**: Transform gizmos remain available for coarse editing while paired sliders and exact numeric fields provide hundredth-step model, group, architecture, camera, and light control.
+    *   Continuous changes update the viewport during interaction, remain usable across repeated drags, and commit one bounded history operation when editing finishes.
+*   **Contextual level controls**: The level panel appears only while an architectural drawing tool is active and provides level creation, selection, elevation, height, slab thickness, visibility, and deletion without occupying the normal 3D workspace.
+
+### Fixes
+
+*   **Pose Manager proportion-only analysis**: Fixed **Auto-analyze proportions** allowing the temporary SAM-detected pose to replace the active Pose Manager card. Both the initial SAM import and the subsequent mesh-overlay fitting now suppress pose-change synchronization during proportion analysis, so only body proportions are transferred and every managed pose is preserved.
+
+### Persistence and Compatibility
+
+*   Added strict shared normalization and validation for levels, optional buildings, room perimeters, wall openings, materials, textures, object collision and light-transport properties, camera paths, local lights, and shadow settings.
+*   Added an independent edit revision so concurrent or stale editors cannot silently overwrite newer scene work, while render revisions continue to invalidate only affected captures and exports.
+*   Extended `.vnccs3d` scene packages to preserve architecture, floor levels, texture assets, camera paths, local lights, shadows, and object assignments; restored packages remap scene-owned IDs and validate every reference.
+*   Existing 3D Factory scenes remain loadable. Migration removes only the recognizable empty synthetic `Building 1` created by the temporary mandatory-building schema and preserves every user-created or transformed structure.
+
+### Packaging and Validation
+
+*   Bumped the package version to `0.6.6` and advanced the 3D Factory backend, editor-state, frontend, and viewer schemas required by the new persistent scene model.
+*   Expanded frontend, backend, node-state, library-package, camera, architecture, placement, lighting, shadow, cutaway, multi-selection, and scaled Plan-marquee regression coverage.
+
 # Version 0.6.5
 ## Pose Manager Reference Proportions and SAM Camera Reliability
 

--- a/api/factory3d.py
+++ b/api/factory3d.py
@@ -28,11 +28,18 @@ from .gaussian_scene import (
     validate_ply_payload,
     validate_splat_payload,
 )
+from .factory3d_schema import (
+    normalize_architecture,
+    normalize_camera_tracks,
+    normalize_levels,
+    normalize_lighting_extensions,
+    normalize_object_editor_properties,
+)
 
 
 LOGGER = logging.getLogger("vnccs.3d_factory")
 API_BASE = "/vnccs/3d-factory"
-SCHEMA_VERSION = 7
+SCHEMA_VERSION = 10
 EXPORT_FORMAT_VERSION = 8
 UPSTREAM_REPOSITORY = "VAST-AI/TripoSplat"
 UPSTREAM_COMMIT = "a78fa12d06dbf1381ca548bfac32bb68cb8c451d"
@@ -42,11 +49,12 @@ MAX_PREVIEW_BYTES = 64 * 1024 * 1024
 MAX_SCENE_CAMERAS = 32
 MAX_IMAGE_PIXELS = 4096 * 4096
 MAX_SKYDOME_BYTES = 64 * 1024 * 1024
+MAX_TEXTURE_BYTES = 32 * 1024 * 1024
 MAX_SKYDOME_PIXELS = 8192 * 4096
 REFERENCE_PREVIEW_SIZE = (640, 640)
 SKYDOME_VIEWPORT_SIZE = (2048, 1024)
 OBJECT_THUMBNAIL_SIZE = (256, 256)
-MAX_SCENE_JSON_BYTES = 2 * 1024 * 1024
+MAX_SCENE_JSON_BYTES = 16 * 1024 * 1024
 MAX_JOB_LOG_LINES = 800
 MAX_ACTIVE_JOBS = 2
 DEFAULT_SPLAT_CACHE_LIMIT_GB = 32
@@ -310,6 +318,12 @@ def _normalize_scene_cameras(
                 "camera_id": camera_id,
                 "name": _clean_name(raw.get("name"), f"Camera {index + 1}", 80),
                 "created_at": created_at,
+                "level_id": str(raw.get("level_id") or "")
+                if _ID_RE.fullmatch(str(raw.get("level_id") or ""))
+                else "",
+                "building_id": str(raw.get("building_id") or "")
+                if _ID_RE.fullmatch(str(raw.get("building_id") or ""))
+                else "",
                 **camera,
             }
         )
@@ -352,6 +366,7 @@ def _normalize_lighting(value: Any) -> dict[str, Any]:
         "elevation": number("elevation", -10.0, 90.0),
         "ambient": number("ambient", 0.0, 1.5),
         "background": color("background"),
+        **normalize_lighting_extensions(data),
     }
 
 
@@ -521,17 +536,29 @@ def _visible_object_ids(scene: dict[str, Any]) -> set[str]:
         for item in scene.get("objects", [])
         if isinstance(item, dict) and isinstance(item.get("object_id"), str)
     }
+    hidden_building_ids = {
+        building.get("building_id")
+        for building in scene.get("architecture", {}).get("buildings", [])
+        if isinstance(building, dict) and building.get("visible") is False
+    }
+
+    def object_is_visible(item: dict[str, Any]) -> bool:
+        return (
+            item.get("visible") is not False
+            and item.get("building_id") not in hidden_building_ids
+        )
+
     visible: set[str] = set()
     for layer in _normalize_scene_layers(scene):
         if layer["type"] == "object":
             object_id = layer["object_id"]
-            if objects[object_id].get("visible") is not False:
+            if object_is_visible(objects[object_id]):
                 visible.add(object_id)
             continue
         if layer.get("visible") is False:
             continue
         for object_id in layer["children"]:
-            if objects[object_id].get("visible") is not False:
+            if object_is_visible(objects[object_id]):
                 visible.add(object_id)
     return visible
 
@@ -567,7 +594,8 @@ def _atomic_json(path: Path, value: Any) -> None:
 
 def _migrate_scene_to_ply_only(path: Path, scene: dict[str, Any]) -> None:
     """Keep PLY as the only permanent source and public export asset."""
-    if int(scene.get("schema_version", 0) or 0) >= SCHEMA_VERSION:
+    previous_schema_version = int(scene.get("schema_version", 0) or 0)
+    if previous_schema_version >= SCHEMA_VERSION:
         return
     scene_root = path.parent.resolve()
     changed = True
@@ -669,6 +697,49 @@ def _migrate_scene_to_ply_only(path: Path, scene: dict[str, Any]) -> None:
                     files.pop(key, None)
                     changed = True
 
+    # Schema 9 temporarily created one mandatory empty Building for every
+    # scene. Remove only that recognizable synthetic container. Any structure
+    # with architecture or a user transform remains untouched.
+    architecture = scene.get("architecture")
+    legacy_buildings = architecture.get("buildings") if isinstance(architecture, dict) else None
+    if previous_schema_version <= 9 and isinstance(legacy_buildings, list) and len(legacy_buildings) == 1:
+        legacy = legacy_buildings[0] if isinstance(legacy_buildings[0], dict) else {}
+        position = legacy.get("position")
+        empty_architecture = not any(
+            architecture.get(key) for key in ("walls", "rooms", "openings")
+        )
+        try:
+            synthetic_transform = (
+                isinstance(position, list)
+                and len(position) == 3
+                and all(abs(float(value or 0)) <= 1e-12 for value in position)
+                and abs(float(legacy.get("rotation_y") or 0)) <= 1e-12
+            )
+        except (TypeError, ValueError):
+            synthetic_transform = False
+        if (
+            empty_architecture
+            and synthetic_transform
+            and str(legacy.get("name") or "Building 1") == "Building 1"
+            and legacy.get("locked") is not True
+        ):
+            removed_building_id = str(legacy.get("building_id") or "")
+            architecture["buildings"] = []
+            for item in scene.get("objects", []):
+                if isinstance(item, dict) and item.get("building_id") == removed_building_id:
+                    item["building_id"] = ""
+            for camera in scene.get("cameras", []):
+                if isinstance(camera, dict) and camera.get("building_id") == removed_building_id:
+                    camera["building_id"] = ""
+            for track in scene.get("camera_tracks", []):
+                if isinstance(track, dict) and track.get("building_id") == removed_building_id:
+                    track["building_id"] = ""
+            lighting = scene.get("lighting")
+            for light in lighting.get("lights", []) if isinstance(lighting, dict) else []:
+                if isinstance(light, dict) and light.get("building_id") == removed_building_id:
+                    light["building_id"] = ""
+            changed = True
+
     scene["schema_version"] = SCHEMA_VERSION
     if changed:
         _atomic_json(path, scene)
@@ -687,11 +758,64 @@ def load_scene(scene_id: str) -> dict[str, Any]:
     _migrate_scene_to_ply_only(path, value)
     if not isinstance(value.get("objects"), list):
         value["objects"] = []
+    for item in value["objects"]:
+        if not isinstance(item, dict):
+            continue
+        item.update(normalize_object_editor_properties(item))
     value["layers"] = _normalize_scene_layers(value)
+    value["levels"] = normalize_levels(scene_id, value.get("levels"))
+    valid_level_ids = {level["level_id"] for level in value["levels"]}
+    default_level_id = value["levels"][0]["level_id"]
+    for item in value["objects"]:
+        if isinstance(item, dict) and item.get("level_id") not in valid_level_ids:
+            item["level_id"] = default_level_id
+    textures = []
+    texture_ids: set[str] = set()
+    for item in (
+        value.get("textures") if isinstance(value.get("textures"), list) else []
+    ):
+        texture_id = str(item.get("texture_id") or "") if isinstance(item, dict) else ""
+        if not _ID_RE.fullmatch(texture_id) or texture_id in texture_ids:
+            continue
+        textures.append(item)
+        texture_ids.add(texture_id)
+        if len(textures) >= 512:
+            break
+    value["textures"] = textures
+    value["architecture"] = normalize_architecture(
+        scene_id,
+        value["levels"],
+        value.get("architecture"),
+    )
+    valid_building_ids = {
+        building["building_id"] for building in value["architecture"]["buildings"]
+    }
+    default_building_id = value["architecture"]["buildings"][0]["building_id"] \
+        if value["architecture"]["buildings"] else ""
+    for item in value["objects"]:
+        if isinstance(item, dict) and item.get("building_id") not in valid_building_ids:
+            item["building_id"] = default_building_id
+    for material in value["architecture"].get("materials", []):
+        if material.get("texture_id") not in texture_ids:
+            material.pop("texture_id", None)
     value["render"] = _normalize_render_settings(value.get("render"))
     value["camera"] = _normalize_camera(value.get("camera"))
     value["cameras"] = _normalize_scene_cameras(value.get("cameras"))
+    for camera in value["cameras"]:
+        if camera.get("level_id") not in valid_level_ids:
+            camera["level_id"] = default_level_id
+        if camera.get("building_id") not in valid_building_ids:
+            camera["building_id"] = default_building_id
+    value["camera_tracks"] = normalize_camera_tracks(value.get("camera_tracks"))
+    for track in value["camera_tracks"]:
+        if track.get("building_id") not in valid_building_ids:
+            track["building_id"] = default_building_id
     value["lighting"] = _normalize_lighting(value.get("lighting"))
+    for light in value["lighting"].get("lights", []):
+        if light.get("level_id") not in valid_level_ids:
+            light["level_id"] = default_level_id
+        if light.get("building_id") not in valid_building_ids:
+            light["building_id"] = default_building_id
     skydome = _normalize_scene_skydome(value.get("skydome"))
     if skydome is None:
         value.pop("skydome", None)
@@ -701,12 +825,25 @@ def load_scene(scene_id: str) -> dict[str, Any]:
         0,
         int(value.get("render_revision", value.get("revision", 0))),
     )
+    value["edit_revision"] = max(
+        0,
+        int(value.get("edit_revision", value.get("revision", 0))),
+    )
     value["schema_version"] = SCHEMA_VERSION
     return value
 
 
-def _save_scene(scene: dict[str, Any], *, bump_revision: bool = True) -> dict[str, Any]:
+def _save_scene(
+    scene: dict[str, Any],
+    *,
+    bump_revision: bool = True,
+    bump_edit_revision: bool | None = None,
+) -> dict[str, Any]:
     scene_id = _validate_id(scene.get("scene_id"), "scene id")
+    if bump_edit_revision is None:
+        bump_edit_revision = bump_revision
+    if bump_edit_revision:
+        scene["edit_revision"] = max(0, int(scene.get("edit_revision", 0))) + 1
     if bump_revision:
         scene["revision"] = max(0, int(scene.get("revision", 0))) + 1
         scene["render_revision"] = max(
@@ -727,10 +864,17 @@ def create_scene(name: Any = "") -> dict[str, Any]:
         "name": _clean_name(name, "Untitled scene"),
         "revision": 0,
         "render_revision": 0,
+        "edit_revision": 0,
         "created_at": timestamp,
         "updated_at": timestamp,
         "objects": [],
         "layers": [],
+        "levels": normalize_levels(scene_id, None),
+        "architecture": normalize_architecture(
+            scene_id,
+            normalize_levels(scene_id, None),
+            {"buildings": [], "walls": [], "rooms": [], "openings": [], "materials": []},
+        ),
         "render": dict(_DEFAULT_RENDER_SETTINGS),
         "camera": {
             "position": list(_DEFAULT_CAMERA["position"]),
@@ -739,12 +883,14 @@ def create_scene(name: Any = "") -> dict[str, Any]:
             "fov": _DEFAULT_CAMERA["fov"],
         },
         "cameras": [],
+        "camera_tracks": [],
+        "textures": [],
         "lighting": dict(_DEFAULT_LIGHTING),
         "exports": {},
     }
     with _STATE_LOCK:
         resolve_scene_dir(scene_id).mkdir(parents=True, exist_ok=False)
-        _save_scene(scene, bump_revision=False)
+        _save_scene(scene, bump_revision=False, bump_edit_revision=False)
     return scene
 
 
@@ -965,6 +1111,7 @@ def import_ply_object(
             "created_at": _now(),
             "visible": True,
             "transform": normalize_transform({}),
+            **normalize_object_editor_properties({}),
             "gaussians": int(normalized["ply"]["gaussians"]),
             "source": {
                 "type": "ply_import",
@@ -990,6 +1137,11 @@ def import_ply_object(
         }
         with _STATE_LOCK:
             scene = load_scene(safe_scene_id)
+            item["level_id"] = scene["levels"][0]["level_id"]
+            item["building_id"] = (
+                scene["architecture"]["buildings"][0]["building_id"]
+                if scene["architecture"]["buildings"] else ""
+            )
             scene["objects"].append(item)
             scene["layers"].append({"type": "object", "object_id": object_id})
             scene["exports"] = {}
@@ -1278,7 +1430,7 @@ def store_scene_reference(
             "preview_size": preview_target.stat().st_size,
             "updated_at": _now(),
         }
-        _save_scene(scene, bump_revision=False)
+        _save_scene(scene, bump_revision=False, bump_edit_revision=True)
         return scene
 
 
@@ -1377,7 +1529,7 @@ def store_scene_skydome(
             0,
             int(scene.get("render_revision", scene.get("revision", 0))),
         ) + 1
-        return _save_scene(scene, bump_revision=False)
+        return _save_scene(scene, bump_revision=False, bump_edit_revision=True)
 
 
 def remove_scene_skydome(scene_id: str) -> dict[str, Any]:
@@ -1393,7 +1545,94 @@ def remove_scene_skydome(scene_id: str) -> dict[str, Any]:
             0,
             int(scene.get("render_revision", scene.get("revision", 0))),
         ) + 1
-        return _save_scene(scene, bump_revision=False)
+        return _save_scene(scene, bump_revision=False, bump_edit_revision=True)
+
+
+def _scene_texture_file(scene: dict[str, Any], texture_id: Any) -> Path:
+    normalized_id = _validate_id(texture_id, "texture id")
+    entry = next(
+        (
+            item for item in scene.get("textures", [])
+            if isinstance(item, dict) and item.get("texture_id") == normalized_id
+        ),
+        None,
+    )
+    if entry is None:
+        raise FileNotFoundError("scene texture was not found")
+    relative = entry.get("file")
+    root = resolve_scene_dir(scene["scene_id"])
+    target = (root / str(relative or "")).resolve()
+    if root not in target.parents or not target.is_file():
+        raise FileNotFoundError("scene texture file is missing")
+    return target
+
+
+def store_scene_texture(
+    scene_id: str,
+    image_bytes: bytes,
+    file_name: Any = "texture.png",
+) -> tuple[dict[str, Any], dict[str, Any]]:
+    image = _decode_image(image_bytes, max_bytes=MAX_TEXTURE_BYTES).convert("RGBA")
+    if image.width > 8192 or image.height > 8192 or image.width * image.height > 67_108_864:
+        raise ValueError("texture dimensions are too large")
+    texture_id = _new_id()
+    root = resolve_scene_dir(scene_id)
+    texture_root = root / "textures"
+    texture_root.mkdir(parents=True, exist_ok=True)
+    target = texture_root / f"{texture_id}.png"
+    temporary = texture_root / f".{texture_id}.{secrets.token_hex(6)}.tmp"
+    try:
+        image.save(temporary, format="PNG", optimize=True)
+        os.replace(temporary, target)
+        with _STATE_LOCK:
+            scene = load_scene(scene_id)
+            if len(scene.get("textures", [])) >= 512:
+                raise ValueError("scene texture limit was exceeded")
+            entry = {
+                "texture_id": texture_id,
+                "name": _clean_name(Path(str(file_name or "")).stem, "Texture", 80),
+                "file": str(target.relative_to(root)),
+                "mime": "image/png",
+                "width": image.width,
+                "height": image.height,
+                "size": target.stat().st_size,
+                "updated_at": _now(),
+            }
+            scene.setdefault("textures", []).append(entry)
+            saved = _save_scene(scene, bump_revision=False, bump_edit_revision=True)
+            return saved, entry
+    except Exception:
+        target.unlink(missing_ok=True)
+        raise
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def remove_scene_texture(scene_id: str, texture_id: Any) -> dict[str, Any]:
+    normalized_id = _validate_id(texture_id, "texture id")
+    with _STATE_LOCK:
+        scene = load_scene(scene_id)
+        target = _scene_texture_file(scene, normalized_id)
+        before = len(scene.get("textures", []))
+        scene["textures"] = [
+            item for item in scene.get("textures", [])
+            if item.get("texture_id") != normalized_id
+        ]
+        if len(scene["textures"]) == before:
+            raise FileNotFoundError("scene texture was not found")
+        for material in scene.get("architecture", {}).get("materials", []):
+            if material.get("texture_id") == normalized_id:
+                material.pop("texture_id", None)
+        scene["render_revision"] = max(
+            0,
+            int(scene.get("render_revision", scene.get("revision", 0))),
+        ) + 1
+        saved = _save_scene(scene, bump_revision=False, bump_edit_revision=True)
+        try:
+            target.unlink(missing_ok=True)
+        except OSError:
+            LOGGER.warning("Could not remove retired scene texture %s", target, exc_info=True)
+        return saved
 
 
 def store_scene_preview(
@@ -2589,6 +2828,7 @@ def _generate_object(
             "name": object_name,
             "created_at": _now(),
             "transform": normalize_transform({}),
+            **normalize_object_editor_properties({}),
             "gaussians": gaussian_count,
             "seed": seed,
             "checksums": {
@@ -2620,6 +2860,11 @@ def _generate_object(
         _emit(job, "scene", 98, "Adding object to scene", detail=object_name)
         with _STATE_LOCK:
             scene = load_scene(scene_id)
+            item["level_id"] = scene["levels"][0]["level_id"]
+            item["building_id"] = (
+                scene["architecture"]["buildings"][0]["building_id"]
+                if scene["architecture"]["buildings"] else ""
+            )
             scene["objects"].append(item)
             scene["layers"].append({"type": "object", "object_id": object_id})
             scene["exports"] = {}
@@ -2666,6 +2911,15 @@ def _public_scene(scene: dict[str, Any]) -> dict[str, Any]:
         )
         skydome.pop("file", None)
         skydome.pop("viewport_file", None)
+    for texture in value.get("textures", []):
+        if not isinstance(texture, dict):
+            continue
+        texture_id = texture.get("texture_id")
+        texture["url"] = (
+            f"{API_BASE}/scenes/{scene_id}/textures/{texture_id}"
+            f"?v={int(float(texture.get('updated_at', 0) or 0) * 1000)}"
+        )
+        texture.pop("file", None)
     preview = value.get("preview")
     if isinstance(preview, dict):
         render = _normalize_render_settings(value.get("render"))
@@ -2702,10 +2956,31 @@ def update_scene(scene_id: str, payload: Any) -> dict[str, Any]:
         raise ValueError("scene update must be an object")
     with _STATE_LOCK:
         scene = load_scene(scene_id)
+        if "base_edit_revision" in payload:
+            try:
+                base_edit_revision = int(payload["base_edit_revision"])
+            except (TypeError, ValueError) as exc:
+                raise ValueError("base edit revision is invalid") from exc
+            if base_edit_revision != int(scene.get("edit_revision", 0)):
+                raise RuntimeError(
+                    "scene was changed by another editor; reload it before saving"
+                )
         visible_before = _visible_object_ids(scene)
         changed = False
         render_changed = False
         preview_changed = False
+        reference_levels = normalize_levels(scene_id, payload["levels"], strict=True) \
+            if "levels" in payload else scene.get("levels", [])
+        reference_architecture = normalize_architecture(
+            scene_id,
+            reference_levels,
+            payload["architecture"],
+            strict=True,
+        ) if "architecture" in payload else scene.get("architecture", {})
+        valid_building_ids = {
+            building["building_id"]
+            for building in reference_architecture.get("buildings", [])
+        }
         if "name" in payload:
             name = _clean_name(payload["name"], scene["name"])
             if name != scene["name"]:
@@ -2740,11 +3015,114 @@ def update_scene(scene_id: str, payload: Any) -> dict[str, Any]:
                     if visible != (item.get("visible") is not False):
                         item["visible"] = visible
                         changed = True
+                if "level_id" in incoming:
+                    level_id = str(incoming.get("level_id") or "")
+                    level_source = normalize_levels(scene_id, payload["levels"], strict=True) \
+                        if "levels" in payload else scene.get("levels", [])
+                    valid_level_ids = {level["level_id"] for level in level_source}
+                    if level_id not in valid_level_ids:
+                        raise ValueError("scene object references an unknown floor level")
+                    if level_id != item.get("level_id"):
+                        item["level_id"] = level_id
+                        changed = True
+                if "building_id" in incoming:
+                    building_id = str(incoming.get("building_id") or "")
+                    if building_id and building_id not in valid_building_ids:
+                        raise ValueError("scene object references an unknown building")
+                    if building_id != item.get("building_id"):
+                        item["building_id"] = building_id
+                        changed = True
+                if any(
+                    key in incoming
+                    for key in ("collision_proxy", "light_transport", "transmission", "locked")
+                ):
+                    editor_properties = normalize_object_editor_properties({
+                        **item,
+                        **incoming,
+                    })
+                    previous_editor_properties = normalize_object_editor_properties(item)
+                    if editor_properties != previous_editor_properties:
+                        item.update(editor_properties)
+                        changed = True
+                        if (
+                            editor_properties["light_transport"]
+                            != previous_editor_properties["light_transport"]
+                            or editor_properties["transmission"]
+                            != previous_editor_properties["transmission"]
+                            or editor_properties["collision_proxy"]
+                            != previous_editor_properties["collision_proxy"]
+                        ):
+                            preview_changed = True
         if "layers" in payload:
             layers = _normalize_scene_layers(scene, payload["layers"], strict=True)
             if layers != scene.get("layers"):
                 scene["layers"] = layers
                 changed = True
+        if "levels" in payload:
+            levels = normalize_levels(scene_id, payload["levels"], strict=True)
+            if levels != scene.get("levels"):
+                scene["levels"] = levels
+                scene["architecture"] = normalize_architecture(
+                    scene_id,
+                    levels,
+                    scene.get("architecture"),
+                )
+                valid_level_ids = {level["level_id"] for level in levels}
+                fallback_level_id = levels[0]["level_id"]
+                for item in scene.get("objects", []):
+                    if item.get("level_id") not in valid_level_ids:
+                        item["level_id"] = fallback_level_id
+                for camera in scene.get("cameras", []):
+                    if camera.get("level_id") not in valid_level_ids:
+                        camera["level_id"] = fallback_level_id
+                for light in scene.get("lighting", {}).get("lights", []):
+                    if light.get("level_id") not in valid_level_ids:
+                        light["level_id"] = fallback_level_id
+                changed = True
+                preview_changed = True
+        if "architecture" in payload:
+            architecture = reference_architecture
+            texture_ids = {
+                item.get("texture_id")
+                for item in scene.get("textures", [])
+                if isinstance(item, dict)
+            }
+            if any(
+                material.get("texture_id")
+                and material.get("texture_id") not in texture_ids
+                for material in architecture.get("materials", [])
+            ):
+                raise ValueError("architecture references an unknown scene texture")
+            referenced_building_ids = {
+                item.get("building_id") for item in scene.get("objects", [])
+            } | {
+                camera.get("building_id")
+                for camera in (
+                    _normalize_scene_cameras(payload["cameras"], strict=True)
+                    if "cameras" in payload else scene.get("cameras", [])
+                )
+            } | {
+                light.get("building_id")
+                for light in (
+                    _normalize_lighting(payload["lighting"])
+                    if "lighting" in payload else scene.get("lighting", {})
+                ).get("lights", [])
+            } | {
+                track.get("building_id")
+                for track in (
+                    normalize_camera_tracks(payload["camera_tracks"], strict=True)
+                    if "camera_tracks" in payload else scene.get("camera_tracks", [])
+                )
+            }
+            if any(
+                building_id and building_id not in valid_building_ids
+                for building_id in referenced_building_ids
+            ):
+                raise ValueError("scene content references a removed building")
+            if architecture != scene.get("architecture"):
+                scene["architecture"] = architecture
+                changed = True
+                preview_changed = True
         if "render" in payload:
             render = _normalize_render_settings(payload["render"])
             previous_render = _normalize_render_settings(scene.get("render"))
@@ -2763,12 +3141,45 @@ def update_scene(scene_id: str, payload: Any) -> dict[str, Any]:
                 preview_changed = True
         if "cameras" in payload:
             cameras = _normalize_scene_cameras(payload["cameras"], strict=True)
+            valid_level_ids = {level["level_id"] for level in scene.get("levels", [])}
+            fallback_level_id = scene.get("levels", [{}])[0].get("level_id", "")
+            for camera in cameras:
+                if not camera.get("level_id") and fallback_level_id:
+                    camera["level_id"] = fallback_level_id
+            if any(camera.get("level_id") not in valid_level_ids for camera in cameras):
+                raise ValueError("saved camera references an unknown floor level")
+            if any(
+                camera.get("building_id")
+                and camera.get("building_id") not in valid_building_ids
+                for camera in cameras
+            ):
+                raise ValueError("saved camera references an unknown building")
             if cameras != _normalize_scene_cameras(scene.get("cameras")):
                 scene["cameras"] = cameras
                 changed = True
                 preview_changed = True
+        if "camera_tracks" in payload:
+            camera_tracks = normalize_camera_tracks(payload["camera_tracks"], strict=True)
+            if any(
+                track.get("building_id")
+                and track.get("building_id") not in valid_building_ids
+                for track in camera_tracks
+            ):
+                raise ValueError("camera path references an unknown building")
+            if camera_tracks != scene.get("camera_tracks"):
+                scene["camera_tracks"] = camera_tracks
+                changed = True
         if "lighting" in payload:
             lighting = _normalize_lighting(payload["lighting"])
+            valid_level_ids = {level["level_id"] for level in scene.get("levels", [])}
+            if any(light.get("level_id") not in valid_level_ids for light in lighting.get("lights", [])):
+                raise ValueError("scene light references an unknown floor level")
+            if any(
+                light.get("building_id")
+                and light.get("building_id") not in valid_building_ids
+                for light in lighting.get("lights", [])
+            ):
+                raise ValueError("scene light references an unknown building")
             if lighting != _normalize_lighting(scene.get("lighting")):
                 scene["lighting"] = lighting
                 changed = True
@@ -2802,7 +3213,11 @@ def update_scene(scene_id: str, payload: Any) -> dict[str, Any]:
                 0,
                 int(scene.get("render_revision", scene.get("revision", 0))),
             ) + 1
-        return _save_scene(scene, bump_revision=render_changed)
+        return _save_scene(
+            scene,
+            bump_revision=render_changed,
+            bump_edit_revision=True,
+        )
 
 
 def _scene_sources(scene: dict[str, Any], only_object_id: str = "") -> list[tuple[Path, Any]]:
@@ -3076,6 +3491,8 @@ def register_routes(routes: Any) -> None:
             return web.json_response(_public_scene(scene))
         except FileNotFoundError as exc:
             return _json_error(web, exc, 404)
+        except RuntimeError as exc:
+            return _json_error(web, exc, 409)
         except Exception as exc:
             return _json_error(web, exc)
 
@@ -3115,7 +3532,9 @@ def register_routes(routes: Any) -> None:
                 image_bytes,
                 getattr(image_field, "filename", "reference.png"),
             )
-            return web.json_response(_public_scene(scene)["reference"], status=201)
+            reference = _public_scene(scene)["reference"]
+            reference["edit_revision"] = scene.get("edit_revision", 0)
+            return web.json_response(reference, status=201)
         except FileNotFoundError as exc:
             return _json_error(web, exc, 404)
         except Exception as exc:
@@ -3198,6 +3617,65 @@ def register_routes(routes: Any) -> None:
     async def factory_scene_skydome_delete(request: Any) -> Any:
         try:
             scene = remove_scene_skydome(request.match_info["scene_id"])
+            return web.json_response(_public_scene(scene))
+        except FileNotFoundError as exc:
+            return _json_error(web, exc, 404)
+        except Exception as exc:
+            return _json_error(web, exc)
+
+    @routes.post(f"{API_BASE}/scenes/{{scene_id}}/textures")
+    async def factory_scene_texture_upload(request: Any) -> Any:
+        try:
+            if not _content_length_ok(request, MAX_TEXTURE_BYTES + 1024 * 1024):
+                return web.json_response({"error": "texture upload is too large"}, status=413)
+            scene_id = _validate_id(request.match_info["scene_id"], "scene id")
+            load_scene(scene_id)
+            post = await request.post()
+            image_field = post.get("image")
+            if image_field is None or not hasattr(image_field, "file"):
+                raise ValueError("missing texture image")
+            image_bytes = await asyncio.to_thread(
+                image_field.file.read,
+                MAX_TEXTURE_BYTES + 1,
+            )
+            scene, entry = await asyncio.to_thread(
+                store_scene_texture,
+                scene_id,
+                image_bytes,
+                getattr(image_field, "filename", "texture.png"),
+            )
+            public_scene = _public_scene(scene)
+            public_entry = next(
+                item for item in public_scene.get("textures", [])
+                if item.get("texture_id") == entry["texture_id"]
+            )
+            return web.json_response({"texture": public_entry, "scene": public_scene}, status=201)
+        except FileNotFoundError as exc:
+            return _json_error(web, exc, 404)
+        except Exception as exc:
+            return _json_error(web, exc)
+
+    @routes.get(f"{API_BASE}/scenes/{{scene_id}}/textures/{{texture_id}}")
+    async def factory_scene_texture_get(request: Any) -> Any:
+        try:
+            scene = load_scene(request.match_info["scene_id"])
+            return web.FileResponse(
+                _scene_texture_file(scene, request.match_info["texture_id"]),
+                headers={"Cache-Control": "private, max-age=31536000, immutable"},
+            )
+        except FileNotFoundError as exc:
+            return _json_error(web, exc, 404)
+        except Exception as exc:
+            return _json_error(web, exc)
+
+    @routes.delete(f"{API_BASE}/scenes/{{scene_id}}/textures/{{texture_id}}")
+    async def factory_scene_texture_delete(request: Any) -> Any:
+        try:
+            scene = await asyncio.to_thread(
+                remove_scene_texture,
+                request.match_info["scene_id"],
+                request.match_info["texture_id"],
+            )
             return web.json_response(_public_scene(scene))
         except FileNotFoundError as exc:
             return _json_error(web, exc, 404)

--- a/api/factory3d.py
+++ b/api/factory3d.py
@@ -885,7 +885,7 @@ def create_scene(name: Any = "") -> dict[str, Any]:
         "cameras": [],
         "camera_tracks": [],
         "textures": [],
-        "lighting": dict(_DEFAULT_LIGHTING),
+        "lighting": _normalize_lighting(None),
         "exports": {},
     }
     with _STATE_LOCK:

--- a/api/factory3d_library.py
+++ b/api/factory3d_library.py
@@ -264,6 +264,29 @@ def _skydome_payload(
     return output
 
 
+def _texture_payloads(
+    archive: zipfile.ZipFile,
+    scene: dict[str, Any],
+) -> list[dict[str, Any]]:
+    stored_textures: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in scene.get("textures", []):
+        if not isinstance(raw, dict):
+            continue
+        texture_id = factory._validate_id(raw.get("texture_id"), "texture id")
+        if texture_id in seen:
+            raise ValueError("scene texture ids must be unique")
+        source = factory._scene_texture_file(scene, texture_id)
+        member = f"payload/textures/{texture_id}.png"
+        _zip_write_file(archive, source, member)
+        stored = json.loads(json.dumps(raw))
+        stored.pop("url", None)
+        stored["file"] = member
+        stored_textures.append(stored)
+        seen.add(texture_id)
+    return stored_textures
+
+
 def _build_package(
     scene: dict[str, Any],
     target: Path,
@@ -299,6 +322,7 @@ def _build_package(
                     gaussian_count += int(item.get("gaussians", 0) or 0)
                 snapshot = json.loads(json.dumps(scene))
                 snapshot["objects"] = stored_objects
+                snapshot["textures"] = _texture_payloads(archive, scene)
                 snapshot.pop("preview", None)
                 snapshot.pop("capture_set", None)
                 snapshot.pop("preview_sync", None)
@@ -719,6 +743,60 @@ def _install_skydome(
     return skydome_id
 
 
+def _install_textures(
+    archive: zipfile.ZipFile,
+    stored_textures: Any,
+    scene: dict[str, Any],
+) -> dict[str, str]:
+    if not isinstance(stored_textures, list):
+        return {}
+    if len(stored_textures) > 512:
+        raise ValueError("scene package contains too many textures")
+    root = factory.resolve_scene_dir(scene["scene_id"])
+    texture_root = root / "textures"
+    texture_id_map: dict[str, str] = {}
+    texture_members: set[str] = set()
+    for stored in stored_textures:
+        if not isinstance(stored, dict):
+            raise ValueError("scene package contains invalid texture metadata")
+        old_id = factory._validate_id(stored.get("texture_id"), "texture id")
+        if old_id in texture_id_map:
+            raise ValueError("scene package contains duplicate texture ids")
+        member_name = str(stored.get("file") or "")
+        if member_name in texture_members:
+            raise ValueError("scene package contains duplicate texture members")
+        member = archive.getinfo(member_name)
+        _safe_member(member)
+        if member.file_size <= 0 or member.file_size > factory.MAX_TEXTURE_BYTES:
+            raise ValueError("scene package texture is empty or too large")
+        image = factory._decode_image(
+            archive.read(member),
+            max_bytes=factory.MAX_TEXTURE_BYTES,
+        ).convert("RGBA")
+        new_id = factory._new_id()
+        texture_root.mkdir(parents=True, exist_ok=True)
+        target = texture_root / f"{new_id}.png"
+        temporary = texture_root / f".{new_id}.{secrets.token_hex(6)}.tmp"
+        try:
+            image.save(temporary, format="PNG", optimize=True)
+            os.replace(temporary, target)
+        finally:
+            temporary.unlink(missing_ok=True)
+        scene.setdefault("textures", []).append({
+            "texture_id": new_id,
+            "name": factory._clean_name(stored.get("name"), "Texture", 80),
+            "file": str(target.relative_to(root)),
+            "mime": "image/png",
+            "width": image.width,
+            "height": image.height,
+            "size": target.stat().st_size,
+            "updated_at": time.time(),
+        })
+        texture_id_map[old_id] = new_id
+        texture_members.add(member_name)
+    return texture_id_map
+
+
 def load_asset(
     asset_id: str,
     *,
@@ -735,9 +813,15 @@ def load_asset(
             with factory._STATE_LOCK:
                 scene = factory.load_scene(scene_id)
                 object_id = _install_object(archive, payload.get("object") or {}, scene)
-                factory._object_by_id(scene, object_id)["name"] = _name(
+                installed_object = factory._object_by_id(scene, object_id)
+                installed_object["name"] = _name(
                     record.get("name"),
                     "Gaussian object",
+                )
+                installed_object["level_id"] = scene["levels"][0]["level_id"]
+                installed_object["building_id"] = (
+                    scene["architecture"]["buildings"][0]["building_id"]
+                    if scene["architecture"]["buildings"] else ""
                 )
                 scene["exports"] = {}
                 factory._save_scene(scene)
@@ -759,7 +843,11 @@ def load_asset(
                     0,
                     int(scene.get("render_revision", scene.get("revision", 0))),
                 ) + 1
-                factory._save_scene(scene, bump_revision=False)
+                factory._save_scene(
+                    scene,
+                    bump_revision=False,
+                    bump_edit_revision=True,
+                )
             return {
                 "scene": factory._public_scene(scene),
                 "object_id": "",
@@ -776,8 +864,15 @@ def load_asset(
         try:
             with factory._STATE_LOCK:
                 scene = factory.load_scene(scene["scene_id"])
+                texture_id_map = _install_textures(
+                    archive,
+                    stored_scene.get("textures", []),
+                    scene,
+                )
                 for stored in stored_scene.get("objects", []):
-                    old_id = str(stored.get("object_id") or "")
+                    old_id = factory._validate_id(stored.get("object_id"), "object id")
+                    if old_id in id_map:
+                        raise ValueError("scene package contains duplicate object ids")
                     id_map[old_id] = _install_object(archive, stored, scene)
                 scene["layers"] = []
                 for layer in stored_scene.get("layers", []):
@@ -796,6 +891,7 @@ def load_asset(
                             copied["group_id"] = factory._new_id()
                             copied["children"] = children
                             scene["layers"].append(copied)
+                scene["layers"] = factory._normalize_scene_layers(scene)
                 scene["render"] = factory._normalize_render_settings(stored_scene.get("render"))
                 scene["camera"] = factory._normalize_camera(stored_scene.get("camera"))
                 scene["cameras"] = factory._normalize_scene_cameras(
@@ -810,6 +906,60 @@ def load_asset(
                     strict=True,
                 )
                 scene["lighting"] = factory._normalize_lighting(stored_scene.get("lighting"))
+                if "levels" in stored_scene:
+                    scene["levels"] = factory.normalize_levels(
+                        scene["scene_id"],
+                        stored_scene.get("levels"),
+                        strict=True,
+                    )
+                if "architecture" in stored_scene:
+                    stored_architecture = json.loads(json.dumps(stored_scene["architecture"]))
+                    if not isinstance(stored_architecture, dict):
+                        raise ValueError("scene package contains invalid architecture")
+                    for material in stored_architecture.get("materials", []):
+                        old_texture_id = material.get("texture_id")
+                        if old_texture_id in texture_id_map:
+                            material["texture_id"] = texture_id_map[old_texture_id]
+                        else:
+                            material.pop("texture_id", None)
+                    scene["architecture"] = factory.normalize_architecture(
+                        scene["scene_id"],
+                        scene["levels"],
+                        stored_architecture,
+                        strict=True,
+                    )
+                if "camera_tracks" in stored_scene:
+                    scene["camera_tracks"] = factory.normalize_camera_tracks(
+                        stored_scene.get("camera_tracks"),
+                        strict=True,
+                    )
+                valid_level_ids = {level["level_id"] for level in scene["levels"]}
+                default_level_id = scene["levels"][0]["level_id"]
+                valid_building_ids = {
+                    building["building_id"] for building in scene["architecture"]["buildings"]
+                }
+                default_building_id = (
+                    scene["architecture"]["buildings"][0]["building_id"]
+                    if scene["architecture"]["buildings"] else ""
+                )
+                for item in scene["objects"]:
+                    if item.get("level_id") not in valid_level_ids:
+                        item["level_id"] = default_level_id
+                    if item.get("building_id") not in valid_building_ids:
+                        item["building_id"] = default_building_id
+                for camera in scene["cameras"]:
+                    if camera.get("level_id") not in valid_level_ids:
+                        camera["level_id"] = default_level_id
+                    if camera.get("building_id") not in valid_building_ids:
+                        camera["building_id"] = default_building_id
+                for light in scene["lighting"].get("lights", []):
+                    if light.get("level_id") not in valid_level_ids:
+                        light["level_id"] = default_level_id
+                    if light.get("building_id") not in valid_building_ids:
+                        light["building_id"] = default_building_id
+                for track in scene.get("camera_tracks", []):
+                    if track.get("building_id") not in valid_building_ids:
+                        track["building_id"] = default_building_id
                 stored_skydome = stored_scene.get("skydome")
                 if isinstance(stored_skydome, dict):
                     _install_skydome(archive, stored_skydome, scene)

--- a/api/factory3d_schema.py
+++ b/api/factory3d_schema.py
@@ -330,6 +330,24 @@ def normalize_architecture(
             return ""
         return result
 
+    def architecture_building_id(raw: dict[str, Any], label: str) -> str:
+        requested = raw.get("building_id")
+        result = _id(requested)
+        if requested not in (None, "") and not result:
+            if strict:
+                raise ValueError(f"{label} building id is invalid")
+            return ""
+        if result and result not in building_ids:
+            if strict:
+                raise ValueError(f"{label} references an unknown building")
+            return ""
+        # Missing ownership belongs to the first Building only for legacy
+        # architecture that never serialized this field. An explicit empty
+        # value is a valid scene-root room or wall, even when Buildings exist.
+        if not result and "building_id" not in raw:
+            return default_building_id
+        return result
+
     if strict and (not isinstance(raw_walls, list) or len(raw_walls) > MAX_WALLS):
         raise ValueError("scene walls are invalid")
     walls: list[dict[str, Any]] = []
@@ -349,11 +367,7 @@ def normalize_architecture(
             if strict:
                 raise ValueError("wall references an unknown level")
             level_id = default_level_id
-        building_id = _id(raw.get("building_id")) or default_building_id
-        if not building_id or building_id not in building_ids:
-            if strict:
-                raise ValueError("wall references an unknown building")
-            continue
+        building_id = architecture_building_id(raw, "wall")
         start = _point2(raw.get("start"))
         end = _point2(raw.get("end"), (1.0, 0.0))
         if math.dist(start, end) < 0.001:
@@ -399,11 +413,7 @@ def normalize_architecture(
             if strict:
                 raise ValueError("room references an unknown level")
             level_id = default_level_id
-        building_id = _id(raw.get("building_id")) or default_building_id
-        if not building_id or building_id not in building_ids:
-            if strict:
-                raise ValueError("room references an unknown building")
-            continue
+        building_id = architecture_building_id(raw, "room")
         raw_polygon = raw.get("polygon", [])
         if not isinstance(raw_polygon, list) or not 3 <= len(raw_polygon) <= 512:
             if strict:

--- a/api/factory3d_schema.py
+++ b/api/factory3d_schema.py
@@ -1,0 +1,721 @@
+"""Versioned scene primitives for VNCCS 3D Factory interior editing.
+
+The Factory backend keeps binary Gaussian assets separate from lightweight
+editor state.  This module owns normalization for the latter so room-layout
+data can evolve without coupling it to generation or PLY export code.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import math
+import re
+from typing import Any
+
+
+ID_RE = re.compile(r"^[a-f0-9]{32}$")
+HEX_COLOR_RE = re.compile(r"^#[0-9a-f]{6}$", re.IGNORECASE)
+
+MAX_LEVELS = 64
+MAX_BUILDINGS = 64
+MAX_MATERIALS = 512
+MAX_WALLS = 4096
+MAX_ROOMS = 1024
+MAX_OPENINGS = 4096
+MAX_CAMERA_TRACKS = 16
+MAX_CAMERA_KEYFRAMES = 1000
+
+DEFAULT_LEVEL_HEIGHT = 2.8
+DEFAULT_SLAB_THICKNESS = 0.15
+DEFAULT_WALL_HEIGHT = 2.8
+DEFAULT_WALL_THICKNESS = 0.12
+
+
+def _finite(value: Any, fallback: float = 0.0) -> float:
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return fallback
+    return number if math.isfinite(number) else fallback
+
+
+def _bounded(value: Any, minimum: float, maximum: float, fallback: float) -> float:
+    return max(minimum, min(maximum, _finite(value, fallback)))
+
+
+def _clean_text(value: Any, fallback: str, maximum: int = 96) -> str:
+    text = re.sub(r"[\x00-\x1f\x7f]+", "", str(value or "")).strip()
+    return text[:maximum] or fallback
+
+
+def _id(value: Any) -> str:
+    text = str(value or "").lower()
+    return text if ID_RE.fullmatch(text) else ""
+
+
+def _required_id(value: Any, label: str, *, strict: bool) -> str:
+    normalized = _id(value)
+    if normalized:
+        return normalized
+    if strict:
+        raise ValueError(f"{label} is invalid")
+    return ""
+
+
+def _stable_id(scene_id: str, namespace: str) -> str:
+    return hashlib.sha256(f"{scene_id}:{namespace}".encode("utf-8")).hexdigest()[:32]
+
+
+def _point2(value: Any, fallback: tuple[float, float] = (0.0, 0.0)) -> list[float]:
+    source = value if isinstance(value, (list, tuple)) else fallback
+    return [
+        _finite(source[index] if index < len(source) else fallback[index], fallback[index])
+        for index in range(2)
+    ]
+
+
+def _point3(
+    value: Any,
+    fallback: tuple[float, float, float] = (0.0, 0.0, 0.0),
+) -> list[float]:
+    source = value if isinstance(value, (list, tuple)) else fallback
+    return [
+        _finite(source[index] if index < len(source) else fallback[index], fallback[index])
+        for index in range(3)
+    ]
+
+
+def _simple_polygon(points: list[list[float]]) -> bool:
+    if any(
+        math.dist(points[index], points[(index + 1) % len(points)]) < 0.001
+        for index in range(len(points))
+    ):
+        return False
+    area = sum(
+        points[index][0] * points[(index + 1) % len(points)][1]
+        - points[(index + 1) % len(points)][0] * points[index][1]
+        for index in range(len(points))
+    ) * 0.5
+    if abs(area) < 1e-6:
+        return False
+
+    def orientation(a: list[float], b: list[float], c: list[float]) -> float:
+        return (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+
+    def on_segment(a: list[float], b: list[float], point: list[float]) -> bool:
+        return (
+            min(a[0], b[0]) - 1e-9 <= point[0] <= max(a[0], b[0]) + 1e-9
+            and min(a[1], b[1]) - 1e-9 <= point[1] <= max(a[1], b[1]) + 1e-9
+        )
+
+    def intersects(
+        a: list[float], b: list[float], c: list[float], d: list[float],
+    ) -> bool:
+        values = (
+            orientation(a, b, c),
+            orientation(a, b, d),
+            orientation(c, d, a),
+            orientation(c, d, b),
+        )
+        if values[0] * values[1] < 0 and values[2] * values[3] < 0:
+            return True
+        return (
+            (abs(values[0]) <= 1e-9 and on_segment(a, b, c))
+            or (abs(values[1]) <= 1e-9 and on_segment(a, b, d))
+            or (abs(values[2]) <= 1e-9 and on_segment(c, d, a))
+            or (abs(values[3]) <= 1e-9 and on_segment(c, d, b))
+        )
+
+    count = len(points)
+    for left in range(count):
+        a = points[left]
+        b = points[(left + 1) % count]
+        for right in range(left + 1, count):
+            if right in {left, (left + 1) % count} or (right + 1) % count == left:
+                continue
+            c = points[right]
+            d = points[(right + 1) % count]
+            if intersects(a, b, c, d):
+                return False
+    return True
+
+
+def _quaternion(value: Any) -> list[float]:
+    source = _point3(value, (0.0, 0.0, 0.0))
+    try:
+        w = _finite(value[3], 1.0) if isinstance(value, (list, tuple)) else 1.0
+    except IndexError:
+        w = 1.0
+    length = math.sqrt(sum(component * component for component in (*source, w)))
+    if length < 1e-12:
+        return [0.0, 0.0, 0.0, 1.0]
+    return [source[0] / length, source[1] / length, source[2] / length, w / length]
+
+
+def default_level(scene_id: str) -> dict[str, Any]:
+    return {
+        "level_id": _stable_id(scene_id, "level:0"),
+        "name": "Level 1",
+        "elevation": 0.0,
+        "height": DEFAULT_LEVEL_HEIGHT,
+        "slab_thickness": DEFAULT_SLAB_THICKNESS,
+        "visible": True,
+    }
+
+
+def normalize_levels(scene_id: str, value: Any, *, strict: bool = False) -> list[dict[str, Any]]:
+    source = value if isinstance(value, list) else []
+    if strict and (not isinstance(value, list) or len(source) > MAX_LEVELS):
+        raise ValueError("scene levels are invalid")
+    output: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for index, raw in enumerate(source[:MAX_LEVELS]):
+        if not isinstance(raw, dict):
+            if strict:
+                raise ValueError("scene levels must be objects")
+            continue
+        level_id = _required_id(raw.get("level_id"), "level id", strict=strict)
+        if not level_id or level_id in seen:
+            if strict and level_id in seen:
+                raise ValueError("scene level ids must be unique")
+            continue
+        output.append({
+            "level_id": level_id,
+            "name": _clean_text(raw.get("name"), f"Level {index + 1}", 80),
+            "elevation": _bounded(raw.get("elevation"), -10000.0, 10000.0, 0.0),
+            "height": _bounded(raw.get("height"), 0.1, 1000.0, DEFAULT_LEVEL_HEIGHT),
+            "slab_thickness": _bounded(
+                raw.get("slab_thickness"), 0.0, 100.0, DEFAULT_SLAB_THICKNESS,
+            ),
+            "visible": raw.get("visible") is not False,
+        })
+        seen.add(level_id)
+    if not output:
+        output.append(default_level(scene_id))
+    output.sort(key=lambda item: (item["elevation"], item["level_id"]))
+    return output
+
+
+def _normalize_texture_slot(value: Any) -> dict[str, Any]:
+    data = value if isinstance(value, dict) else {}
+    texture_id = _id(data.get("texture_id"))
+    output = {
+        "color": (
+            str(data.get("color")).lower()
+            if HEX_COLOR_RE.fullmatch(str(data.get("color") or ""))
+            else "#d7d2ca"
+        ),
+        "roughness": _bounded(data.get("roughness"), 0.0, 1.0, 0.78),
+        "metalness": _bounded(data.get("metalness"), 0.0, 1.0, 0.0),
+        "opacity": _bounded(data.get("opacity"), 0.0, 1.0, 1.0),
+        "uv_scale": [
+            _bounded(_point2(data.get("uv_scale"), (1.0, 1.0))[0], 0.001, 1000.0, 1.0),
+            _bounded(_point2(data.get("uv_scale"), (1.0, 1.0))[1], 0.001, 1000.0, 1.0),
+        ],
+        "uv_rotation": _bounded(data.get("uv_rotation"), -36000.0, 36000.0, 0.0),
+    }
+    if texture_id:
+        output["texture_id"] = texture_id
+    return output
+
+
+def normalize_materials(value: Any, *, strict: bool = False) -> list[dict[str, Any]]:
+    source = value if isinstance(value, list) else []
+    if strict and (not isinstance(value, list) or len(source) > MAX_MATERIALS):
+        raise ValueError("scene materials are invalid")
+    output: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    for raw in source[:MAX_MATERIALS]:
+        if not isinstance(raw, dict):
+            if strict:
+                raise ValueError("scene materials must be objects")
+            continue
+        material_id = _required_id(raw.get("material_id"), "material id", strict=strict)
+        if not material_id or material_id in seen:
+            if strict and material_id in seen:
+                raise ValueError("scene material ids must be unique")
+            continue
+        kind = str(raw.get("kind") or "standard").lower()
+        if kind not in {"standard", "glass"}:
+            if strict:
+                raise ValueError("scene material kind is invalid")
+            kind = "standard"
+        material = {
+            "material_id": material_id,
+            "name": _clean_text(raw.get("name"), "Material", 80),
+            "kind": kind,
+            **_normalize_texture_slot(raw),
+        }
+        material["transmission"] = _bounded(
+            raw.get("transmission"), 0.0, 1.0, 1.0 if kind == "glass" else 0.0,
+        )
+        material["ior"] = _bounded(raw.get("ior"), 1.0, 2.5, 1.5)
+        output.append(material)
+        seen.add(material_id)
+    return output
+
+
+def normalize_architecture(
+    scene_id: str,
+    levels: list[dict[str, Any]],
+    value: Any,
+    *,
+    strict: bool = False,
+) -> dict[str, Any]:
+    data = value if isinstance(value, dict) else {}
+    if strict and not isinstance(value, dict):
+        raise ValueError("scene architecture must be an object")
+    level_ids = {item["level_id"] for item in levels}
+    default_level_id = levels[0]["level_id"]
+    materials = normalize_materials(data.get("materials", []), strict=strict)
+    material_ids = {item["material_id"] for item in materials}
+
+    has_building_schema = isinstance(data.get("buildings"), list)
+    raw_buildings = data.get("buildings", [])
+    raw_walls = data.get("walls", [])
+    raw_rooms = data.get("rooms", [])
+    if strict and (not isinstance(raw_buildings, list) or len(raw_buildings) > MAX_BUILDINGS):
+        raise ValueError("scene buildings are invalid")
+    buildings: list[dict[str, Any]] = []
+    building_ids: set[str] = set()
+    for index, raw in enumerate(
+        (raw_buildings if isinstance(raw_buildings, list) else [])[:MAX_BUILDINGS]
+    ):
+        if not isinstance(raw, dict):
+            if strict:
+                raise ValueError("scene buildings must be objects")
+            continue
+        building_id = _required_id(raw.get("building_id"), "building id", strict=strict)
+        if not building_id or building_id in building_ids:
+            if strict and building_id in building_ids:
+                raise ValueError("scene building ids must be unique")
+            continue
+        buildings.append({
+            "building_id": building_id,
+            "name": _clean_text(raw.get("name"), f"Building {index + 1}", 80),
+            "position": _point3(raw.get("position")),
+            "rotation_y": _bounded(raw.get("rotation_y"), -36000.0, 36000.0, 0.0),
+            "visible": raw.get("visible") is not False,
+            "locked": raw.get("locked") is True,
+        })
+        building_ids.add(building_id)
+    # Preserve architecture created before Building ownership existed, but
+    # treat an explicit empty list as intentional. New scenes and users who
+    # delete their final Building must remain building-free.
+    if (
+        not buildings
+        and not has_building_schema
+        and (
+            isinstance(raw_walls, list) and raw_walls
+            or isinstance(raw_rooms, list) and raw_rooms
+        )
+    ):
+        building_id = _stable_id(scene_id, "building:0")
+        buildings.append({
+            "building_id": building_id,
+            "name": "Building 1",
+            "position": [0.0, 0.0, 0.0],
+            "rotation_y": 0.0,
+            "visible": True,
+            "locked": False,
+        })
+        building_ids.add(building_id)
+    default_building_id = buildings[0]["building_id"] if buildings else ""
+
+    def material_id(raw: Any) -> str:
+        result = _id(raw)
+        if result and result not in material_ids:
+            if strict:
+                raise ValueError("architecture references an unknown material")
+            return ""
+        return result
+
+    if strict and (not isinstance(raw_walls, list) or len(raw_walls) > MAX_WALLS):
+        raise ValueError("scene walls are invalid")
+    walls: list[dict[str, Any]] = []
+    wall_ids: set[str] = set()
+    for raw in (raw_walls if isinstance(raw_walls, list) else [])[:MAX_WALLS]:
+        if not isinstance(raw, dict):
+            if strict:
+                raise ValueError("scene walls must be objects")
+            continue
+        wall_id = _required_id(raw.get("wall_id"), "wall id", strict=strict)
+        if not wall_id or wall_id in wall_ids:
+            if strict and wall_id in wall_ids:
+                raise ValueError("scene wall ids must be unique")
+            continue
+        level_id = _id(raw.get("level_id")) or default_level_id
+        if level_id not in level_ids:
+            if strict:
+                raise ValueError("wall references an unknown level")
+            level_id = default_level_id
+        building_id = _id(raw.get("building_id")) or default_building_id
+        if not building_id or building_id not in building_ids:
+            if strict:
+                raise ValueError("wall references an unknown building")
+            continue
+        start = _point2(raw.get("start"))
+        end = _point2(raw.get("end"), (1.0, 0.0))
+        if math.dist(start, end) < 0.001:
+            if strict:
+                raise ValueError("wall length is too small")
+            continue
+        walls.append({
+            "wall_id": wall_id,
+            "name": _clean_text(raw.get("name"), "Wall", 80),
+            "level_id": level_id,
+            "building_id": building_id,
+            "start": start,
+            "end": end,
+            "thickness": _bounded(
+                raw.get("thickness"), 0.01, 10.0, DEFAULT_WALL_THICKNESS,
+            ),
+            "height": _bounded(raw.get("height"), 0.05, 1000.0, DEFAULT_WALL_HEIGHT),
+            "elevation_offset": _bounded(raw.get("elevation_offset"), -1000.0, 1000.0, 0.0),
+            "material_left": material_id(raw.get("material_left")),
+            "material_right": material_id(raw.get("material_right")),
+            "material_caps": material_id(raw.get("material_caps")),
+            "visible": raw.get("visible") is not False,
+            "locked": raw.get("locked") is True,
+        })
+        wall_ids.add(wall_id)
+
+    if strict and (not isinstance(raw_rooms, list) or len(raw_rooms) > MAX_ROOMS):
+        raise ValueError("scene rooms are invalid")
+    rooms: list[dict[str, Any]] = []
+    room_ids: set[str] = set()
+    for raw in (raw_rooms if isinstance(raw_rooms, list) else [])[:MAX_ROOMS]:
+        if not isinstance(raw, dict):
+            if strict:
+                raise ValueError("scene rooms must be objects")
+            continue
+        room_id = _required_id(raw.get("room_id"), "room id", strict=strict)
+        if not room_id or room_id in room_ids:
+            if strict and room_id in room_ids:
+                raise ValueError("scene room ids must be unique")
+            continue
+        level_id = _id(raw.get("level_id")) or default_level_id
+        if level_id not in level_ids:
+            if strict:
+                raise ValueError("room references an unknown level")
+            level_id = default_level_id
+        building_id = _id(raw.get("building_id")) or default_building_id
+        if not building_id or building_id not in building_ids:
+            if strict:
+                raise ValueError("room references an unknown building")
+            continue
+        raw_polygon = raw.get("polygon", [])
+        if not isinstance(raw_polygon, list) or not 3 <= len(raw_polygon) <= 512:
+            if strict:
+                raise ValueError("room polygon is invalid")
+            continue
+        polygon = [_point2(point) for point in raw_polygon]
+        if not _simple_polygon(polygon):
+            if strict:
+                raise ValueError("room polygon must be simple and have non-zero area")
+            continue
+        floor = raw.get("floor") if isinstance(raw.get("floor"), dict) else {}
+        ceiling = raw.get("ceiling") if isinstance(raw.get("ceiling"), dict) else {}
+        raw_wall_ids = raw.get("wall_ids") if isinstance(raw.get("wall_ids"), list) else []
+        normalized_wall_ids = [_id(value) for value in raw_wall_ids]
+        linked_walls = {item["wall_id"]: item for item in walls}
+        if strict and any(wall_id not in wall_ids for wall_id in normalized_wall_ids):
+            raise ValueError("room references an unknown wall")
+        if strict and len(set(normalized_wall_ids)) != len(normalized_wall_ids):
+            raise ValueError("room perimeter wall ids must be unique")
+        normalized_wall_ids = [wall_id for wall_id in normalized_wall_ids if wall_id in wall_ids]
+        normalized_wall_ids = list(dict.fromkeys(normalized_wall_ids))
+        if normalized_wall_ids:
+            perimeter_valid = len(normalized_wall_ids) == len(polygon)
+            if strict and not perimeter_valid:
+                raise ValueError("room perimeter wall count does not match its polygon")
+            for index, wall_id in enumerate(normalized_wall_ids if perimeter_valid else []):
+                linked = linked_walls.get(wall_id)
+                if (
+                    linked is None
+                    or linked["level_id"] != level_id
+                    or linked["building_id"] != building_id
+                ):
+                    perimeter_valid = False
+                    if not strict:
+                        break
+                    raise ValueError("room perimeter wall belongs to another floor or building")
+                if (
+                    math.dist(linked["start"], polygon[index]) > 1e-4
+                    or math.dist(linked["end"], polygon[(index + 1) % len(polygon)]) > 1e-4
+                ):
+                    perimeter_valid = False
+                    if not strict:
+                        break
+                    raise ValueError("room perimeter walls do not match its polygon")
+            if not perimeter_valid:
+                normalized_wall_ids = []
+        rooms.append({
+            "room_id": room_id,
+            "name": _clean_text(raw.get("name"), "Room", 80),
+            "level_id": level_id,
+            "building_id": building_id,
+            "polygon": polygon,
+            "wall_ids": normalized_wall_ids,
+            "floor": {
+                "enabled": floor.get("enabled") is not False,
+                "thickness": _bounded(floor.get("thickness"), 0.0, 10.0, 0.02),
+                "material_id": material_id(floor.get("material_id")),
+            },
+            "ceiling": {
+                "enabled": ceiling.get("enabled") is not False,
+                "height": _bounded(ceiling.get("height"), 0.05, 1000.0, DEFAULT_LEVEL_HEIGHT),
+                "thickness": _bounded(ceiling.get("thickness"), 0.0, 10.0, 0.02),
+                "material_id": material_id(ceiling.get("material_id")),
+            },
+            "visible": raw.get("visible") is not False,
+            "locked": raw.get("locked") is True,
+        })
+        room_ids.add(room_id)
+
+    raw_openings = data.get("openings", [])
+    if strict and (not isinstance(raw_openings, list) or len(raw_openings) > MAX_OPENINGS):
+        raise ValueError("scene openings are invalid")
+    openings: list[dict[str, Any]] = []
+    opening_ids: set[str] = set()
+    walls_by_id = {item["wall_id"]: item for item in walls}
+    occupied_by_wall: dict[str, list[tuple[float, float]]] = {}
+    for raw in (raw_openings if isinstance(raw_openings, list) else [])[:MAX_OPENINGS]:
+        if not isinstance(raw, dict):
+            if strict:
+                raise ValueError("scene openings must be objects")
+            continue
+        opening_id = _required_id(raw.get("opening_id"), "opening id", strict=strict)
+        wall_id = _required_id(raw.get("wall_id"), "opening wall id", strict=strict)
+        if not opening_id or opening_id in opening_ids or wall_id not in wall_ids:
+            if strict:
+                raise ValueError("opening references an unknown wall or duplicate id")
+            continue
+        kind = str(raw.get("kind") or "empty").lower()
+        if kind not in {"empty", "door", "window"}:
+            if strict:
+                raise ValueError("opening kind is invalid")
+            kind = "empty"
+        wall = walls_by_id[wall_id]
+        wall_length = math.dist(wall["start"], wall["end"])
+        requested_offset = _bounded(raw.get("offset"), 0.0, 1.0, 0.5)
+        requested_width = _bounded(raw.get("width"), 0.05, 100.0, 0.9)
+        requested_height = _bounded(
+            raw.get("height"), 0.05, 100.0, 2.0 if kind == "door" else 1.2,
+        )
+        requested_sill = _bounded(
+            raw.get("sill_height"), 0.0, 100.0, 0.0 if kind == "door" else 0.9,
+        )
+        width = min(requested_width, wall_length)
+        height = min(requested_height, wall["height"])
+        sill_height = min(requested_sill, max(0.0, wall["height"] - height))
+        half = width / 2.0
+        requested_center = requested_offset * wall_length
+        occupied = occupied_by_wall.setdefault(wall_id, [])
+        free_intervals: list[tuple[float, float]] = []
+        cursor = 0.0
+        for start, end in sorted(occupied):
+            if start > cursor:
+                free_intervals.append((cursor, start))
+            cursor = max(cursor, end)
+        if cursor < wall_length:
+            free_intervals.append((cursor, wall_length))
+        candidates: list[tuple[float, float]] = []
+        for start, end in free_intervals:
+            minimum = start + half
+            maximum = end - half
+            if minimum <= maximum + 1e-9:
+                center = min(max(requested_center, minimum), maximum)
+                candidates.append((abs(center - requested_center), center))
+        if strict and (
+            requested_width > wall_length + 1e-9
+            or requested_center - half < -1e-9
+            or requested_center + half > wall_length + 1e-9
+            or requested_height + requested_sill > wall["height"] + 1e-9
+            or not candidates
+            or min(candidates)[0] > 1e-9
+        ):
+            raise ValueError("opening is outside its wall or overlaps another opening")
+        if not candidates:
+            continue
+        _, center = min(candidates)
+        offset = center / wall_length
+        occupied.append((center - half, center + half))
+        openings.append({
+            "opening_id": opening_id,
+            "wall_id": wall_id,
+            "name": _clean_text(raw.get("name"), kind.title(), 80),
+            "kind": kind,
+            "offset": offset,
+            "width": width,
+            "height": height,
+            "sill_height": sill_height,
+            "material_id": material_id(raw.get("material_id")),
+            "visible": raw.get("visible") is not False,
+            "locked": raw.get("locked") is True,
+        })
+        opening_ids.add(opening_id)
+
+    return {
+        "units": "m",
+        "materials": materials,
+        "buildings": buildings,
+        "walls": walls,
+        "rooms": rooms,
+        "openings": openings,
+    }
+
+
+def normalize_object_editor_properties(value: Any) -> dict[str, Any]:
+    data = value if isinstance(value, dict) else {}
+    collision = data.get("collision_proxy") if isinstance(data.get("collision_proxy"), dict) else {}
+    mode = str(collision.get("mode") or "auto_box").lower()
+    if mode not in {"auto_box", "box", "off"}:
+        mode = "auto_box"
+    light_transport = str(data.get("light_transport") or "opaque").lower()
+    if light_transport not in {"opaque", "cutout", "transmissive"}:
+        light_transport = "opaque"
+    return {
+        "collision_proxy": {
+            "mode": mode,
+            "center": _point3(collision.get("center")),
+            "size": [
+                _bounded(component, 0.001, 1000000.0, 1.0)
+                for component in _point3(collision.get("size"), (1.0, 1.0, 1.0))
+            ],
+            "supports_objects": collision.get("supports_objects") is not False,
+        },
+        "light_transport": light_transport,
+        "transmission": _bounded(data.get("transmission"), 0.0, 1.0, 1.0 if light_transport == "transmissive" else 0.0),
+        "locked": data.get("locked") is True,
+    }
+
+
+def normalize_camera_tracks(value: Any, *, strict: bool = False) -> list[dict[str, Any]]:
+    source = value if isinstance(value, list) else []
+    if strict and (not isinstance(value, list) or len(source) > MAX_CAMERA_TRACKS):
+        raise ValueError("camera tracks are invalid")
+    output: list[dict[str, Any]] = []
+    seen: set[str] = set()
+    seen_keyframes: set[str] = set()
+    total_keyframes = 0
+    for raw in source[:MAX_CAMERA_TRACKS]:
+        if not isinstance(raw, dict):
+            if strict:
+                raise ValueError("camera tracks must be objects")
+            continue
+        track_id = _required_id(raw.get("track_id"), "camera track id", strict=strict)
+        if not track_id or track_id in seen:
+            if strict and track_id in seen:
+                raise ValueError("camera track ids must be unique")
+            continue
+        raw_keyframes = raw.get("keyframes", [])
+        if not isinstance(raw_keyframes, list):
+            if strict:
+                raise ValueError("camera track keyframes are invalid")
+            raw_keyframes = []
+        keyframes: list[dict[str, Any]] = []
+        keyframe_ids: set[str] = set()
+        for frame in raw_keyframes:
+            if total_keyframes >= MAX_CAMERA_KEYFRAMES:
+                if strict:
+                    raise ValueError("camera track keyframe limit was exceeded")
+                break
+            if not isinstance(frame, dict):
+                if strict:
+                    raise ValueError("camera keyframes must be objects")
+                continue
+            keyframe_id = _required_id(frame.get("keyframe_id"), "camera keyframe id", strict=strict)
+            if (
+                not keyframe_id
+                or keyframe_id in keyframe_ids
+                or keyframe_id in seen_keyframes
+            ):
+                if strict:
+                    raise ValueError("camera keyframe ids must be unique within the scene")
+                continue
+            easing = str(frame.get("easing") or "smooth").lower()
+            if easing not in {"linear", "smooth", "ease_in", "ease_out", "ease_in_out"}:
+                easing = "smooth"
+            keyframes.append({
+                "keyframe_id": keyframe_id,
+                "time": _bounded(frame.get("time"), 0.0, 86400.0, 0.0),
+                "position": _point3(frame.get("position")),
+                "quaternion": _quaternion(frame.get("quaternion")),
+                "fov": _bounded(frame.get("fov"), 5.0, 120.0, 42.0),
+                "focus_distance": _bounded(frame.get("focus_distance"), 0.001, 1000000.0, 1.0),
+                "easing": easing,
+            })
+            keyframe_ids.add(keyframe_id)
+            seen_keyframes.add(keyframe_id)
+            total_keyframes += 1
+        keyframes.sort(key=lambda item: (item["time"], item["keyframe_id"]))
+        interpolation = str(raw.get("interpolation") or "catmullrom").lower()
+        if interpolation not in {"linear", "catmullrom"}:
+            interpolation = "catmullrom"
+        duration = max(
+            _bounded(raw.get("duration"), 0.1, 86400.0, 5.0),
+            keyframes[-1]["time"] if keyframes else 0.1,
+        )
+        output.append({
+            "track_id": track_id,
+            "name": _clean_text(raw.get("name"), "Camera track", 80),
+            "building_id": _id(raw.get("building_id")),
+            "duration": duration,
+            "fps": int(_bounded(raw.get("fps"), 1.0, 120.0, 30.0)),
+            "interpolation": interpolation,
+            "constant_speed": raw.get("constant_speed") is not False,
+            "loop": raw.get("loop") is True,
+            "keyframes": keyframes,
+        })
+        seen.add(track_id)
+    return output
+
+
+def normalize_lighting_extensions(value: Any) -> dict[str, Any]:
+    data = value if isinstance(value, dict) else {}
+    shadows = data.get("shadows") if isinstance(data.get("shadows"), dict) else {}
+    quality = str(shadows.get("quality") or "medium").lower()
+    if quality not in {"off", "low", "medium", "high", "ultra"}:
+        quality = "medium"
+    raw_lights = data.get("lights", [])
+    lights = []
+    seen: set[str] = set()
+    for raw in (raw_lights if isinstance(raw_lights, list) else [])[:32]:
+        if not isinstance(raw, dict):
+            continue
+        light_id = _id(raw.get("light_id"))
+        if not light_id or light_id in seen:
+            continue
+        kind = str(raw.get("kind") or "point").lower()
+        if kind not in {"point", "spot", "directional"}:
+            kind = "point"
+        color = str(raw.get("color") or "#ffffff").lower()
+        if not HEX_COLOR_RE.fullmatch(color):
+            color = "#ffffff"
+        lights.append({
+            "light_id": light_id,
+            "name": _clean_text(raw.get("name"), kind.title(), 80),
+            "level_id": _id(raw.get("level_id")),
+            "building_id": _id(raw.get("building_id")),
+            "kind": kind,
+            "position": _point3(raw.get("position"), (0.0, 2.0, 0.0)),
+            "target": _point3(raw.get("target"), (0.0, 0.0, -1.0)),
+            "color": color,
+            "intensity": _bounded(raw.get("intensity"), 0.0, 100000.0, 1.0),
+            "distance": _bounded(raw.get("distance"), 0.0, 1000000.0, 0.0),
+            "angle": _bounded(raw.get("angle"), 1.0, 179.0, 45.0),
+            "penumbra": _bounded(raw.get("penumbra"), 0.0, 1.0, 0.2),
+            "cast_shadow": raw.get("cast_shadow") is not False,
+            "visible": raw.get("visible") is not False,
+        })
+        seen.add(light_id)
+    return {
+        "shadows": {
+            "enabled": shadows.get("enabled") is not False and quality != "off",
+            "quality": quality,
+            "bias": _bounded(shadows.get("bias"), -0.1, 0.1, -0.0005),
+            "normal_bias": _bounded(shadows.get("normal_bias"), 0.0, 10.0, 0.02),
+        },
+        "lights": lights,
+    }

--- a/nodes/factory3d.py
+++ b/nodes/factory3d.py
@@ -16,8 +16,8 @@ import torch
 from PIL import Image
 
 
-_EMPTY_STATE = '{"schema_version":10,"scene_id":"","selected_object_id":"","selected_group_id":"","selected_object_ids":[]}'
-_MAX_STATE_CHARS = 2 * 1024 * 1024
+_EMPTY_STATE = '{"schema_version":17,"scene_id":"","selected_object_id":"","selected_group_id":"","selected_object_ids":[]}'
+_MAX_STATE_CHARS = 16 * 1024 * 1024
 _MAX_PREVIEW_PIXELS = 4096 * 4096
 _MAX_SCENE_CAMERAS = 32
 _ID_RE = re.compile(r"^[a-f0-9]{32}$")
@@ -81,6 +81,37 @@ def _parse_state(factory_data: Any) -> dict[str, Any]:
                 raise ValueError("3D Factory scene snapshot contains duplicate objects")
             if "visible" in item and not isinstance(item["visible"], bool):
                 raise ValueError("3D Factory scene snapshot contains invalid object visibility")
+            collision = item.get("collision_proxy", {})
+            if not isinstance(collision, dict) or collision.get("mode", "auto_box") not in {
+                "auto_box", "box", "off",
+            }:
+                raise ValueError("3D Factory scene snapshot contains an invalid collision proxy")
+            for key in ("center", "size"):
+                vector = collision.get(key, [0, 0, 0] if key == "center" else [1, 1, 1])
+                if (
+                    not isinstance(vector, list)
+                    or len(vector) != 3
+                    or any(
+                        not isinstance(component, (int, float))
+                        or isinstance(component, bool)
+                        or not math.isfinite(float(component))
+                        for component in vector
+                    )
+                    or (key == "size" and any(float(component) <= 0 for component in vector))
+                ):
+                    raise ValueError("3D Factory scene snapshot contains invalid collision geometry")
+            if item.get("light_transport", "opaque") not in {"opaque", "cutout", "transmissive"}:
+                raise ValueError("3D Factory scene snapshot contains invalid light transport")
+            transmission = item.get("transmission", 0)
+            if (
+                not isinstance(transmission, (int, float))
+                or isinstance(transmission, bool)
+                or not math.isfinite(float(transmission))
+                or not 0 <= float(transmission) <= 1
+            ):
+                raise ValueError("3D Factory scene snapshot contains invalid light transmission")
+            if "locked" in item and not isinstance(item["locked"], bool):
+                raise ValueError("3D Factory scene snapshot contains invalid object lock state")
             object_ids.add(object_id)
         layers = snapshot.get("layers", [])
         if not isinstance(layers, list) or len(layers) > len(objects) + 1024:
@@ -187,6 +218,258 @@ def _parse_state(factory_data: Any) -> dict[str, Any]:
                 )
             validate_camera(saved_camera, "saved camera")
             camera_ids.add(camera_id)
+        levels = snapshot.get("levels", [])
+        if "levels" in snapshot and (not isinstance(levels, list) or not 1 <= len(levels) <= 64):
+            raise ValueError("3D Factory scene snapshot has invalid floor levels")
+        level_ids: set[str] = set()
+        for level in levels:
+            level_id = level.get("level_id") if isinstance(level, dict) else None
+            if not isinstance(level_id, str) or not _ID_RE.fullmatch(level_id) or level_id in level_ids:
+                raise ValueError("3D Factory scene snapshot contains an invalid floor level")
+            for key in ("elevation", "height", "slab_thickness"):
+                number = level.get(key)
+                if not isinstance(number, (int, float)) or isinstance(number, bool) or not math.isfinite(float(number)):
+                    raise ValueError("3D Factory scene snapshot contains invalid floor geometry")
+            level_ids.add(level_id)
+        if level_ids:
+            for item in objects:
+                if item.get("level_id") is not None and item.get("level_id") not in level_ids:
+                    raise ValueError("3D Factory object references an unknown floor level")
+            for saved_camera in cameras:
+                if saved_camera.get("level_id") is not None and saved_camera.get("level_id") not in level_ids:
+                    raise ValueError("3D Factory saved camera references an unknown floor level")
+        architecture = snapshot.get("architecture", {})
+        if not isinstance(architecture, dict):
+            raise ValueError("3D Factory scene snapshot has invalid architecture")
+        architecture_limits = {
+            "materials": 512,
+            "buildings": 64,
+            "walls": 4096,
+            "rooms": 1024,
+            "openings": 4096,
+        }
+        for key, limit in architecture_limits.items():
+            entries = architecture.get(key, [])
+            if not isinstance(entries, list) or len(entries) > limit or any(not isinstance(item, dict) for item in entries):
+                raise ValueError(f"3D Factory scene snapshot has invalid architecture {key}")
+        def finite_number(value: Any) -> bool:
+            return (
+                isinstance(value, (int, float))
+                and not isinstance(value, bool)
+                and math.isfinite(float(value))
+            )
+
+        def finite_vector(value: Any, length: int) -> bool:
+            return (
+                isinstance(value, list)
+                and len(value) == length
+                and all(finite_number(item) for item in value)
+            )
+
+        material_ids: set[str] = set()
+        for material in architecture.get("materials", []):
+            material_id = material.get("material_id")
+            if (
+                not isinstance(material_id, str)
+                or not _ID_RE.fullmatch(material_id)
+                or material_id in material_ids
+            ):
+                raise ValueError("3D Factory scene snapshot contains an invalid material")
+            material_ids.add(material_id)
+        building_ids: set[str] = set()
+        raw_buildings = architecture.get("buildings", [])
+        has_building_schema = "buildings" in architecture
+        requires_content_building_refs = int(value.get("schema_version", 0) or 0) >= 16
+        for building in raw_buildings:
+            building_id = building.get("building_id")
+            if (
+                not isinstance(building_id, str)
+                or not _ID_RE.fullmatch(building_id)
+                or building_id in building_ids
+                or not finite_vector(building.get("position"), 3)
+                or not finite_number(building.get("rotation_y"))
+            ):
+                raise ValueError("3D Factory scene snapshot contains an invalid building")
+            building_ids.add(building_id)
+        if has_building_schema and requires_content_building_refs:
+            for item in objects:
+                if item.get("building_id") and item.get("building_id") not in building_ids:
+                    raise ValueError("3D Factory object references an unknown building")
+            for saved_camera in cameras:
+                if (
+                    saved_camera.get("building_id")
+                    and saved_camera.get("building_id") not in building_ids
+                ):
+                    raise ValueError("3D Factory saved camera references an unknown building")
+        wall_ids: set[str] = set()
+        for wall in architecture.get("walls", []):
+            wall_id = wall.get("wall_id")
+            if not isinstance(wall_id, str) or not _ID_RE.fullmatch(wall_id) or wall_id in wall_ids:
+                raise ValueError("3D Factory scene snapshot contains an invalid wall")
+            if (
+                wall.get("level_id") not in level_ids
+                or (has_building_schema and wall.get("building_id") not in building_ids)
+            ):
+                raise ValueError("3D Factory wall references an unknown floor level")
+            if (
+                not finite_vector(wall.get("start"), 2)
+                or not finite_vector(wall.get("end"), 2)
+                or any(
+                    not finite_number(wall.get(key))
+                    for key in ("thickness", "height", "elevation_offset")
+                )
+            ):
+                raise ValueError("3D Factory scene snapshot contains invalid wall geometry")
+            wall_ids.add(wall_id)
+        room_ids: set[str] = set()
+        walls_by_id = {
+            wall["wall_id"]: wall
+            for wall in architecture.get("walls", [])
+        }
+        for room in architecture.get("rooms", []):
+            room_id = room.get("room_id")
+            polygon = room.get("polygon")
+            if (
+                not isinstance(room_id, str)
+                or not _ID_RE.fullmatch(room_id)
+                or room_id in room_ids
+                or room.get("level_id") not in level_ids
+                or (has_building_schema and room.get("building_id") not in building_ids)
+                or not isinstance(polygon, list)
+                or not 3 <= len(polygon) <= 512
+                or any(not finite_vector(point, 2) for point in polygon)
+                or not isinstance(room.get("wall_ids", []), list)
+                or any(wall_id not in wall_ids for wall_id in room.get("wall_ids", []))
+            ):
+                raise ValueError("3D Factory scene snapshot contains an invalid room")
+            linked_ids = room.get("wall_ids", [])
+            if linked_ids:
+                if len(linked_ids) != len(polygon) or len(set(linked_ids)) != len(linked_ids):
+                    raise ValueError("3D Factory room perimeter does not match its polygon")
+                for index, wall_id in enumerate(linked_ids):
+                    wall = walls_by_id[wall_id]
+                    if (
+                        wall.get("level_id") != room.get("level_id")
+                        or wall.get("building_id") != room.get("building_id")
+                        or math.dist(wall["start"], polygon[index]) > 1e-4
+                        or math.dist(wall["end"], polygon[(index + 1) % len(polygon)]) > 1e-4
+                    ):
+                        raise ValueError("3D Factory room perimeter walls are inconsistent")
+            room_ids.add(room_id)
+        opening_ids: set[str] = set()
+        occupied_by_wall: dict[str, list[tuple[float, float]]] = {}
+        for opening in architecture.get("openings", []):
+            opening_id = opening.get("opening_id")
+            if (
+                not isinstance(opening_id, str)
+                or not _ID_RE.fullmatch(opening_id)
+                or opening_id in opening_ids
+                or opening.get("wall_id") not in wall_ids
+                or any(
+                    not finite_number(opening.get(key))
+                    for key in ("offset", "width", "height", "sill_height")
+                )
+            ):
+                raise ValueError("3D Factory scene snapshot contains an invalid opening")
+            wall = walls_by_id[opening["wall_id"]]
+            wall_length = math.dist(wall["start"], wall["end"])
+            center = float(opening["offset"]) * wall_length
+            half = float(opening["width"]) / 2.0
+            interval = (center - half, center + half)
+            if (
+                interval[0] < -1e-9
+                or interval[1] > wall_length + 1e-9
+                or float(opening["sill_height"]) + float(opening["height"]) > float(wall["height"]) + 1e-9
+                or any(interval[0] < end - 1e-9 and interval[1] > start + 1e-9 for start, end in occupied_by_wall.setdefault(opening["wall_id"], []))
+            ):
+                raise ValueError("3D Factory opening is outside its wall or overlaps another opening")
+            occupied_by_wall[opening["wall_id"]].append(interval)
+            opening_ids.add(opening_id)
+        tracks = snapshot.get("camera_tracks", [])
+        if not isinstance(tracks, list) or len(tracks) > 16:
+            raise ValueError("3D Factory scene snapshot has invalid camera paths")
+        total_keyframes = 0
+        track_ids: set[str] = set()
+        all_keyframe_ids: set[str] = set()
+        for track in tracks:
+            track_id = track.get("track_id") if isinstance(track, dict) else None
+            keyframes = track.get("keyframes", []) if isinstance(track, dict) else None
+            if (
+                not isinstance(track_id, str)
+                or not _ID_RE.fullmatch(track_id)
+                or track_id in track_ids
+                or not isinstance(keyframes, list)
+                or not finite_number(track.get("duration"))
+                or not finite_number(track.get("fps"))
+                or (
+                    has_building_schema
+                    and requires_content_building_refs
+                    and track.get("building_id")
+                    and track.get("building_id") not in building_ids
+                )
+            ):
+                raise ValueError("3D Factory scene snapshot contains an invalid camera path")
+            total_keyframes += len(keyframes)
+            if total_keyframes > 1000:
+                raise ValueError("3D Factory camera path point limit was exceeded")
+            keyframe_ids: set[str] = set()
+            for frame in keyframes:
+                quaternion = frame.get("quaternion") if isinstance(frame, dict) else None
+                if (
+                    not isinstance(frame, dict)
+                    or not isinstance(frame.get("keyframe_id"), str)
+                    or not _ID_RE.fullmatch(frame["keyframe_id"])
+                    or frame["keyframe_id"] in keyframe_ids
+                    or frame["keyframe_id"] in all_keyframe_ids
+                    or not isinstance(quaternion, list)
+                    or len(quaternion) != 4
+                    or any(not isinstance(item, (int, float)) or not math.isfinite(float(item)) for item in quaternion)
+                    or not finite_vector(frame.get("position"), 3)
+                    or not finite_number(frame.get("time"))
+                    or not finite_number(frame.get("fov"))
+                    or not finite_number(frame.get("focus_distance"))
+                ):
+                    raise ValueError("3D Factory scene snapshot contains an invalid camera path point")
+                keyframe_ids.add(frame["keyframe_id"])
+                all_keyframe_ids.add(frame["keyframe_id"])
+            if keyframes and max(float(frame["time"]) for frame in keyframes) > float(track["duration"]):
+                raise ValueError("3D Factory camera path duration ends before its last point")
+            track_ids.add(track_id)
+        lighting = snapshot.get("lighting", {})
+        if not isinstance(lighting, dict):
+            raise ValueError("3D Factory scene snapshot has invalid lighting")
+        shadows = lighting.get("shadows", {})
+        if not isinstance(shadows, dict) or shadows.get("quality", "medium") not in {
+            "off", "low", "medium", "high", "ultra",
+        }:
+            raise ValueError("3D Factory scene snapshot has invalid shadow settings")
+        lights = lighting.get("lights", [])
+        if not isinstance(lights, list) or len(lights) > 32:
+            raise ValueError("3D Factory scene snapshot has invalid local lights")
+        light_ids: set[str] = set()
+        for light in lights:
+            light_id = light.get("light_id") if isinstance(light, dict) else None
+            if (
+                not isinstance(light_id, str)
+                or not _ID_RE.fullmatch(light_id)
+                or light_id in light_ids
+                or light.get("kind") not in {"point", "spot", "directional"}
+                or (light.get("level_id") is not None and light.get("level_id") not in level_ids)
+                or (
+                    has_building_schema
+                    and requires_content_building_refs
+                    and light.get("building_id")
+                    and light.get("building_id") not in building_ids
+                )
+                or not finite_vector(light.get("position"), 3)
+                or not finite_vector(light.get("target"), 3)
+                or any(
+                    not finite_number(light.get(key))
+                    for key in ("intensity", "distance", "angle", "penumbra")
+                )
+            ):
+                raise ValueError("3D Factory scene snapshot contains an invalid local light")
+            light_ids.add(light_id)
     return value
 
 

--- a/nodes/factory3d.py
+++ b/nodes/factory3d.py
@@ -308,7 +308,11 @@ def _parse_state(factory_data: Any) -> dict[str, Any]:
                 raise ValueError("3D Factory scene snapshot contains an invalid wall")
             if (
                 wall.get("level_id") not in level_ids
-                or (has_building_schema and wall.get("building_id") not in building_ids)
+                or (
+                    has_building_schema
+                    and wall.get("building_id")
+                    and wall.get("building_id") not in building_ids
+                )
             ):
                 raise ValueError("3D Factory wall references an unknown floor level")
             if (
@@ -334,7 +338,11 @@ def _parse_state(factory_data: Any) -> dict[str, Any]:
                 or not _ID_RE.fullmatch(room_id)
                 or room_id in room_ids
                 or room.get("level_id") not in level_ids
-                or (has_building_schema and room.get("building_id") not in building_ids)
+                or (
+                    has_building_schema
+                    and room.get("building_id")
+                    and room.get("building_id") not in building_ids
+                )
                 or not isinstance(polygon, list)
                 or not 3 <= len(polygon) <= 512
                 or any(not finite_vector(point, 2) for point in polygon)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "vnccs-utils"
 description = "VNCCS utility nodes: Pose Studio, UniCanvas, and 3D Factory."
-version = "0.6.5"
+version = "0.6.6"
 license = {file = "LICENSE"} 
 
 dependencies = [

--- a/tests/test_factory3d_backend.py
+++ b/tests/test_factory3d_backend.py
@@ -117,6 +117,55 @@ class FactoryBackendTests(unittest.TestCase):
         unchanged = self.factory.update_scene(scene["scene_id"], {"name": "Renamed", "objects": []})
         self.assertEqual(unchanged["revision"], 0)
 
+    def test_room_can_be_saved_without_a_building(self):
+        scene = self.factory.create_scene("Standalone room")
+        level_id = scene["levels"][0]["level_id"]
+        wall_ids = [character * 32 for character in "1234"]
+        polygon = [[0, 0], [4, 0], [4, 3], [0, 3]]
+        walls = [
+            {
+                "wall_id": wall_ids[index],
+                "name": "Wall",
+                "level_id": level_id,
+                "building_id": "",
+                "start": polygon[index],
+                "end": polygon[(index + 1) % len(polygon)],
+                "thickness": 0.12,
+                "height": 2.8,
+                "elevation_offset": 0.0,
+            }
+            for index in range(len(polygon))
+        ]
+        architecture = {
+            "materials": [],
+            "buildings": [],
+            "walls": walls,
+            "rooms": [{
+                "room_id": "5" * 32,
+                "name": "Room",
+                "level_id": level_id,
+                "building_id": "",
+                "polygon": polygon,
+                "wall_ids": wall_ids,
+            }],
+            "openings": [],
+        }
+
+        updated = self.factory.update_scene(
+            scene["scene_id"],
+            {"architecture": architecture},
+        )
+        self.assertEqual(updated["architecture"]["buildings"], [])
+        self.assertEqual(
+            [wall["building_id"] for wall in updated["architecture"]["walls"]],
+            ["", "", "", ""],
+        )
+        self.assertEqual(updated["architecture"]["rooms"][0]["building_id"], "")
+        restored = self.factory.load_scene(scene["scene_id"])
+        self.assertEqual(len(restored["architecture"]["walls"]), 4)
+        self.assertEqual(len(restored["architecture"]["rooms"]), 1)
+        self.assertEqual(restored["architecture"]["buildings"], [])
+
     def test_saved_cameras_are_normalized_and_invalidate_capture_revision(self):
         scene = self.factory.create_scene("Camera scene")
         camera_id = "c" * 32

--- a/tests/test_factory3d_backend.py
+++ b/tests/test_factory3d_backend.py
@@ -98,6 +98,16 @@ class FactoryBackendTests(unittest.TestCase):
         self.assertEqual(scene["architecture"]["buildings"], [])
         self.assertEqual(scene["lighting"]["preset"], "day")
         self.assertEqual(scene["lighting"]["color"], "#fff1d6")
+        self.assertEqual(
+            scene["lighting"]["shadows"],
+            {
+                "enabled": True,
+                "quality": "medium",
+                "bias": -0.0005,
+                "normal_bias": 0.02,
+            },
+        )
+        self.assertEqual(scene["lighting"]["lights"], [])
         self.assertEqual(self.factory.list_scenes()[0]["name"], "First scene")
 
         updated = self.factory.update_scene(scene["scene_id"], {"name": "Renamed"})
@@ -173,6 +183,8 @@ class FactoryBackendTests(unittest.TestCase):
 
     def test_scene_lighting_is_normalized_persisted_and_invalidates_preview_only(self):
         scene = self.factory.create_scene("Lighting")
+        level_id = scene["levels"][0]["level_id"]
+        light_id = "1" * 32
         updated = self.factory.update_scene(
             scene["scene_id"],
             {
@@ -184,6 +196,28 @@ class FactoryBackendTests(unittest.TestCase):
                     "elevation": 11,
                     "ambient": 0.28,
                     "background": "#25141B",
+                    "shadows": {
+                        "enabled": True,
+                        "quality": "high",
+                        "bias": -0.0002,
+                        "normal_bias": 0.0015,
+                    },
+                    "lights": [{
+                        "light_id": light_id,
+                        "name": "Practical",
+                        "level_id": level_id,
+                        "building_id": "",
+                        "kind": "point",
+                        "position": [1, 2.4, 3],
+                        "target": [1, 0, 3],
+                        "color": "#FF0088",
+                        "intensity": 10,
+                        "distance": 8,
+                        "angle": 45,
+                        "penumbra": 0.2,
+                        "cast_shadow": True,
+                        "visible": True,
+                    }],
                 }
             },
         )
@@ -199,6 +233,28 @@ class FactoryBackendTests(unittest.TestCase):
                 "elevation": 11.0,
                 "ambient": 0.28,
                 "background": "#25141b",
+                "shadows": {
+                    "enabled": True,
+                    "quality": "high",
+                    "bias": -0.0002,
+                    "normal_bias": 0.0015,
+                },
+                "lights": [{
+                    "light_id": light_id,
+                    "name": "Practical",
+                    "level_id": level_id,
+                    "building_id": "",
+                    "kind": "point",
+                    "position": [1.0, 2.4, 3.0],
+                    "target": [1.0, 0.0, 3.0],
+                    "color": "#ff0088",
+                    "intensity": 10.0,
+                    "distance": 8.0,
+                    "angle": 45.0,
+                    "penumbra": 0.2,
+                    "cast_shadow": True,
+                    "visible": True,
+                }],
             },
         )
         restored = self.factory.load_scene(scene["scene_id"])
@@ -219,6 +275,8 @@ class FactoryBackendTests(unittest.TestCase):
         )
         self.assertEqual(off["lighting"]["preset"], "off")
         self.assertEqual(off["lighting"]["background"], "#171b25")
+        self.assertEqual(off["lighting"]["lights"], [])
+        self.assertEqual(off["lighting"]["shadows"]["quality"], "medium")
 
     def test_experimental_density_modes_are_supported_through_api_and_triposplat(self):
         capabilities = self.factory.capabilities()

--- a/tests/test_factory3d_backend.py
+++ b/tests/test_factory3d_backend.py
@@ -95,6 +95,7 @@ class FactoryBackendTests(unittest.TestCase):
         self.assertEqual(scene["camera"]["fov"], 42.0)
         self.assertEqual(scene["camera"]["up"], [0.0, 1.0, 0.0])
         self.assertEqual(scene["cameras"], [])
+        self.assertEqual(scene["architecture"]["buildings"], [])
         self.assertEqual(scene["lighting"]["preset"], "day")
         self.assertEqual(scene["lighting"]["color"], "#fff1d6")
         self.assertEqual(self.factory.list_scenes()[0]["name"], "First scene")

--- a/tests/test_factory3d_frontend.mjs
+++ b/tests/test_factory3d_frontend.mjs
@@ -17,7 +17,7 @@ test("Factory widget registers the renamed node and persists opaque state", () =
     assert.match(studio, /selected_object_id/);
     assert.match(studio, /scene_snapshot/);
     assert.match(studio, /source: this\.sourceAsset/);
-    assert.match(studio, /FRONTEND_BUILD = "20260726\.4"/);
+    assert.match(studio, /FRONTEND_BUILD = "20260825\.26"/);
     assert.doesNotMatch(studio, /vnccs-i3s__brand/);
     assert.doesNotMatch(studio, /Image to Gaussian scene/);
     assert.match(studio, /<option value="524288">524K · Experimental<\/option>/);
@@ -70,6 +70,28 @@ test("Factory provides a native Gaussian object and scene library with HF reposi
     assert.doesNotMatch(studio, /window\.(?:alert|confirm|prompt)/);
 });
 
+test("Factory exposes complete on-screen viewport camera navigation", () => {
+    assert.match(studio, /class="vnccs-i3s__viewport-camera" open/);
+    assert.match(studio, /data-camera-action="home"/);
+    assert.match(studio, /data-camera-action="scene"/);
+    assert.match(studio, /data-camera-action="selection"/);
+    assert.match(studio, /data-camera-preset="perspective"/);
+    assert.match(studio, /data-camera-preset="top"/);
+    assert.match(studio, /data-camera-pan="forward"/);
+    assert.match(studio, /vnccs-i3s__camera-distance-range/);
+    assert.match(studio, /vnccs-i3s__camera-height-range/);
+    assert.match(studio, /data-camera-vector="position"/);
+    assert.match(studio, /data-camera-vector="target"/);
+    assert.match(viewer, /resetView\(\{ emit = true \} = \{\}\)/);
+    assert.match(viewer, /frameScene\(\{ emit = true \} = \{\}\)/);
+    assert.match(viewer, /frameSelection\(\{ emit = true \} = \{\}\)/);
+    assert.match(viewer, /setCameraDistance\(value/);
+    assert.match(viewer, /panCamera\(\{ right = 0, forward = 0 \}/);
+    assert.match(viewer, /setCameraHeight\(value/);
+    assert.match(viewer, /this\._expandVisibleObjectBounds\(box, this\.architecture\?\.root\)/);
+    assert.match(styles, /\.vnccs-i3s__viewport-camera/);
+});
+
 test("Factory exposes scenes, generation, transforms, and PLY export", () => {
     assert.match(studio, /Scene manager/);
     assert.match(studio, /confirmDeleteScene\(scene\)/);
@@ -81,7 +103,7 @@ test("Factory exposes scenes, generation, transforms, and PLY export", () => {
     assert.match(studio, /Generate object/);
     assert.match(viewer, /TransformControls/);
     assert.match(studio, /duplicateObject/);
-    assert.match(studio, /Scene PLY/);
+    assert.match(studio, /Gaussian PLY/);
     assert.match(studio, /item\?\.urls\?\.export_ply/);
     assert.match(studio, /exportScene\(\)/);
     assert.match(studio, /download\(scene\.exports\.urls\.ply\)/);
@@ -445,6 +467,32 @@ test("Camera block provides graphical FPV control, one Cameras group, and LIST c
     assert.match(styles, /vnccs-i3s__camera-item\.is-selected/);
 });
 
+test("Exact saved-camera XYZ rotation round-trips through one quaternion order", async () => {
+    const helpers = studio.match(
+        /(function quaternionFromEulerDegrees[\s\S]*?function eulerDegreesFromQuaternion[\s\S]*?\n\})\n\n\nclass Factory3DWidget/,
+    );
+    assert.ok(helpers, "camera rotation helpers not found");
+    const THREE = await import(pathToFileURL(path.join(root, "web", "vendor", "spark", "three.module.js")).href);
+    const normalizePose = value => {
+        const quaternion = new THREE.Quaternion().fromArray(value.quaternion || [0, 0, 0, 1]);
+        if (quaternion.lengthSq() < 1e-12) quaternion.identity();
+        quaternion.normalize();
+        return { quaternion: quaternion.toArray() };
+    };
+    const rotationHelpers = Function(
+        "normalizedCameraPose",
+        `${helpers[1]}; return { quaternionFromEulerDegrees, eulerDegreesFromQuaternion };`,
+    )(normalizePose);
+    for (const rotation of [[17, -23, 41], [-32, 18, -11], [6.25, 54.5, 72.75]]) {
+        const restored = rotationHelpers.eulerDegreesFromQuaternion(
+            rotationHelpers.quaternionFromEulerDegrees(rotation),
+        );
+        for (let axis = 0; axis < 3; axis += 1) {
+            assert.ok(Math.abs(restored[axis] - rotation[axis]) < 1e-9);
+        }
+    }
+});
+
 test("Scene export exposes persistent dimensions, aspect presets, and an exact camera frame", () => {
     assert.match(studio, /Aspect ratio/);
     assert.match(studio, /16:9 · Widescreen/);
@@ -465,10 +513,14 @@ test("Scene export exposes persistent dimensions, aspect presets, and an exact c
     assert.match(styles, /\.vnccs-i3s__scene-render-settings/);
 });
 
-test("Canvas transforms are the only transform UI and object actions live on cards", () => {
+test("Canvas gizmos and the Inspector provide coarse and precise transforms", () => {
     assert.doesNotMatch(studio, /vnccs-i3s__transform-panel/);
-    assert.doesNotMatch(studio, /Precise values/);
     assert.doesNotMatch(studio, /vnccs-i3s__selected-name/);
+    assert.match(studio, /data-editor-path=/);
+    assert.match(studio, /exact value/);
+    assert.match(studio, /type="range" aria-label=/);
+    assert.match(studio, /Rotation · degrees/);
+    assert.match(studio, /step: 0\.01/);
     assert.match(studio, /Duplicate object/);
     assert.match(studio, /confirmDeleteObject\(item\.object_id\)/);
     assert.match(studio, /actions\.append\(visibility, exportObject, duplicate, remove\)/);
@@ -476,15 +528,149 @@ test("Canvas transforms are the only transform UI and object actions live on car
     assert.match(studio, /W\/E\/R: move\/rotate\/scale/);
 });
 
-test("Factory preserves the accepted Sakura three-column Studio interface", () => {
+test("Factory keeps a responsive Sakura workspace with isolated side-panel tabs", () => {
     assert.match(styles, /--i3-pink: #ff8fa3/);
     assert.match(styles, /--i3-lavender: #b8a9e8/);
-    assert.match(styles, /grid-template-columns: 300px minmax\(330px, 1fr\) 412\.5px/);
+    assert.match(styles, /grid-template-columns: 280px minmax\(420px, 1fr\) 360px/);
     assert.match(styles, /grid-template-columns: 200px minmax\(290px, 1fr\) 220px/);
+    assert.match(studio, /data-workspace-tab="generate"/);
+    assert.match(studio, /data-workspace-tab="cameras"/);
+    assert.match(studio, /data-workspace-tab="objects"/);
+    assert.match(studio, /data-workspace-tab="inspector"/);
+    assert.match(studio, /data-workspace-tab="export"/);
+    assert.match(styles, /\.vnccs-i3s__workspace-panel/);
     assert.doesNotMatch(styles, /minmax\(205px, 23fr\)/);
     assert.match(studio, /vnccs-i3s__side--left/);
     assert.match(studio, /vnccs-i3s__center/);
     assert.match(studio, /vnccs-i3s__side--right/);
+});
+
+test("Plan mode exposes distinct, previewed building workflows and explicit snap controls", () => {
+    assert.match(studio, /data-plan-tool="wall"/);
+    assert.match(studio, /Draw connected wall segments/);
+    assert.match(studio, /data-plan-tool="room"/);
+    assert.match(studio, /Create a rectangular room from two corners/);
+    assert.match(studio, /data-plan-tool="opening"/);
+    assert.match(studio, /data-plan-tool="camera"/);
+    assert.match(studio, /Opening type/);
+    assert.match(studio, /Grid step · m/);
+    assert.match(studio, /Major line every/);
+    assert.match(studio, /Hold Alt to bypass snap/);
+    assert.match(studio, /Hold Shift to force an orthogonal segment/);
+    assert.match(studio, /_queuePlanHover/);
+    assert.match(studio, /Opening preview/);
+    assert.match(studio, /Camera position set · move to aim/);
+    assert.match(studio, /_fitOpeningOnWall/);
+    assert.match(viewer, /snapPlanPoint: options\.snapPlanPoint/);
+    assert.match(viewer, /setPlanDraft\(draft\)/);
+    assert.match(viewer, /setPlanGrid\(value = \{\}\)/);
+    assert.match(viewer, /setCameraMarkers\(cameras = \[\]\)/);
+});
+
+test("Editor workflows keep selection, whole-building transforms, floor drop, and camera exits explicit", () => {
+    assert.match(studio, /\+ Building/);
+    assert.match(studio, /Move building/);
+    assert.match(studio, /Delete building/);
+    assert.match(studio, /No replacement Building will be created/);
+    assert.match(studio, /No buildings/);
+    assert.match(studio, /_applyBuildingTransform/);
+    assert.match(studio, /Assign camera to building/);
+    assert.match(studio, /data-object-property="building_id"/);
+    assert.match(studio, /data-camera-property="building_id"/);
+    assert.match(studio, /data-light-path="building_id"/);
+    assert.match(studio, /vnccs-i3s__camera-track-building/);
+    assert.match(studio, /track\.building_id !== building\.building_id/);
+    assert.match(studio, /vnccs-i3s__building-select/);
+    assert.match(studio, /active_building_id/);
+    assert.match(viewer, /selectedBuildingIds/);
+    assert.match(viewer, /this\.controls\.enableRotate = false/);
+    assert.match(viewer, /dollyCamera\(/);
+    assert.match(viewer, /rotateCameraFPV/);
+    assert.match(studio, /Drop selection to the nearest surface \(End\)/);
+    assert.match(studio, /this\._dropSelectionToSurface\(event\.shiftKey\)/);
+    assert.match(viewer, /dropSelectionToSurface\(\{ individual = false \} = \{\}\)/);
+    assert.match(studio, /Enter camera view/);
+    assert.match(studio, /Exit camera view/);
+    assert.match(studio, /Update from current view/);
+    assert.match(studio, /Add camera as path point/);
+    assert.match(studio, /Delete active camera path/);
+    assert.match(studio, /Precise edits in 3D enter the saved camera non-destructively/);
+    assert.match(studio, /selected_architecture: this\.selectedArchitecture/);
+    assert.match(studio, /selected_camera_keyframe_id: this\.selectedCameraKeyframeId/);
+});
+
+test("Editor schema normalizes grid aliases, room perimeters, buildings, and non-overlapping openings", async () => {
+    const schema = await import(
+        `${pathToFileURL(path.join(root, "web", "factory3d", "editor_schema.mjs")).href}?test=${Date.now()}`
+    );
+    const view = schema.normalizedEditorView({
+        plan_grid: { visible: false, step: 0.25, major_every: 8 },
+        snap: { enabled: false, grid: 3, endpoints: false },
+    }, "level-a");
+    assert.deepEqual(view.plan_grid, { visible: false, step: 0.25, major_every: 8 });
+    assert.equal(view.snap.enabled, false);
+    assert.equal(view.snap.grid, 0.25);
+    assert.equal(view.snap.endpoints, false);
+    assert.equal(view.active_level_id, "level-a");
+    assert.equal(schema.normalizedEditorView({ active_building_id: "building-a" }).active_building_id, "building-a");
+    assert.equal(schema.normalizedObjectEditorProperties({
+        building_id: "building-a",
+        light_transport: "transmissive",
+        transmission: 0.42,
+    }).building_id, "building-a");
+    assert.equal(schema.normalizedObjectEditorProperties({
+        building_id: "building-a",
+        light_transport: "transmissive",
+        transmission: 0.42,
+    }).transmission, 0.42);
+
+    const level = { level_id: "level-a" };
+    const building = { building_id: "building-a", name: "House" };
+    const walls = [
+        { wall_id: "w1", building_id: "building-a", level_id: "level-a", start: [0, 0], end: [4, 0] },
+        { wall_id: "w2", building_id: "building-a", level_id: "level-a", start: [4, 0], end: [4, 3] },
+        { wall_id: "w3", building_id: "building-a", level_id: "level-a", start: [4, 3], end: [0, 3] },
+        { wall_id: "w4", building_id: "building-a", level_id: "level-a", start: [0, 3], end: [0, 0] },
+    ];
+    const normalized = schema.normalizedArchitecture({
+        buildings: [building],
+        walls,
+        rooms: [{
+            room_id: "room-a",
+            building_id: "building-a",
+            level_id: "level-a",
+            polygon: [[0, 0], [4, 0], [4, 3], [0, 3]],
+            wall_ids: ["w1", "w2", "w3", "w4"],
+        }],
+        openings: [
+            { opening_id: "o1", wall_id: "w1", offset: 0.5, width: 2 },
+            { opening_id: "o2", wall_id: "w1", offset: 0.5, width: 2 },
+        ],
+    }, [level]);
+    assert.equal(normalized.buildings[0].building_id, "building-a");
+    assert.deepEqual(normalized.rooms[0].wall_ids, ["w1", "w2", "w3", "w4"]);
+    assert.equal(normalized.openings.length, 2);
+    const intervals = normalized.openings
+        .map(opening => [opening.offset * 4 - opening.width / 2, opening.offset * 4 + opening.width / 2])
+        .sort((left, right) => left[0] - right[0]);
+    assert.ok(intervals[0][1] <= intervals[1][0] + 1e-9);
+
+    const invalid = schema.normalizedArchitecture({
+        buildings: [building],
+        walls,
+        rooms: [{
+            room_id: "room-b",
+            building_id: "building-a",
+            level_id: "level-a",
+            polygon: [[0, 0], [4, 0], [4, 3], [0, 3]],
+            wall_ids: ["w1", "w1", "w3", "w4"],
+        }],
+    }, [level]);
+    assert.deepEqual(invalid.rooms[0].wall_ids, []);
+    const emptyArchitecture = schema.normalizedArchitecture({
+        buildings: [], walls: [], rooms: [], openings: [], materials: [],
+    }, [level]);
+    assert.deepEqual(emptyArchitecture.buildings, []);
 });
 
 test("Factory DOM widget follows node resize like Pose Studio", () => {
@@ -596,6 +782,9 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
     );
     const THREE = await import(pathToFileURL(path.join(root, "web", "vendor", "spark", "three.module.js")).href);
     const SPARK = await import(pathToFileURL(path.join(root, "web", "vendor", "spark", "spark.module.js")).href);
+    const support = await import(
+        `${pathToFileURL(path.join(root, "web", "factory3d", "support_solver.mjs")).href}?test=${Date.now()}`
+    );
     assert.equal(typeof module.Factory3DViewer, "function");
     assert.equal(typeof module.boundedObjectHit, "function");
     assert.equal(typeof module.computeRobustSplatBounds, "function");
@@ -609,7 +798,25 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
     assert.equal(typeof module.validateSplatBuffer, "function");
     assert.equal(typeof module.prepareSplatBuffer, "function");
     assert.equal(typeof module.prepareSplatBufferAsync, "function");
-    assert.equal(module.FACTORY_VIEWER_BUILD, "20260726.18");
+    assert.equal(typeof support.solveDropToSurface, "function");
+    assert.equal(module.FACTORY_VIEWER_BUILD, "20260825.16");
+    const basementMesh = new THREE.Object3D();
+    basementMesh.position.set(0, -2, 0);
+    basementMesh.updateMatrixWorld(true);
+    const basementDrop = support.solveDropToSurface({
+        entries: new Map([["basement-object", {
+            mesh: basementMesh,
+            data: { collision_proxy: { mode: "auto_box" } },
+            localBounds: new THREE.Box3(
+                new THREE.Vector3(-0.5, -0.5, -0.5),
+                new THREE.Vector3(0.5, 0.5, 0.5),
+            ),
+        }]]),
+        selectedIds: ["basement-object"],
+        floorElevations: [-3],
+    });
+    assert.ok(Math.abs(basementDrop.supportY + 3) < 1e-9);
+    assert.ok(basementDrop.deltaY < 0);
     const fpvViewer = Object.create(module.Factory3DViewer.prototype);
     fpvViewer.camera = new THREE.PerspectiveCamera(42, 1, 0.01, 1000);
     fpvViewer.camera.position.set(1, 2, 3);
@@ -1043,7 +1250,11 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
             { object_id: "object-a", visible: true },
             { object_id: "object-b", visible: true },
             { object_id: "object-c", visible: false },
+            { object_id: "object-d", visible: true, building_id: "building-hidden" },
         ],
+        architecture: {
+            buildings: [{ building_id: "building-hidden", visible: false }],
+        },
         layers: [
             {
                 type: "group",
@@ -1053,6 +1264,7 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
             },
             { type: "object", object_id: "object-b" },
             { type: "object", object_id: "object-c" },
+            { type: "object", object_id: "object-d" },
         ],
     });
     assert.deepEqual(Array.from(visibility), ["object-b"]);

--- a/tests/test_factory3d_frontend.mjs
+++ b/tests/test_factory3d_frontend.mjs
@@ -545,6 +545,7 @@ test("Interior cutaway is viewport-only and camera exports restore complete arch
     assert.match(viewer, /setInteriorCutaway\(enabled\)/);
     assert.match(viewer, /hideCeilings: this\.interiorCutaway/);
     assert.match(viewer, /const hiddenWallId = this\._nearestCutawayWallId\(\)/);
+    assert.match(viewer, /filter\(hit => isObjectPickableInHierarchy\(hit\.object\)\)/);
     assert.match(viewer, /this\.lightHelperRoot\.visible = false/);
     assert.match(viewer, /this\.architecture\.setActiveLevel\(this\.activeLevelId, false, \{[\s\S]*?hideCeilings: false,[\s\S]*?hiddenWallId: ""/);
     assert.match(viewer, /this\._syncViewportCutaway\(true\)/);
@@ -760,6 +761,22 @@ test("Editor schema normalizes grid aliases, room perimeters, buildings, and non
     }, [level]);
     assert.deepEqual(rootArchitecture.buildings, []);
     assert.equal(rootArchitecture.walls[0].building_id, "");
+    const rootRoomArchitecture = schema.normalizedArchitecture({
+        buildings: [],
+        walls: walls.map(wall => ({ ...wall, building_id: "" })),
+        rooms: [{
+            room_id: "root-room",
+            building_id: "",
+            level_id: "level-a",
+            polygon: [[0, 0], [4, 0], [4, 3], [0, 3]],
+            wall_ids: ["w1", "w2", "w3", "w4"],
+        }],
+        openings: [],
+        materials: [],
+    }, [level]);
+    assert.deepEqual(rootRoomArchitecture.buildings, []);
+    assert.deepEqual(rootRoomArchitecture.rooms[0].wall_ids, ["w1", "w2", "w3", "w4"]);
+    assert.equal(rootRoomArchitecture.rooms[0].building_id, "");
 });
 
 test("Factory DOM widget follows node resize like Pose Studio", () => {
@@ -928,6 +945,73 @@ test("Plan marquee converts client coordinates into the scaled viewport host", a
     });
 });
 
+test("Plan object drag moves selected Gaussian objects live while preserving height", async () => {
+    const module = await import(
+        `${pathToFileURL(path.join(root, "web", "vnccs_3d_factory_viewer.js")).href}?object-drag=${Date.now()}`
+    );
+    const viewer = Object.create(module.Factory3DViewer.prototype);
+    const changes = [];
+    const transforms = {
+        "object-a": {
+            position: [10, 2.5, 20],
+            rotation: [0, 15, 0],
+            scale: 1,
+        },
+        "object-b": {
+            position: [14, 6, 25],
+            rotation: [0, -20, 0],
+            scale: 0.8,
+        },
+    };
+    viewer.objects = new Map(Object.keys(transforms).map(objectId => [objectId, {
+        data: { transform: transforms[objectId] },
+        mesh: { objectId },
+    }]));
+    viewer._objectPlanDrag = {
+        pointerId: 7,
+        objectIds: ["object-a", "object-b"],
+        originPoint: [1, 1],
+        anchorPosition: [10, 20],
+        previousTransforms: structuredClone(transforms),
+        currentTransforms: structuredClone(transforms),
+        originX: 100,
+        originY: 100,
+        moved: false,
+        interactive: false,
+    };
+    viewer.selectedGroupId = "";
+    viewer.screenToPlan = () => [3, 4];
+    viewer.options = {
+        snapPlanPoint: point => point,
+        onTransformChange: (objectId, transform, options) => changes.push({
+            objectId,
+            transform: structuredClone(transform),
+            options,
+        }),
+    };
+    viewer._applyTransform = (mesh, transform) => { mesh.transform = structuredClone(transform); };
+    viewer._refreshSelectionBounds = () => {};
+    viewer._refreshObjectSelectionHighlights = () => {};
+    viewer._setInteractive = () => {};
+    viewer.spark = { setDirty() {} };
+    viewer.invalidate = () => {};
+    viewer.canvas = {
+        style: {},
+        releasePointerCapture() {},
+    };
+
+    viewer._updatePlanObjectDrag({ pointerId: 7, clientX: 120, clientY: 115 });
+    assert.deepEqual(viewer.objects.get("object-a").data.transform.position, [12, 2.5, 23]);
+    assert.deepEqual(viewer.objects.get("object-b").data.transform.position, [16, 6, 28]);
+    assert.equal(changes.at(-1).options.final, false);
+
+    viewer._finishPlanObjectDrag({ pointerId: 7, clientX: 120, clientY: 115 });
+    assert.equal(viewer._objectPlanDrag, null);
+    assert.equal(changes.at(-1).options.final, true);
+    assert.equal(changes.at(-1).options.command_last, true);
+    assert.deepEqual(changes.at(-1).options.previous_transforms, transforms);
+});
+
 test("Architecture runtime casts opaque closed geometry from back faces only", async () => {
     const geometryModule = await import(
         `${pathToFileURL(path.join(root, "web", "factory3d", "plan_geometry.mjs")).href}?shadow=${Date.now()}`
@@ -978,6 +1062,8 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
     assert.equal(typeof module.Factory3DViewer, "function");
     assert.equal(typeof module.boundedObjectHit, "function");
     assert.equal(typeof module.computeRobustSplatBounds, "function");
+    assert.equal(typeof module.gaussianShadowProxyTransforms, "function");
+    assert.equal(typeof module.isObjectPickableInHierarchy, "function");
     assert.equal(typeof module.canonicalObjectPreviewCamera, "function");
     assert.equal(typeof module.createDirectionalLightingModifier, "function");
     assert.equal(typeof module.effectiveVisibleObjectIds, "function");
@@ -990,6 +1076,61 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
     assert.equal(typeof module.prepareSplatBufferAsync, "function");
     assert.equal(typeof support.solveDropToSurface, "function");
     assert.equal(module.FACTORY_VIEWER_BUILD, "20260825.16");
+    const visiblePickRoot = new THREE.Group();
+    const visiblePickMesh = new THREE.Mesh(new THREE.BoxGeometry(1, 1, 1));
+    visiblePickRoot.add(visiblePickMesh);
+    assert.equal(module.isObjectPickableInHierarchy(visiblePickMesh), true);
+    visiblePickRoot.visible = false;
+    assert.equal(module.isObjectPickableInHierarchy(visiblePickMesh), false);
+    visiblePickRoot.visible = true;
+    visiblePickRoot.userData.factoryPointerPassthrough = true;
+    assert.equal(module.isObjectPickableInHierarchy(visiblePickMesh), false);
+    visiblePickMesh.geometry.dispose();
+
+    const shadowSplats = [];
+    for (let index = 0; index < 96; index += 1) {
+        shadowSplats.push({
+            center: new THREE.Vector3((index % 12) / 11, Math.floor(index / 12) / 7, 0),
+            scales: new THREE.Vector3(0.02, 0.03, 0.01),
+            quaternion: new THREE.Quaternion(),
+            opacity: index === 95 ? 0 : 1,
+        });
+    }
+    const shadowTransforms = module.gaussianShadowProxyTransforms(
+        {
+            numSplats: shadowSplats.length,
+            splats: { getSplat: index => shadowSplats[index] },
+        },
+        new THREE.Box3(new THREE.Vector3(0, 0, -0.1), new THREE.Vector3(1, 1, 0.1)),
+        { maxInstances: 32 },
+    );
+    assert.equal(shadowTransforms.length, 32);
+    assert.ok(shadowTransforms.every(item => item.position.isVector3));
+    assert.ok(shadowTransforms.every(
+        item => item.scale.x > 0 && item.scale.y > 0 && item.scale.z > 0,
+    ));
+    const shadowViewer = Object.create(module.Factory3DViewer.prototype);
+    shadowViewer.lighting = { shadows: { enabled: true, quality: "medium" } };
+    const shadowRoot = new THREE.Group();
+    const shadowSplat = new THREE.Object3D();
+    shadowSplat.numSplats = shadowSplats.length;
+    shadowSplat.splats = { getSplat: index => shadowSplats[index] };
+    shadowRoot.add(shadowSplat);
+    const shadowEntry = {
+        mesh: shadowRoot,
+        splat: shadowSplat,
+        splatBounds: new THREE.Box3(
+            new THREE.Vector3(0, 0, -0.1),
+            new THREE.Vector3(1, 1, 0.1),
+        ),
+        data: { light_transport: "opaque" },
+    };
+    shadowViewer._attachShadowProxy(shadowEntry);
+    assert.equal(shadowEntry.shadowProxy.isInstancedMesh, true);
+    assert.equal(shadowEntry.shadowProxy.geometry.type, "IcosahedronGeometry");
+    assert.equal(shadowEntry.shadowProxy.castShadow, true);
+    assert.equal(shadowEntry.shadowProxy.material.colorWrite, false);
+    shadowViewer._disposeEntry(shadowEntry);
     const basementMesh = new THREE.Object3D();
     basementMesh.position.set(0, -2, 0);
     basementMesh.updateMatrixWorld(true);

--- a/tests/test_factory3d_frontend.mjs
+++ b/tests/test_factory3d_frontend.mjs
@@ -9,6 +9,7 @@ const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
 const studio = fs.readFileSync(path.join(root, "web", "vnccs_3d_factory.js"), "utf8");
 const viewer = fs.readFileSync(path.join(root, "web", "vnccs_3d_factory_viewer.js"), "utf8");
 const styles = fs.readFileSync(path.join(root, "web", "vnccs_3d_factory.css"), "utf8");
+const planGeometry = fs.readFileSync(path.join(root, "web", "factory3d", "plan_geometry.mjs"), "utf8");
 
 test("Factory widget registers the renamed node and persists opaque state", () => {
     assert.match(studio, /VNCCS_3DFactory/);
@@ -70,26 +71,27 @@ test("Factory provides a native Gaussian object and scene library with HF reposi
     assert.doesNotMatch(studio, /window\.(?:alert|confirm|prompt)/);
 });
 
-test("Factory exposes complete on-screen viewport camera navigation", () => {
-    assert.match(studio, /class="vnccs-i3s__viewport-camera" open/);
-    assert.match(studio, /data-camera-action="home"/);
-    assert.match(studio, /data-camera-action="scene"/);
-    assert.match(studio, /data-camera-action="selection"/);
+test("Factory keeps the viewport clear and exposes camera projections in the Cameras panel", () => {
+    assert.doesNotMatch(studio, /vnccs-i3s__viewport-camera/);
+    assert.doesNotMatch(styles, /vnccs-i3s__viewport-camera/);
+    assert.doesNotMatch(studio, /data-camera-action=/);
+    assert.doesNotMatch(studio, /data-camera-pan=/);
+    assert.doesNotMatch(studio, /data-camera-orbit=/);
+    assert.doesNotMatch(studio, /data-camera-vector=/);
+    assert.doesNotMatch(studio, /vnccs-i3s__camera-distance-range/);
+    assert.doesNotMatch(studio, /vnccs-i3s__camera-height-range/);
+    assert.match(studio, /Wheel zoom speed/);
+    assert.match(studio, /vnccs-i3s__camera-zoom-speed-range/);
+    assert.match(studio, /View projection/);
     assert.match(studio, /data-camera-preset="perspective"/);
+    assert.match(studio, /data-camera-preset="front"/);
+    assert.match(studio, /data-camera-preset="right"/);
     assert.match(studio, /data-camera-preset="top"/);
-    assert.match(studio, /data-camera-pan="forward"/);
-    assert.match(studio, /vnccs-i3s__camera-distance-range/);
-    assert.match(studio, /vnccs-i3s__camera-height-range/);
-    assert.match(studio, /data-camera-vector="position"/);
-    assert.match(studio, /data-camera-vector="target"/);
-    assert.match(viewer, /resetView\(\{ emit = true \} = \{\}\)/);
-    assert.match(viewer, /frameScene\(\{ emit = true \} = \{\}\)/);
-    assert.match(viewer, /frameSelection\(\{ emit = true \} = \{\}\)/);
-    assert.match(viewer, /setCameraDistance\(value/);
-    assert.match(viewer, /panCamera\(\{ right = 0, forward = 0 \}/);
-    assert.match(viewer, /setCameraHeight\(value/);
-    assert.match(viewer, /this\._expandVisibleObjectBounds\(box, this\.architecture\?\.root\)/);
-    assert.match(styles, /\.vnccs-i3s__viewport-camera/);
+    assert.match(studio, /_syncCameraPanelControls/);
+    assert.match(studio, /this\.editorView\.view_mode === "plan"/);
+    assert.match(viewer, /setZoomSensitivity\(value/);
+    assert.match(viewer, /this\.dollyCamera\(\(-event\.deltaY \/ 100\) \* this\.zoomSensitivity/);
+    assert.match(styles, /\.vnccs-i3s__camera-view-preset-grid/);
 });
 
 test("Factory exposes scenes, generation, transforms, and PLY export", () => {
@@ -191,7 +193,26 @@ test("Factory provides persistent realtime lighting for Gaussian scenes", () => 
     assert.match(viewer, /document\.visibilityState !== "hidden"/);
     assert.match(viewer, /setLighting\(value = \{\}\)/);
     assert.match(viewer, /for \(const entry of this\.objects\.values\(\)\)/);
+    assert.match(studio, /Occlusion shadows/);
+    assert.match(studio, /Active shadow-casting point lights/);
+    assert.match(studio, /vnccs-i3s__local-light-add/);
+    assert.match(studio, /this\.lighting\.lights\.push\(\{/);
+    assert.match(studio, /kind: "point"/);
+    assert.match(studio, /const lights = this\.lighting\?\.lights \|\| \[\]/);
+    assert.match(studio, /fragment\.appendChild\(this\._createLightCard\(light\)\)/);
+    assert.match(studio, /Scene object · editor sphere is excluded from camera exports/);
+    assert.match(viewer, /new THREE\.PointLight\(data\.color, data\.intensity, data\.distance\)/);
+    assert.match(viewer, /this\.lightHelperRoot/);
     assert.match(styles, /\.vnccs-i3s__lighting-panel/);
+});
+
+test("Architecture shadows use closed geometry without hidden full-wall shadow casters", () => {
+    assert.match(planGeometry, /shadowSide: data\.kind === "glass" \? THREE\.DoubleSide : THREE\.BackSide/);
+    assert.doesNotMatch(planGeometry, /shadowSeal|factoryShadowSeal|WALL_SHADOW_SEAL/);
+    assert.match(planGeometry, /mesh\.castShadow = true/);
+    assert.match(planGeometry, /mesh\.receiveShadow = true/);
+    assert.match(viewer, /Math\.max\(configuredNormalBias, DEFAULT_LIGHTING\.shadows\.normal_bias\)/);
+    assert.doesNotMatch(viewer, /Math\.max\(configuredNormalBias, 0\.006\)/);
 });
 
 test("Factory provides a persistent equirectangular skydome with professional controls", () => {
@@ -437,6 +458,10 @@ test("Camera block provides graphical FPV control, one Cameras group, and LIST c
     )?.[0] || "";
     assert.match(cameraBlock, />Camera</);
     assert.match(cameraBlock, /vnccs-i3s__camera-look/);
+    assert.match(cameraBlock, /vnccs-i3s__camera-zoom-speed-range/);
+    assert.match(cameraBlock, /vnccs-i3s__camera-view-presets/);
+    assert.match(cameraBlock, /data-camera-preset="perspective"/);
+    assert.match(cameraBlock, /data-camera-preset="top"/);
     assert.doesNotMatch(cameraBlock, /camera-roll|Roll camera|slider to roll/);
     assert.match(cameraBlock, />Add camera</);
     assert.match(cameraBlock, /<strong>Cameras<\/strong>/);
@@ -513,6 +538,18 @@ test("Scene export exposes persistent dimensions, aspect presets, and an exact c
     assert.match(styles, /\.vnccs-i3s__scene-render-settings/);
 });
 
+test("Interior cutaway is viewport-only and camera exports restore complete architecture", () => {
+    assert.match(studio, /Interior cutaway \(viewport only\)/);
+    assert.match(studio, /this\.editorView\.interior_cutaway\[key\]/);
+    assert.match(studio, /this\.editorView\.interior_cutaway\?\.\[cutawayKey\]/);
+    assert.match(viewer, /setInteriorCutaway\(enabled\)/);
+    assert.match(viewer, /hideCeilings: this\.interiorCutaway/);
+    assert.match(viewer, /const hiddenWallId = this\._nearestCutawayWallId\(\)/);
+    assert.match(viewer, /this\.lightHelperRoot\.visible = false/);
+    assert.match(viewer, /this\.architecture\.setActiveLevel\(this\.activeLevelId, false, \{[\s\S]*?hideCeilings: false,[\s\S]*?hiddenWallId: ""/);
+    assert.match(viewer, /this\._syncViewportCutaway\(true\)/);
+});
+
 test("Canvas gizmos and the Inspector provide coarse and precise transforms", () => {
     assert.doesNotMatch(studio, /vnccs-i3s__transform-panel/);
     assert.doesNotMatch(studio, /vnccs-i3s__selected-name/);
@@ -557,7 +594,14 @@ test("Plan mode exposes distinct, previewed building workflows and explicit snap
     assert.match(studio, /Major line every/);
     assert.match(studio, /Hold Alt to bypass snap/);
     assert.match(studio, /Hold Shift to force an orthogonal segment/);
+    assert.match(studio, /Press and drag to draw a wall/);
+    assert.match(studio, /Press and drag diagonally to draw a rectangular room/);
+    assert.match(studio, /Press on a wall and drag to set the opening width/);
     assert.match(studio, /_queuePlanHover/);
+    assert.match(studio, /phase === "start"/);
+    assert.match(studio, /phase === "move"/);
+    assert.match(studio, /phase !== "end"/);
+    assert.match(studio, /if \(!gesture\.moved\)/);
     assert.match(studio, /Opening preview/);
     assert.match(studio, /Camera position set · move to aim/);
     assert.match(studio, /_fitOpeningOnWall/);
@@ -565,14 +609,19 @@ test("Plan mode exposes distinct, previewed building workflows and explicit snap
     assert.match(viewer, /setPlanDraft\(draft\)/);
     assert.match(viewer, /setPlanGrid\(value = \{\}\)/);
     assert.match(viewer, /setCameraMarkers\(cameras = \[\]\)/);
+    assert.match(viewer, /onPlanGesture: options\.onPlanGesture/);
+    assert.match(viewer, /phase: "start",[\s\S]*?type: "room"/);
+    assert.match(viewer, /phase: "move",[\s\S]*?type: "room"/);
+    assert.match(studio, /if \(phase === "move"\) \{[\s\S]*?_queueSelectedArchitecturePreview\(\{ persist: false \}\)/);
 });
 
-test("Editor workflows keep selection, whole-building transforms, floor drop, and camera exits explicit", () => {
-    assert.match(studio, /\+ Building/);
+test("Editor workflows keep buildings optional and make levels, selection, floor drop, and camera exits explicit", () => {
+    assert.doesNotMatch(studio, /\+ Building/);
+    assert.doesNotMatch(studio, /vnccs-i3s__building-select/);
     assert.match(studio, /Move building/);
     assert.match(studio, /Delete building/);
     assert.match(studio, /No replacement Building will be created/);
-    assert.match(studio, /No buildings/);
+    assert.doesNotMatch(studio, /_ensureBuilding|_createDefaultBuilding/);
     assert.match(studio, /_applyBuildingTransform/);
     assert.match(studio, /Assign camera to building/);
     assert.match(studio, /data-object-property="building_id"/);
@@ -580,8 +629,11 @@ test("Editor workflows keep selection, whole-building transforms, floor drop, an
     assert.match(studio, /data-light-path="building_id"/);
     assert.match(studio, /vnccs-i3s__camera-track-building/);
     assert.match(studio, /track\.building_id !== building\.building_id/);
-    assert.match(studio, /vnccs-i3s__building-select/);
     assert.match(studio, /active_building_id/);
+    assert.match(studio, /vnccs-i3s__level-panel/);
+    assert.match(studio, /Add level/);
+    assert.match(studio, /\["wall", "room", "opening"\]\.includes\(this\.editorView\.plan_tool\)/);
+    assert.match(studio, /this\.els\.levelPanel\.hidden = !architectureToolActive/);
     assert.match(viewer, /selectedBuildingIds/);
     assert.match(viewer, /this\.controls\.enableRotate = false/);
     assert.match(viewer, /dollyCamera\(/);
@@ -597,6 +649,23 @@ test("Editor workflows keep selection, whole-building transforms, floor drop, an
     assert.match(studio, /Precise edits in 3D enter the saved camera non-destructively/);
     assert.match(studio, /selected_architecture: this\.selectedArchitecture/);
     assert.match(studio, /selected_camera_keyframe_id: this\.selectedCameraKeyframeId/);
+    assert.match(studio, /this\._listen\(window, "keydown", event =>/);
+    assert.match(studio, /event\.key === "Delete" \|\| event\.key === "Backspace"/);
+    assert.match(studio, /\[data-inspector-action="delete"\]/);
+    assert.match(studio, /if \(editing\) return/);
+    assert.match(studio, /if \(key === "c"\) this\._copySelection\(\)/);
+    assert.match(studio, /else void this\._pasteSelection\(\)/);
+    assert.match(studio, /_selectPlanItems\(items = \[\]/);
+    assert.match(viewer, /onPlanMarqueeSelection\(items/);
+    assert.match(viewer, /_planItemsInBounds\(start, end\)/);
+    assert.match(studio, /rooms: Array\.from\(rooms\.values\(\)\)/);
+    assert.match(studio, /walls: Array\.from\(walls\.values\(\)\)/);
+    assert.match(studio, /openings: Array\.from\(openings\.values\(\)\)/);
+    assert.match(studio, /cameras,/);
+    assert.match(studio, /lights,/);
+    assert.match(studio, /for \(const source of clipboard\.rooms \|\| \[\]\)/);
+    assert.match(studio, /wall_ids: \(source\.wall_ids \|\| \[\]\)\.map\(id => wallIds\.get\(id\) \|\| id\)/);
+    assert.match(studio, /for \(const source of clipboard\.lights \|\| \[\]\)/);
 });
 
 test("Editor schema normalizes grid aliases, room perimeters, buildings, and non-overlapping openings", async () => {
@@ -612,6 +681,11 @@ test("Editor schema normalizes grid aliases, room perimeters, buildings, and non
     assert.equal(view.snap.grid, 0.25);
     assert.equal(view.snap.endpoints, false);
     assert.equal(view.active_level_id, "level-a");
+    assert.deepEqual(view.interior_cutaway, { plan: true, three_d: false });
+    assert.deepEqual(
+        schema.normalizedEditorView({ interior_cutaway: true }).interior_cutaway,
+        { plan: true, three_d: true },
+    );
     assert.equal(schema.normalizedEditorView({ active_building_id: "building-a" }).active_building_id, "building-a");
     assert.equal(schema.normalizedObjectEditorProperties({
         building_id: "building-a",
@@ -671,6 +745,21 @@ test("Editor schema normalizes grid aliases, room perimeters, buildings, and non
         buildings: [], walls: [], rooms: [], openings: [], materials: [],
     }, [level]);
     assert.deepEqual(emptyArchitecture.buildings, []);
+    const rootArchitecture = schema.normalizedArchitecture({
+        buildings: [],
+        walls: [{
+            wall_id: "root-wall",
+            building_id: "",
+            level_id: "level-a",
+            start: [0, 0],
+            end: [2, 0],
+        }],
+        rooms: [],
+        openings: [],
+        materials: [],
+    }, [level]);
+    assert.deepEqual(rootArchitecture.buildings, []);
+    assert.equal(rootArchitecture.walls[0].building_id, "");
 });
 
 test("Factory DOM widget follows node resize like Pose Studio", () => {
@@ -703,7 +792,7 @@ test("Factory cache executes after createLayout without a leaked local root vari
 test("Factory serializes settings, source, scene snapshot, selection, and viewer state", () => {
     const method = studio.match(/(serializeState\(\) \{[\s\S]*?\n    \})\n\n    _scheduleStateSave/);
     assert.ok(method, "serializeState method not found");
-    const serialize = Function(`return ({${method[1].replace("STATE_VERSION", "4")}}).serializeState;`)();
+    const serialize = Function(`return ({${method[1].replace("STATE_VERSION", "17")}}).serializeState;`)();
     const snapshot = {
         name: "Remembered",
         objects: [{ object_id: "object-a" }, { object_id: "object-b" }],
@@ -728,13 +817,39 @@ test("Factory serializes settings, source, scene snapshot, selection, and viewer
             aspect: "16:9",
             show_camera_frame: true,
         },
-        viewerState: { mode: "rotate" },
-        viewer: { getState: () => ({ mode: "scale", camera: { position: [1, 2, 3] } }) },
+        selectedSkydome: false,
+        selectedArchitecture: { type: "room", id: "room-a" },
+        selectedArchitectureItems: new Map([["room:room-a", { type: "room", id: "room-a" }]]),
+        selectedCameraId: "camera-a",
+        selectedCameraIds: new Set(["camera-a"]),
+        selectedLightId: "light-a",
+        selectedCameraKeyframeId: "keyframe-a",
+        activeCameraTrackId: "track-a",
+        lighting: {
+            shadows: { enabled: true, quality: "medium" },
+            lights: [{ light_id: "light-a", kind: "point" }],
+        },
+        editorView: {
+            view_mode: "plan",
+            plan_tool: "room",
+            interior_cutaway: { plan: true, three_d: false },
+            plan_camera: { target: [0, 0], zoom: 24 },
+        },
+        viewerState: { mode: "rotate", zoom_sensitivity: 0.1 },
+        viewer: {
+            getState: () => ({
+                mode: "scale",
+                zoom_sensitivity: 0.08,
+                plan_camera: { target: [4, 5], zoom: 32 },
+                camera: { position: [1, 2, 3] },
+            }),
+        },
         scene: { objects: snapshot.objects },
         sourceAsset: { url: "/reference", name: "input.png" },
+        _selectedArchitectureRefs: () => [{ type: "room", id: "room-a" }],
         _scenePayload: () => snapshot,
     });
-    assert.equal(state.schema_version, 4);
+    assert.equal(state.schema_version, 17);
     assert.equal(state.settings.steps, 37);
     assert.equal(state.selected_object_id, "object-a");
     assert.deepEqual(state.selected_object_ids, ["object-a", "object-b"]);
@@ -743,6 +858,15 @@ test("Factory serializes settings, source, scene snapshot, selection, and viewer
     assert.deepEqual(state.scene_snapshot, snapshot);
     assert.equal(state.source.url, "/reference");
     assert.equal(state.viewer_state.mode, "scale");
+    assert.equal(state.viewer_state.zoom_sensitivity, 0.08);
+    assert.deepEqual(state.selected_architectures, [{ type: "room", id: "room-a" }]);
+    assert.deepEqual(state.selected_camera_ids, ["camera-a"]);
+    assert.equal(state.selected_light_id, "light-a");
+    assert.equal(state.active_camera_track_id, "track-a");
+    assert.equal(state.selected_camera_keyframe_id, "keyframe-a");
+    assert.deepEqual(state.editor_view.interior_cutaway, { plan: true, three_d: false });
+    assert.deepEqual(state.editor_view.plan_camera, { target: [4, 5], zoom: 32 });
+    assert.equal(state.lighting_settings.lights[0].light_id, "light-a");
     assert.deepEqual(state.render_settings, {
         width: 1920,
         height: 1080,
@@ -774,6 +898,72 @@ test("Configured nodes cancel blank initialization before restoring their saved 
     assert.match(lifecycle[0], /clearTimeout\(this\._vnccsFactoryInit\)/);
     assert.match(lifecycle[0], /\}, 400\)/);
     assert.match(lifecycle[0], /\}, 40\)/);
+});
+
+test("Plan marquee converts client coordinates into the scaled viewport host", async () => {
+    const module = await import(
+        `${pathToFileURL(path.join(root, "web", "vnccs_3d_factory_viewer.js")).href}?marquee=${Date.now()}`
+    );
+    const marqueeViewer = Object.create(module.Factory3DViewer.prototype);
+    marqueeViewer.host = { clientWidth: 1600, clientHeight: 900 };
+    marqueeViewer.canvas = {
+        clientWidth: 1600,
+        clientHeight: 900,
+        getBoundingClientRect: () => ({ left: 300, top: 200, width: 800, height: 450 }),
+    };
+    marqueeViewer.planMarqueeElement = { hidden: true, style: {} };
+    marqueeViewer._planMarquee = {
+        originX: 500,
+        originY: 300,
+        currentX: 700,
+        currentY: 450,
+    };
+    marqueeViewer._updatePlanMarqueeElement();
+    assert.equal(marqueeViewer.planMarqueeElement.hidden, false);
+    assert.deepEqual(marqueeViewer.planMarqueeElement.style, {
+        left: "400px",
+        top: "200px",
+        width: "400px",
+        height: "300px",
+    });
+});
+
+test("Architecture runtime casts opaque closed geometry from back faces only", async () => {
+    const geometryModule = await import(
+        `${pathToFileURL(path.join(root, "web", "factory3d", "plan_geometry.mjs")).href}?shadow=${Date.now()}`
+    );
+    const THREE = await import(
+        pathToFileURL(path.join(root, "web", "vendor", "spark", "three.module.js")).href
+    );
+    const materials = new geometryModule.FactoryMaterialRegistry();
+    const wall = geometryModule.createWallObject(
+        {
+            wall_id: "wall-a",
+            name: "Wall",
+            start: [0, 0],
+            end: [4, 0],
+            thickness: 0.12,
+            height: 2.8,
+        },
+        { elevation: 0, height: 2.8 },
+        [],
+        materials,
+    );
+    const wallMeshes = wall.children.filter(
+        child => child.isMesh && child.userData?.factoryType === "wall",
+    );
+    assert.equal(wallMeshes.length, 1);
+    assert.equal(wallMeshes[0].castShadow, true);
+    assert.equal(wallMeshes[0].receiveShadow, true);
+    for (const material of wallMeshes[0].material) {
+        assert.equal(material.shadowSide, THREE.BackSide);
+    }
+    assert.equal(
+        wall.children.some(child => child.userData?.factoryShadowSeal),
+        false,
+    );
+    wall.traverse(child => child.geometry?.dispose?.());
+    materials.dispose();
 });
 
 test("Factory viewer and every vendored Three/Spark dependency can actually import", async () => {
@@ -902,8 +1092,35 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
             elevation: 24,
             ambient: 0.22,
             background: "#090d1a",
+            shadows: {
+                enabled: true,
+                quality: "medium",
+                bias: -0.0002,
+                normal_bias: 0.0015,
+            },
+            lights: [],
         },
     );
+    const normalizedPointLight = module.normalizedLighting({
+        shadows: { enabled: true, quality: "high", bias: -0.0002, normal_bias: 0.0015 },
+        lights: [{
+            light_id: "light-a",
+            name: "Practical",
+            kind: "point",
+            position: [1, 2.4, 3],
+            target: [1, 0, 3],
+            color: "#FF0088",
+            intensity: 10,
+            distance: 8,
+            cast_shadow: true,
+            visible: true,
+        }],
+    });
+    assert.equal(normalizedPointLight.shadows.quality, "high");
+    assert.equal(normalizedPointLight.lights.length, 1);
+    assert.equal(normalizedPointLight.lights[0].kind, "point");
+    assert.equal(normalizedPointLight.lights[0].color, "#FF0088");
+    assert.deepEqual(normalizedPointLight.lights[0].position, [1, 2.4, 3]);
     assert.deepEqual(
         module.normalizedSkydome({
             url: "/sky.jpg",

--- a/tests/test_factory3d_frontend.mjs
+++ b/tests/test_factory3d_frontend.mjs
@@ -296,7 +296,9 @@ test("Selection no longer rebuilds layer cards before a double-click can rename 
 
 test("Scene updates reuse loaded splats and group transforms fan out to every object", () => {
     assert.match(studio, /this\.viewer\.setScene\(scene, \{ incremental \}\)/);
-    assert.match(viewer, /async setScene\(sceneData, \{ incremental = false \} = \{\}\)/);
+    assert.match(viewer, /setScene\(sceneData, options = \{\}\)/);
+    assert.match(viewer, /async _setSceneNow\(sceneData, \{ incremental = false \} = \{\}\)/);
+    assert.match(viewer, /this\._sceneSetSerial = operation\.catch\(\(\) => null\)/);
     assert.match(viewer, /if \(!incremental\) \{/);
     assert.match(viewer, /existing\?\.assetPath === assetPath/);
     assert.match(viewer, /this\.objects\.delete\(objectId\)/);
@@ -585,16 +587,16 @@ test("Factory keeps a responsive Sakura workspace with isolated side-panel tabs"
 
 test("Plan mode exposes distinct, previewed building workflows and explicit snap controls", () => {
     assert.match(studio, /data-plan-tool="wall"/);
-    assert.match(studio, /Draw connected wall segments/);
+    assert.match(studio, /Press and drag to draw a wall/);
     assert.match(studio, /data-plan-tool="room"/);
-    assert.match(studio, /Create a rectangular room from two corners/);
+    assert.match(studio, /Press and drag diagonally to draw a rectangular room/);
     assert.match(studio, /data-plan-tool="opening"/);
     assert.match(studio, /data-plan-tool="camera"/);
     assert.match(studio, /Opening type/);
     assert.match(studio, /Grid step · m/);
     assert.match(studio, /Major line every/);
-    assert.match(studio, /Hold Alt to bypass snap/);
-    assert.match(studio, /Hold Shift to force an orthogonal segment/);
+    assert.match(studio, /event\.altKey \|\| this\.editorView\.snap\?\.enabled === false/);
+    assert.match(studio, /event\.shiftKey \|\| this\.editorView\.snap\?\.orthogonal/);
     assert.match(studio, /Press and drag to draw a wall/);
     assert.match(studio, /Press and drag diagonally to draw a rectangular room/);
     assert.match(studio, /Press on a wall and drag to set the opening width/);
@@ -603,13 +605,13 @@ test("Plan mode exposes distinct, previewed building workflows and explicit snap
     assert.match(studio, /phase === "move"/);
     assert.match(studio, /phase !== "end"/);
     assert.match(studio, /if \(!gesture\.moved\)/);
-    assert.match(studio, /Opening preview/);
-    assert.match(studio, /Camera position set · move to aim/);
+    assert.match(studio, /this\.planHover = \{ tool, point, opening: placement \}/);
+    assert.match(studio, /Drag to aim the camera/);
     assert.match(studio, /_fitOpeningOnWall/);
     assert.match(viewer, /snapPlanPoint: options\.snapPlanPoint/);
     assert.match(viewer, /setPlanDraft\(draft\)/);
     assert.match(viewer, /setPlanGrid\(value = \{\}\)/);
-    assert.match(viewer, /setCameraMarkers\(cameras = \[\]\)/);
+    assert.match(viewer, /setCameraMarkers\(cameras = \[\], selectedIds = null\)/);
     assert.match(viewer, /onPlanGesture: options\.onPlanGesture/);
     assert.match(viewer, /phase: "start",[\s\S]*?type: "room"/);
     assert.match(viewer, /phase: "move",[\s\S]*?type: "room"/);
@@ -627,7 +629,7 @@ test("Editor workflows keep buildings optional and make levels, selection, floor
     assert.match(studio, /Assign camera to building/);
     assert.match(studio, /data-object-property="building_id"/);
     assert.match(studio, /data-camera-property="building_id"/);
-    assert.match(studio, /data-light-path="building_id"/);
+    assert.match(studio, /data-light-property="building_id"/);
     assert.match(studio, /vnccs-i3s__camera-track-building/);
     assert.match(studio, /track\.building_id !== building\.building_id/);
     assert.match(studio, /active_building_id/);
@@ -718,8 +720,8 @@ test("Editor schema normalizes grid aliases, room perimeters, buildings, and non
             wall_ids: ["w1", "w2", "w3", "w4"],
         }],
         openings: [
-            { opening_id: "o1", wall_id: "w1", offset: 0.5, width: 2 },
-            { opening_id: "o2", wall_id: "w1", offset: 0.5, width: 2 },
+            { opening_id: "o1", wall_id: "w1", offset: 0.25, width: 1 },
+            { opening_id: "o2", wall_id: "w1", offset: 0.75, width: 1 },
         ],
     }, [level]);
     assert.equal(normalized.buildings[0].building_id, "building-a");
@@ -729,6 +731,16 @@ test("Editor schema normalizes grid aliases, room perimeters, buildings, and non
         .map(opening => [opening.offset * 4 - opening.width / 2, opening.offset * 4 + opening.width / 2])
         .sort((left, right) => left[0] - right[0]);
     assert.ok(intervals[0][1] <= intervals[1][0] + 1e-9);
+    const overlapping = schema.normalizedArchitecture({
+        buildings: [building],
+        walls,
+        rooms: [],
+        openings: [
+            { opening_id: "overlap-a", wall_id: "w1", offset: 0.5, width: 2 },
+            { opening_id: "overlap-b", wall_id: "w1", offset: 0.5, width: 2 },
+        ],
+    }, [level]);
+    assert.equal(overlapping.openings.length, 1);
 
     const invalid = schema.normalizedArchitecture({
         buildings: [building],
@@ -1492,6 +1504,10 @@ test("Factory viewer and every vendored Three/Spark dependency can actually impo
     const frameViewer = Object.create(module.Factory3DViewer.prototype);
     frameViewer.host = { clientWidth: 1600, clientHeight: 900 };
     frameViewer.camera = new THREE.PerspectiveCamera();
+    frameViewer.planCamera = new THREE.OrthographicCamera();
+    frameViewer.planCameraState = { target: [0, 0], zoom: 24 };
+    frameViewer.sceneData = null;
+    frameViewer._syncPlanGrid = () => {};
     frameViewer.captureWidth = 1080;
     frameViewer.captureHeight = 1920;
     frameViewer.captureFov = 42;

--- a/tests/test_factory3d_library.py
+++ b/tests/test_factory3d_library.py
@@ -194,6 +194,7 @@ class FactoryLibraryTests(unittest.TestCase):
             "aspect": "16:9",
             "show_camera_frame": True,
         }
+        light_id = self.factory._new_id()
         scene["lighting"] = {
             "preset": "sunset",
             "intensity": 0.8,
@@ -202,6 +203,28 @@ class FactoryLibraryTests(unittest.TestCase):
             "elevation": 11,
             "ambient": 0.28,
             "background": "#25141b",
+            "shadows": {
+                "enabled": True,
+                "quality": "high",
+                "bias": -0.0002,
+                "normal_bias": 0.0015,
+            },
+            "lights": [{
+                "light_id": light_id,
+                "name": "Practical",
+                "level_id": scene["levels"][0]["level_id"],
+                "building_id": "",
+                "kind": "point",
+                "position": [1, 2.4, 3],
+                "target": [1, 0, 3],
+                "color": "#ff0088",
+                "intensity": 10,
+                "distance": 8,
+                "angle": 45,
+                "penumbra": 0.2,
+                "cast_shadow": True,
+                "visible": True,
+            }],
         }
         scene["layers"] = [
             {
@@ -234,6 +257,15 @@ class FactoryLibraryTests(unittest.TestCase):
         self.assertEqual(restored["cameras"][0]["position"], [3.0, 2.0, 1.0])
         self.assertEqual(restored["render"]["width"], 1600)
         self.assertEqual(restored["lighting"]["preset"], "sunset")
+        self.assertEqual(restored["lighting"]["shadows"]["quality"], "high")
+        self.assertEqual(len(restored["lighting"]["lights"]), 1)
+        self.assertEqual(restored["lighting"]["lights"][0]["light_id"], light_id)
+        self.assertEqual(restored["lighting"]["lights"][0]["name"], "Practical")
+        self.assertEqual(restored["lighting"]["lights"][0]["position"], [1.0, 2.4, 3.0])
+        self.assertEqual(
+            restored["lighting"]["lights"][0]["level_id"],
+            restored["levels"][0]["level_id"],
+        )
         self.assertEqual(restored["layers"][0]["type"], "group")
         self.assertEqual(len(restored["layers"][0]["children"]), 1)
         self.assertEqual(restored["skydome"]["type"], "skydome")

--- a/tests/test_factory3d_node.py
+++ b/tests/test_factory3d_node.py
@@ -289,6 +289,35 @@ class FactoryNodeTests(unittest.TestCase):
             )
         )
 
+        standalone_room = json.loads(json.dumps(empty_building_scene))
+        polygon = [[0.0, 0.0], [4.0, 0.0], [4.0, 3.0], [0.0, 3.0]]
+        wall_ids = [character * 32 for character in "2345"]
+        standalone_room["scene_snapshot"]["architecture"]["walls"] = [
+            {
+                "wall_id": wall_ids[index],
+                "level_id": level_id,
+                "building_id": "",
+                "start": polygon[index],
+                "end": polygon[(index + 1) % len(polygon)],
+                "thickness": 0.12,
+                "height": 2.8,
+                "elevation_offset": 0.0,
+            }
+            for index in range(len(polygon))
+        ]
+        standalone_room["scene_snapshot"]["architecture"]["rooms"] = [{
+            "room_id": "6" * 32,
+            "level_id": level_id,
+            "building_id": "",
+            "polygon": polygon,
+            "wall_ids": wall_ids,
+        }]
+        self.assertTrue(
+            self.module.VNCCS_3DFactory.VALIDATE_INPUTS(
+                json.dumps(standalone_room)
+            )
+        )
+
         duplicate_light = json.loads(json.dumps(empty_building_scene))
         duplicate_light["scene_snapshot"]["lighting"]["lights"].append(point_light)
         self.assertIsInstance(

--- a/tests/test_factory3d_node.py
+++ b/tests/test_factory3d_node.py
@@ -43,7 +43,7 @@ class FactoryNodeTests(unittest.TestCase):
     def test_state_validation_accepts_opaque_ids_and_rejects_paths(self):
         valid = json.dumps(
             {
-                "schema_version": 4,
+                "schema_version": 17,
                 "scene_id": "a" * 32,
                 "selected_object_id": "b" * 32,
                 "selected_object_ids": ["b" * 32, "c" * 32],
@@ -51,6 +51,14 @@ class FactoryNodeTests(unittest.TestCase):
                 "collapsed_group_ids": ["d" * 32],
                 "scene_snapshot": {
                     "name": "Scene",
+                    "levels": [{
+                        "level_id": "f" * 32,
+                        "name": "Level 1",
+                        "elevation": 0.0,
+                        "height": 2.8,
+                        "slab_thickness": 0.15,
+                        "visible": True,
+                    }],
                     "render": {
                         "width": 1920,
                         "height": 1080,
@@ -70,10 +78,24 @@ class FactoryNodeTests(unittest.TestCase):
                         "target": [0.0, 0.0, 0.0],
                         "up": [0.0, 1.0, 0.0],
                         "fov": 48.0,
+                        "level_id": "f" * 32,
+                        "building_id": "",
                     }],
                     "objects": [
-                        {"object_id": "b" * 32, "transform": {}, "visible": True},
-                        {"object_id": "c" * 32, "transform": {}, "visible": False},
+                        {
+                            "object_id": "b" * 32,
+                            "transform": {},
+                            "visible": True,
+                            "level_id": "f" * 32,
+                            "building_id": "",
+                        },
+                        {
+                            "object_id": "c" * 32,
+                            "transform": {},
+                            "visible": False,
+                            "level_id": "f" * 32,
+                            "building_id": "",
+                        },
                     ],
                     "layers": [{
                         "type": "group",
@@ -82,6 +104,50 @@ class FactoryNodeTests(unittest.TestCase):
                         "visible": True,
                         "children": ["b" * 32, "c" * 32],
                     }],
+                    "architecture": {
+                        "materials": [],
+                        "buildings": [],
+                        "walls": [],
+                        "rooms": [],
+                        "openings": [],
+                    },
+                    "camera_tracks": [],
+                    "lighting": {
+                        "shadows": {
+                            "enabled": True,
+                            "quality": "medium",
+                            "bias": -0.0002,
+                            "normal_bias": 0.0015,
+                        },
+                        "lights": [{
+                            "light_id": "1" * 32,
+                            "name": "Practical",
+                            "level_id": "f" * 32,
+                            "building_id": "",
+                            "kind": "point",
+                            "position": [1.0, 2.4, 3.0],
+                            "target": [1.0, 0.0, 3.0],
+                            "color": "#ff0088",
+                            "intensity": 10.0,
+                            "distance": 8.0,
+                            "angle": 45.0,
+                            "penumbra": 0.2,
+                            "cast_shadow": True,
+                            "visible": True,
+                        }],
+                    },
+                },
+                "viewer_state": {
+                    "view_mode": "plan",
+                    "zoom_sensitivity": 0.1,
+                    "plan_camera": {"target": [0.0, 0.0], "zoom": 24.0},
+                },
+                "editor_view": {
+                    "view_mode": "plan",
+                    "plan_tool": "room",
+                    "active_level_id": "f" * 32,
+                    "active_building_id": "",
+                    "interior_cutaway": {"plan": True, "three_d": False},
                 },
                 "source": {
                     "scene_id": "a" * 32,
@@ -173,6 +239,74 @@ class FactoryNodeTests(unittest.TestCase):
         )
         self.assertIsInstance(
             self.module.VNCCS_3DFactory.VALIDATE_INPUTS(invalid_camera),
+            str,
+        )
+
+    def test_state_validation_keeps_buildings_optional_and_validates_local_light_references(self):
+        level_id = "f" * 32
+        light_id = "1" * 32
+        point_light = {
+            "light_id": light_id,
+            "name": "Practical",
+            "level_id": level_id,
+            "building_id": "",
+            "kind": "point",
+            "position": [1.0, 2.4, 3.0],
+            "target": [1.0, 0.0, 3.0],
+            "intensity": 10.0,
+            "distance": 8.0,
+            "angle": 45.0,
+            "penumbra": 0.2,
+        }
+        empty_building_scene = {
+            "schema_version": 17,
+            "scene_id": "a" * 32,
+            "scene_snapshot": {
+                "objects": [],
+                "layers": [],
+                "levels": [{
+                    "level_id": level_id,
+                    "elevation": 0.0,
+                    "height": 2.8,
+                    "slab_thickness": 0.15,
+                }],
+                "architecture": {
+                    "materials": [],
+                    "buildings": [],
+                    "walls": [],
+                    "rooms": [],
+                    "openings": [],
+                },
+                "lighting": {
+                    "shadows": {"enabled": True, "quality": "medium"},
+                    "lights": [point_light],
+                },
+            },
+        }
+        self.assertTrue(
+            self.module.VNCCS_3DFactory.VALIDATE_INPUTS(
+                json.dumps(empty_building_scene)
+            )
+        )
+
+        duplicate_light = json.loads(json.dumps(empty_building_scene))
+        duplicate_light["scene_snapshot"]["lighting"]["lights"].append(point_light)
+        self.assertIsInstance(
+            self.module.VNCCS_3DFactory.VALIDATE_INPUTS(json.dumps(duplicate_light)),
+            str,
+        )
+
+        unknown_level = json.loads(json.dumps(empty_building_scene))
+        unknown_level["scene_snapshot"]["lighting"]["lights"][0]["level_id"] = "e" * 32
+        self.assertIsInstance(
+            self.module.VNCCS_3DFactory.VALIDATE_INPUTS(json.dumps(unknown_level)),
+            str,
+        )
+
+        unknown_building = json.loads(json.dumps(empty_building_scene))
+        unknown_building["scene_snapshot"]["lighting"]["lights"][0]["building_id"] = "d" * 32
+        self.assertIsInstance(
+            self.module.VNCCS_3DFactory.VALIDATE_INPUTS(json.dumps(unknown_building)),
             str,
         )
 

--- a/tests/test_widget_hardening.mjs
+++ b/tests/test_widget_hardening.mjs
@@ -265,9 +265,12 @@ test("Pose Manager SAM input applies proportions without replacing managed poses
     assert.match(managerMethod, /manager_auto_analyze_proportions === false/);
     assert.match(
         managerMethod,
-        /viewer\.applySAM3DImport\([\s\S]*poseForAnalysis,[\s\S]*\{ recordState: false \}/,
+        /viewer\.applySAM3DImport\([\s\S]*poseForAnalysis,[\s\S]*recordState: false,[\s\S]*dispatchPoseChange: false/,
     );
-    assert.match(managerMethod, /applySAM3DMeshOverlayFit\(fitData\.meshData, poseForAnalysis\)/);
+    assert.match(
+        managerMethod,
+        /applySAM3DMeshOverlayFit\([\s\S]*fitData\.meshData,[\s\S]*poseForAnalysis,[\s\S]*dispatchPoseChange: false/,
+    );
     assert.doesNotMatch(managerMethod, /commitViewerPoseToCurrentEditor/);
     assert.doesNotMatch(managerMethod, /this\.poses\[this\.activeTab\]\s*=\s*poseForAnalysis/);
     assert.match(managerMethod, /for \(const pose of this\.poses \|\| \[\]\)/);
@@ -291,6 +294,38 @@ test("Pose Manager SAM input applies proportions without replacing managed poses
     assert.match(eventMethod, /applySAM3DProportionsToPoseManager\(poseData\)/);
     assert.match(eventMethod, /widget\.syncToNode\(true, \{[\s\S]*executionCapture: true/);
     assert.match(eventMethod, /viewer\.applySAM3DImport\(/, "ordinary Pose Studio import must remain intact");
+
+    const coreImportStart = poseStudioCoreSource.indexOf("applySAM3DImport(data, shoulderYOffset = 0, options = {})");
+    const coreImportEnd = poseStudioCoreSource.indexOf("\n    applyHMR2v1Import", coreImportStart);
+    const coreImportMethod = poseStudioCoreSource.slice(coreImportStart, coreImportEnd);
+    assert.match(
+        coreImportMethod,
+        /dispatchPoseChange: options\.dispatchPoseChange !== false/,
+        "world-keypoint SAM imports must honor proportion-only analysis",
+    );
+    assert.match(
+        coreImportMethod,
+        /if \(options\.dispatchPoseChange !== false\) this\.dispatchPoseChange\(\)/,
+        "rotation-only SAM imports must honor proportion-only analysis",
+    );
+
+    const overlayStart = poseStudioCoreSource.indexOf("fitCurrentPoseToSAMMeshOverlay(shoulderYOffset = 0, options = {})");
+    const overlayEnd = poseStudioCoreSource.indexOf("\n    fitSAM3DJointRootLengthsToWorldKps", overlayStart);
+    const overlayMethod = poseStudioCoreSource.slice(overlayStart, overlayEnd);
+    assert.match(
+        overlayMethod,
+        /dispatchPoseChange: finalPass && options\.dispatchPoseChange !== false/,
+        "mesh-overlay proportion fitting must not leak the detected pose either",
+    );
+
+    const overlayBridgeStart = poseStudioSource.indexOf("applySAM3DMeshOverlayFit(meshData, poseData, options = {})");
+    const overlayBridgeEnd = poseStudioSource.indexOf("\n    applySAM3DStandardCameraFit", overlayBridgeStart);
+    const overlayBridgeMethod = poseStudioSource.slice(overlayBridgeStart, overlayBridgeEnd);
+    assert.match(
+        overlayBridgeMethod,
+        /fitCurrentPoseToSAMMeshOverlay\([\s\S]*dispatchPoseChange: options\.dispatchPoseChange !== false/,
+        "the Pose Manager suppression flag must reach the overlay fitter",
+    );
 });
 
 

--- a/web/factory3d/camera_path.mjs
+++ b/web/factory3d/camera_path.mjs
@@ -1,0 +1,197 @@
+import * as THREE from "../vendor/spark/three.module.js";
+
+const clamp01 = value => Math.max(0, Math.min(1, Number(value) || 0));
+
+function eased(value, kind = "smooth") {
+    const t = clamp01(value);
+    if (kind === "linear") return t;
+    if (kind === "ease_in") return t * t;
+    if (kind === "ease_out") return 1 - (1 - t) * (1 - t);
+    if (kind === "ease_in_out") return t < 0.5 ? 2 * t * t : 1 - ((-2 * t + 2) ** 2) / 2;
+    return t * t * (3 - 2 * t);
+}
+
+export function normalizedCameraPose(value = {}) {
+    const position = new THREE.Vector3().fromArray(value.position || [0, 1.6, 0]);
+    const quaternion = new THREE.Quaternion().fromArray(value.quaternion || [0, 0, 0, 1]);
+    if (quaternion.lengthSq() < 1e-12) quaternion.identity();
+    quaternion.normalize();
+    return {
+        position: position.toArray(),
+        quaternion: quaternion.toArray(),
+        fov: Math.max(5, Math.min(120, Number(value.fov) || 42)),
+        focus_distance: Math.max(0.001, Number(value.focus_distance) || 1),
+    };
+}
+
+export function cameraPoseFromLegacy(value = {}) {
+    if (Array.isArray(value.quaternion)) return normalizedCameraPose(value);
+    const position = new THREE.Vector3().fromArray(value.position || [0, 1.6, 0]);
+    const target = new THREE.Vector3().fromArray(value.target || [0, 1.6, -1]);
+    const up = new THREE.Vector3().fromArray(value.up || [0, 1, 0]).normalize();
+    if (position.distanceToSquared(target) < 1e-12) target.set(position.x, position.y, position.z - 1);
+    const matrix = new THREE.Matrix4().lookAt(position, target, up);
+    const quaternion = new THREE.Quaternion().setFromRotationMatrix(matrix);
+    return normalizedCameraPose({
+        position: position.toArray(),
+        quaternion: quaternion.toArray(),
+        fov: value.fov,
+        focus_distance: position.distanceTo(target),
+    });
+}
+
+export function legacyCameraFromPose(value = {}) {
+    const pose = normalizedCameraPose(value);
+    const position = new THREE.Vector3().fromArray(pose.position);
+    const quaternion = new THREE.Quaternion().fromArray(pose.quaternion);
+    const forward = new THREE.Vector3(0, 0, -1).applyQuaternion(quaternion);
+    const up = new THREE.Vector3(0, 1, 0).applyQuaternion(quaternion);
+    return {
+        position: pose.position,
+        target: position.addScaledVector(forward, pose.focus_distance).toArray(),
+        up: up.toArray(),
+        fov: pose.fov,
+    };
+}
+
+export class FactoryCameraPath {
+    constructor(track = {}) {
+        this.track = track;
+        this.frames = (Array.isArray(track.keyframes) ? track.keyframes : [])
+            .map(frame => ({ ...frame, ...normalizedCameraPose(frame) }))
+            .sort((left, right) => Number(left.time) - Number(right.time));
+        this.duration = Math.max(0.1, Number(track.duration) || this.frames.at(-1)?.time || 5);
+        if (
+            track.loop
+            && this.frames.length > 1
+            && Number(this.frames.at(-1).time) < this.duration - 1e-9
+        ) {
+            this.frames.push({ ...this.frames[0], time: this.duration, synthetic_loop: true });
+        }
+        this.points = this.frames.map(frame => new THREE.Vector3().fromArray(frame.position));
+        this.segmentCurves = [];
+        this.segmentArcTables = [];
+        this.segmentLengths = [];
+        this.totalLength = 0;
+        for (let index = 1; index < this.points.length; index += 1) {
+            let length = this.points[index - 1].distanceTo(this.points[index]);
+            if (this.track.interpolation !== "linear") {
+                const last = this.points.length - 1;
+                const point = pointIndex => {
+                    if (this.track.loop) {
+                        const loopLength = this.frames.at(-1)?.synthetic_loop
+                            ? this.points.length - 1
+                            : this.points.length;
+                        return this.points[(pointIndex + loopLength) % loopLength];
+                    }
+                    return this.points[Math.max(0, Math.min(last, pointIndex))];
+                };
+                const leftIndex = index - 1;
+                const curve = new THREE.CatmullRomCurve3(
+                    [point(leftIndex - 1), point(leftIndex), point(leftIndex + 1), point(leftIndex + 2)],
+                    false,
+                    "centripetal",
+                    0.5,
+                );
+                const distances = [0];
+                let previous = curve.getPoint(1 / 3);
+                for (let sample = 1; sample <= 64; sample += 1) {
+                    const current = curve.getPoint((1 + sample / 64) / 3);
+                    distances.push(distances.at(-1) + previous.distanceTo(current));
+                    previous = current;
+                }
+                length = distances.at(-1);
+                this.segmentCurves.push(curve);
+                this.segmentArcTables.push(distances);
+            } else {
+                this.segmentCurves.push(null);
+                this.segmentArcTables.push(null);
+            }
+            this.segmentLengths.push(length);
+            this.totalLength += length;
+        }
+    }
+
+    _segmentPosition(leftIndex, local, constantSpeed = false) {
+        if (this.track.interpolation === "linear") {
+            return this.points[leftIndex].clone().lerp(this.points[leftIndex + 1], local);
+        }
+        const curve = this.segmentCurves[leftIndex];
+        let curveLocal = Math.max(0, Math.min(1, local));
+        if (constantSpeed) {
+            const table = this.segmentArcTables[leftIndex];
+            const target = curveLocal * (table?.at(-1) || 0);
+            let upper = table?.findIndex(distance => distance >= target) ?? -1;
+            if (upper < 0) upper = 64;
+            if (upper <= 0) upper = 1;
+            const lower = upper - 1;
+            const span = Math.max(1e-9, table[upper] - table[lower]);
+            curveLocal = (lower + (target - table[lower]) / span) / 64;
+        }
+        return curve.getPoint((1 + curveLocal) / 3);
+    }
+
+    _constantSpeedSample(progress) {
+        if (this.totalLength <= 1e-9) {
+            return { position: this.points[0].clone(), leftIndex: 0, local: 0 };
+        }
+        const target = clamp01(progress) * this.totalLength;
+        let traversed = 0;
+        for (let index = 0; index < this.segmentLengths.length; index += 1) {
+            const length = this.segmentLengths[index];
+            if (traversed + length >= target || index === this.segmentLengths.length - 1) {
+                const local = Math.max(0, Math.min(
+                    1,
+                    length > 1e-9 ? (target - traversed) / length : 0,
+                ));
+                return {
+                    position: this._segmentPosition(index, local, true),
+                    leftIndex: index,
+                    local,
+                };
+            }
+            traversed += length;
+        }
+        return {
+            position: this.points.at(-1).clone(),
+            leftIndex: Math.max(0, this.points.length - 2),
+            local: 1,
+        };
+    }
+
+    evaluate(timeSeconds) {
+        if (!this.frames.length) return normalizedCameraPose();
+        if (this.frames.length === 1) return normalizedCameraPose(this.frames[0]);
+        let time = Number(timeSeconds) || 0;
+        time = this.track.loop
+            ? ((time % this.duration) + this.duration) % this.duration
+            : Math.max(0, Math.min(this.duration, time));
+        let rightIndex = this.frames.findIndex(frame => Number(frame.time) >= time);
+        if (rightIndex <= 0) rightIndex = 1;
+        if (rightIndex < 0) rightIndex = this.frames.length - 1;
+        let left = this.frames[rightIndex - 1];
+        let right = this.frames[rightIndex];
+        const span = Math.max(1e-9, Number(right.time) - Number(left.time));
+        let local = eased((time - Number(left.time)) / span, right.easing || left.easing);
+        let position;
+        if (this.track.constant_speed === true) {
+            const sample = this._constantSpeedSample(time / this.duration);
+            left = this.frames[sample.leftIndex];
+            right = this.frames[sample.leftIndex + 1];
+            local = eased(sample.local, right.easing || left.easing);
+            position = sample.position;
+        } else {
+            position = this._segmentPosition(rightIndex - 1, local);
+        }
+        const quaternion = new THREE.Quaternion().fromArray(left.quaternion).slerp(
+            new THREE.Quaternion().fromArray(right.quaternion),
+            local,
+        ).normalize();
+        return {
+            position: position.toArray(),
+            quaternion: quaternion.toArray(),
+            fov: THREE.MathUtils.lerp(left.fov, right.fov, local),
+            focus_distance: THREE.MathUtils.lerp(left.focus_distance, right.focus_distance, local),
+        };
+    }
+}

--- a/web/factory3d/editor_commands.mjs
+++ b/web/factory3d/editor_commands.mjs
@@ -1,0 +1,87 @@
+const clone = value => globalThis.structuredClone
+    ? globalThis.structuredClone(value)
+    : JSON.parse(JSON.stringify(value));
+
+export class FactoryCommandHistory {
+    constructor({ limit = 100, onRestore = () => {} } = {}) {
+        this.limit = Math.max(1, Number(limit) || 100);
+        this.onRestore = onRestore;
+        this.undoStack = [];
+        this.redoStack = [];
+        this.pending = null;
+    }
+
+    begin(label, value) {
+        if (this.pending) return;
+        this.pending = { label: String(label || "Edit"), before: clone(value) };
+    }
+
+    commit(value) {
+        if (!this.pending) return false;
+        const entry = { ...this.pending, after: clone(value) };
+        this.pending = null;
+        if (JSON.stringify(entry.before) === JSON.stringify(entry.after)) return false;
+        this.undoStack.push(entry);
+        if (this.undoStack.length > this.limit) this.undoStack.shift();
+        this.redoStack.length = 0;
+        return true;
+    }
+
+    cancel() {
+        if (!this.pending) return false;
+        const before = this.pending.before;
+        this.pending = null;
+        this.onRestore(clone(before), { direction: "cancel" });
+        return true;
+    }
+
+    push(label, before, after) {
+        this.pending = { label: String(label || "Edit"), before: clone(before) };
+        return this.commit(after);
+    }
+
+    undo() {
+        const entry = this.undoStack.pop();
+        if (!entry) return false;
+        this.redoStack.push(entry);
+        this.onRestore(clone(entry.before), { direction: "undo", label: entry.label });
+        return true;
+    }
+
+    redo() {
+        const entry = this.redoStack.pop();
+        if (!entry) return false;
+        this.undoStack.push(entry);
+        this.onRestore(clone(entry.after), { direction: "redo", label: entry.label });
+        return true;
+    }
+
+    clear() {
+        this.pending = null;
+        this.undoStack.length = 0;
+        this.redoStack.length = 0;
+    }
+
+    get canUndo() { return this.undoStack.length > 0; }
+    get canRedo() { return this.redoStack.length > 0; }
+}
+
+export function preserveScrollState(root, operation) {
+    const states = new Map();
+    for (const element of root?.querySelectorAll?.("[data-preserve-scroll]") || []) {
+        states.set(element.dataset.preserveScroll, {
+            top: element.scrollTop,
+            left: element.scrollLeft,
+        });
+    }
+    const result = operation();
+    requestAnimationFrame(() => {
+        for (const element of root?.querySelectorAll?.("[data-preserve-scroll]") || []) {
+            const state = states.get(element.dataset.preserveScroll);
+            if (!state) continue;
+            element.scrollTop = state.top;
+            element.scrollLeft = state.left;
+        }
+    });
+    return result;
+}

--- a/web/factory3d/editor_schema.mjs
+++ b/web/factory3d/editor_schema.mjs
@@ -267,6 +267,14 @@ export function normalizedArchitecture(value = {}, levels = []) {
     }
     const buildingIds = new Set(buildings.map(item => item.building_id));
     const defaultBuildingId = buildings[0]?.building_id || "";
+    const architectureBuildingId = item => {
+        const sourceItem = item && typeof item === "object" ? item : {};
+        const requested = String(sourceItem.building_id || "");
+        if (buildingIds.has(requested)) return requested;
+        return Object.prototype.hasOwnProperty.call(sourceItem, "building_id")
+            ? ""
+            : defaultBuildingId;
+    };
     const walls = rawWalls.map(item => ({
         ...DEFAULT_WALL,
         ...item,
@@ -274,9 +282,7 @@ export function normalizedArchitecture(value = {}, levels = []) {
         level_id: levelIds.has(String(item?.level_id || ""))
             ? String(item.level_id)
             : defaultLevelId,
-        building_id: buildingIds.has(String(item?.building_id || ""))
-            ? String(item.building_id)
-            : defaultBuildingId,
+        building_id: architectureBuildingId(item),
         start: finitePoint2(item?.start),
         end: finitePoint2(item?.end, [1, 0]),
         thickness: finiteNumber(item?.thickness, DEFAULT_WALL.thickness, 0.01, 10),
@@ -296,9 +302,7 @@ export function normalizedArchitecture(value = {}, levels = []) {
         level_id: levelIds.has(String(item?.level_id || ""))
             ? String(item.level_id)
             : defaultLevelId,
-        building_id: buildingIds.has(String(item?.building_id || ""))
-            ? String(item.building_id)
-            : defaultBuildingId,
+        building_id: architectureBuildingId(item),
         polygon: (Array.isArray(item?.polygon) ? item.polygon : []).map(point => finitePoint2(point)),
         wall_ids: Array.isArray(item?.wall_ids)
             ? item.wall_ids.map(String).filter(wallId => wallIds.has(wallId))

--- a/web/factory3d/editor_schema.mjs
+++ b/web/factory3d/editor_schema.mjs
@@ -1,0 +1,400 @@
+export const FACTORY_EDITOR_SCHEMA_VERSION = 17;
+
+export const DEFAULT_BUILDING = Object.freeze({
+    name: "Building 1",
+    position: Object.freeze([0, 0, 0]),
+    rotation_y: 0,
+    visible: true,
+    locked: false,
+});
+
+export const DEFAULT_LEVEL = Object.freeze({
+    name: "Level 1",
+    elevation: 0,
+    height: 2.8,
+    slab_thickness: 0.15,
+    visible: true,
+});
+
+export const DEFAULT_WALL = Object.freeze({
+    name: "Wall",
+    thickness: 0.12,
+    height: 2.8,
+    elevation_offset: 0,
+    material_left: "",
+    material_right: "",
+    material_caps: "",
+    visible: true,
+    locked: false,
+});
+
+export const DEFAULT_ROOM = Object.freeze({
+    name: "Room",
+    floor: Object.freeze({ enabled: true, thickness: 0.02, material_id: "" }),
+    ceiling: Object.freeze({ enabled: true, height: 2.8, thickness: 0.02, material_id: "" }),
+    visible: true,
+    locked: false,
+});
+
+export const DEFAULT_EDITOR_VIEW = Object.freeze({
+    view_mode: "3d",
+    plan_tool: "select",
+    opening_kind: "window",
+    active_level_id: "",
+    active_building_id: "",
+    workspace: Object.freeze({
+        left: "generate",
+        right: "objects",
+    }),
+    plan_grid: Object.freeze({
+        visible: true,
+        step: 0.1,
+        major_every: 10,
+    }),
+    snap: Object.freeze({
+        enabled: true,
+        grid: 0.1,
+        angle: 15,
+        endpoints: true,
+        midpoints: true,
+        orthogonal: true,
+    }),
+    plan_camera: Object.freeze({
+        target: Object.freeze([0, 0]),
+        zoom: 24,
+    }),
+});
+
+export function factoryId() {
+    const bytes = new Uint8Array(16);
+    if (globalThis.crypto?.getRandomValues) {
+        globalThis.crypto.getRandomValues(bytes);
+    } else {
+        for (let index = 0; index < bytes.length; index += 1) {
+            bytes[index] = Math.floor(Math.random() * 256);
+        }
+    }
+    return Array.from(bytes, value => value.toString(16).padStart(2, "0")).join("");
+}
+
+export function finiteNumber(value, fallback = 0, minimum = -1e6, maximum = 1e6) {
+    const number = Number(value);
+    return Math.max(minimum, Math.min(maximum, Number.isFinite(number) ? number : fallback));
+}
+
+export function finitePoint2(value, fallback = [0, 0]) {
+    return [
+        finiteNumber(value?.[0], fallback[0]),
+        finiteNumber(value?.[1], fallback[1]),
+    ];
+}
+
+export function finitePoint3(value, fallback = [0, 0, 0]) {
+    return [
+        finiteNumber(value?.[0], fallback[0]),
+        finiteNumber(value?.[1], fallback[1]),
+        finiteNumber(value?.[2], fallback[2]),
+    ];
+}
+
+export function isSimpleRoomPolygon(points = []) {
+    if (!Array.isArray(points) || points.length < 3) return false;
+    const polygon = points.map(point => finitePoint2(point));
+    const distance = (left, right) => Math.hypot(left[0] - right[0], left[1] - right[1]);
+    if (polygon.some((point, index) => distance(point, polygon[(index + 1) % polygon.length]) < 0.001)) {
+        return false;
+    }
+    const area = polygon.reduce((total, point, index) => {
+        const next = polygon[(index + 1) % polygon.length];
+        return total + point[0] * next[1] - next[0] * point[1];
+    }, 0) * 0.5;
+    if (Math.abs(area) < 1e-6) return false;
+    const orientation = (a, b, c) => (
+        (b[0] - a[0]) * (c[1] - a[1]) - (b[1] - a[1]) * (c[0] - a[0])
+    );
+    const onSegment = (a, b, point) => (
+        point[0] >= Math.min(a[0], b[0]) - 1e-9
+        && point[0] <= Math.max(a[0], b[0]) + 1e-9
+        && point[1] >= Math.min(a[1], b[1]) - 1e-9
+        && point[1] <= Math.max(a[1], b[1]) + 1e-9
+    );
+    const intersects = (a, b, c, d) => {
+        const values = [
+            orientation(a, b, c),
+            orientation(a, b, d),
+            orientation(c, d, a),
+            orientation(c, d, b),
+        ];
+        if (values[0] * values[1] < 0 && values[2] * values[3] < 0) return true;
+        return (Math.abs(values[0]) <= 1e-9 && onSegment(a, b, c))
+            || (Math.abs(values[1]) <= 1e-9 && onSegment(a, b, d))
+            || (Math.abs(values[2]) <= 1e-9 && onSegment(c, d, a))
+            || (Math.abs(values[3]) <= 1e-9 && onSegment(c, d, b));
+    };
+    for (let left = 0; left < polygon.length; left += 1) {
+        const a = polygon[left];
+        const b = polygon[(left + 1) % polygon.length];
+        for (let right = left + 1; right < polygon.length; right += 1) {
+            if (right === left || right === (left + 1) % polygon.length || (right + 1) % polygon.length === left) {
+                continue;
+            }
+            if (intersects(a, b, polygon[right], polygon[(right + 1) % polygon.length])) return false;
+        }
+    }
+    return true;
+}
+
+export function normalizedEditorView(value = {}, activeLevelId = "") {
+    const source = value && typeof value === "object" ? value : {};
+    const snap = source.snap && typeof source.snap === "object" ? source.snap : {};
+    const planGrid = source.plan_grid && typeof source.plan_grid === "object"
+        ? source.plan_grid
+        : {};
+    // `snap.grid` was the original Plan Mode spacing field. Keep emitting it
+    // as a compatibility alias while making the visible grid the canonical
+    // owner of the shared step.
+    const gridStep = finiteNumber(planGrid.step ?? snap.grid, 0.1, 0.001, 1000);
+    const planCamera = source.plan_camera && typeof source.plan_camera === "object"
+        ? source.plan_camera
+        : {};
+    const workspace = source.workspace && typeof source.workspace === "object"
+        ? source.workspace
+        : {};
+    return {
+        view_mode: source.view_mode === "plan" ? "plan" : "3d",
+        plan_tool: ["select", "wall", "room", "opening", "camera"].includes(source.plan_tool)
+            ? source.plan_tool
+            : "select",
+        opening_kind: ["window", "door", "empty"].includes(source.opening_kind)
+            ? source.opening_kind
+            : "window",
+        active_level_id: String(source.active_level_id || activeLevelId || ""),
+        active_building_id: String(source.active_building_id || ""),
+        workspace: {
+            left: ["generate", "cameras"].includes(workspace.left)
+                ? workspace.left
+                : "generate",
+            right: ["objects", "inspector", "export"].includes(workspace.right)
+                ? workspace.right
+                : "objects",
+        },
+        plan_grid: {
+            visible: planGrid.visible !== false,
+            step: gridStep,
+            major_every: Math.round(finiteNumber(planGrid.major_every, 10, 2, 100)),
+        },
+        snap: {
+            enabled: snap.enabled !== false,
+            grid: gridStep,
+            angle: finiteNumber(snap.angle, 15, 0.01, 180),
+            endpoints: snap.endpoints !== false,
+            midpoints: snap.midpoints !== false,
+            orthogonal: snap.orthogonal !== false,
+        },
+        plan_camera: {
+            target: finitePoint2(planCamera.target),
+            zoom: finiteNumber(planCamera.zoom, 24, 0.01, 100000),
+        },
+    };
+}
+
+export function normalizedCollisionProxy(value = {}) {
+    const source = value && typeof value === "object" ? value : {};
+    const mode = ["auto_box", "box", "off"].includes(source.mode)
+        ? source.mode
+        : "auto_box";
+    return {
+        mode,
+        center: finitePoint3(source.center),
+        size: finitePoint3(source.size, [1, 1, 1]).map(item => Math.max(0.001, item)),
+        supports_objects: source.supports_objects !== false,
+    };
+}
+
+export function normalizedObjectEditorProperties(value = {}) {
+    const lightTransport = ["opaque", "cutout", "transmissive"].includes(value.light_transport)
+        ? value.light_transport
+        : "opaque";
+    return {
+        building_id: String(value.building_id || ""),
+        collision_proxy: normalizedCollisionProxy(value.collision_proxy),
+        light_transport: lightTransport,
+        transmission: finiteNumber(
+            value.transmission,
+            lightTransport === "transmissive" ? 1 : 0,
+            0,
+            1,
+        ),
+        locked: value.locked === true,
+    };
+}
+
+export function normalizedArchitecture(value = {}, levels = []) {
+    const source = value && typeof value === "object" ? value : {};
+    const defaultLevelId = String(levels[0]?.level_id || "");
+    const levelIds = new Set(levels.map(level => String(level.level_id || "")));
+    const hasBuildingSchema = Array.isArray(source.buildings);
+    const rawBuildings = Array.isArray(source.buildings) ? source.buildings : [];
+    const rawWalls = Array.isArray(source.walls) ? source.walls : [];
+    const rawRooms = Array.isArray(source.rooms) ? source.rooms : [];
+    const buildings = rawBuildings.map((item, index) => ({
+        ...DEFAULT_BUILDING,
+        ...item,
+        building_id: String(item?.building_id || factoryId()),
+        name: String(item?.name || `Building ${index + 1}`),
+        position: finitePoint3(item?.position),
+        rotation_y: finiteNumber(item?.rotation_y, 0, -36000, 36000),
+        visible: item?.visible !== false,
+        locked: item?.locked === true,
+    }));
+    // Architecture saved before Buildings existed is migrated once so its
+    // walls and rooms retain an owner. An explicit empty `buildings` array is
+    // authoritative: new and intentionally cleared scenes remain building-free.
+    if (!buildings.length && !hasBuildingSchema && (rawWalls.length || rawRooms.length)) {
+        buildings.push({ ...DEFAULT_BUILDING, position: [0, 0, 0], building_id: factoryId() });
+    }
+    const buildingIds = new Set(buildings.map(item => item.building_id));
+    const defaultBuildingId = buildings[0]?.building_id || "";
+    const walls = rawWalls.map(item => ({
+        ...DEFAULT_WALL,
+        ...item,
+        wall_id: String(item?.wall_id || factoryId()),
+        level_id: levelIds.has(String(item?.level_id || ""))
+            ? String(item.level_id)
+            : defaultLevelId,
+        building_id: buildingIds.has(String(item?.building_id || ""))
+            ? String(item.building_id)
+            : defaultBuildingId,
+        start: finitePoint2(item?.start),
+        end: finitePoint2(item?.end, [1, 0]),
+        thickness: finiteNumber(item?.thickness, DEFAULT_WALL.thickness, 0.01, 10),
+        height: finiteNumber(item?.height, DEFAULT_WALL.height, 0.05, 1000),
+        elevation_offset: finiteNumber(item?.elevation_offset, 0, -1000, 1000),
+        visible: item?.visible !== false,
+        locked: item?.locked === true,
+    })).filter(item => (
+        (!item.building_id || buildingIds.has(item.building_id))
+        && Math.hypot(item.end[0] - item.start[0], item.end[1] - item.start[1]) >= 0.001
+    ));
+    const wallIds = new Set(walls.map(item => item.wall_id));
+    const rooms = rawRooms.map(item => ({
+        ...DEFAULT_ROOM,
+        ...item,
+        room_id: String(item?.room_id || factoryId()),
+        level_id: levelIds.has(String(item?.level_id || ""))
+            ? String(item.level_id)
+            : defaultLevelId,
+        building_id: buildingIds.has(String(item?.building_id || ""))
+            ? String(item.building_id)
+            : defaultBuildingId,
+        polygon: (Array.isArray(item?.polygon) ? item.polygon : []).map(point => finitePoint2(point)),
+        wall_ids: Array.isArray(item?.wall_ids)
+            ? item.wall_ids.map(String).filter(wallId => wallIds.has(wallId))
+            : [],
+        floor: { ...DEFAULT_ROOM.floor, ...(item?.floor || {}) },
+        ceiling: { ...DEFAULT_ROOM.ceiling, ...(item?.ceiling || {}) },
+        visible: item?.visible !== false,
+        locked: item?.locked === true,
+    })).filter(item => (
+        (!item.building_id || buildingIds.has(item.building_id))
+        && isSimpleRoomPolygon(item.polygon)
+    ));
+    const wallsById = new Map(walls.map(wall => [wall.wall_id, wall]));
+    for (const room of rooms) {
+        room.wall_ids = [...new Set(room.wall_ids)];
+        const perimeterValid = room.wall_ids.length === room.polygon.length
+            && room.wall_ids.every((wallId, index) => {
+                const wall = wallsById.get(wallId);
+                const start = room.polygon[index];
+                const end = room.polygon[(index + 1) % room.polygon.length];
+                return wall
+                    && wall.level_id === room.level_id
+                    && wall.building_id === room.building_id
+                    && Math.hypot(wall.start[0] - start[0], wall.start[1] - start[1]) <= 1e-4
+                    && Math.hypot(wall.end[0] - end[0], wall.end[1] - end[1]) <= 1e-4;
+            });
+        if (!perimeterValid) room.wall_ids = [];
+    }
+    const openingCandidates = (Array.isArray(source.openings) ? source.openings : [])
+        .filter(item => wallIds.has(String(item?.wall_id || "")))
+        .map(item => ({
+            opening_id: String(item?.opening_id || factoryId()),
+            wall_id: String(item.wall_id),
+            name: String(item?.name || "Opening"),
+            kind: ["empty", "door", "window"].includes(item?.kind) ? item.kind : "empty",
+            offset: finiteNumber(item?.offset, 0.5, 0, 1),
+            width: finiteNumber(item?.width, 0.9, 0.05, 100),
+            height: finiteNumber(item?.height, 1.2, 0.05, 100),
+            sill_height: finiteNumber(item?.sill_height, 0.9, 0, 100),
+            material_id: String(item?.material_id || ""),
+            visible: item?.visible !== false,
+            locked: item?.locked === true,
+        }));
+    const occupiedByWall = new Map();
+    const openings = [];
+    for (const opening of openingCandidates) {
+        const wall = wallsById.get(opening.wall_id);
+        const length = Math.hypot(wall.end[0] - wall.start[0], wall.end[1] - wall.start[1]);
+        if (length < 0.05) continue;
+        const width = Math.min(length, opening.width);
+        const half = width / 2;
+        const occupied = occupiedByWall.get(wall.wall_id) || [];
+        const free = [];
+        let cursor = 0;
+        for (const [start, end] of occupied.sort((left, right) => left[0] - right[0])) {
+            if (start > cursor) free.push([cursor, start]);
+            cursor = Math.max(cursor, end);
+        }
+        if (cursor < length) free.push([cursor, length]);
+        const requested = opening.offset * length;
+        const candidates = free.map(([start, end]) => {
+            const minimum = start + half;
+            const maximum = end - half;
+            if (minimum > maximum + 1e-9) return null;
+            const center = Math.max(minimum, Math.min(maximum, requested));
+            return { center, distance: Math.abs(center - requested) };
+        }).filter(Boolean).sort((left, right) => left.distance - right.distance);
+        if (!candidates.length) continue;
+        const center = candidates[0].center;
+        occupied.push([center - half, center + half]);
+        occupiedByWall.set(wall.wall_id, occupied);
+        const height = Math.min(opening.height, wall.height);
+        openings.push({
+            ...opening,
+            offset: center / length,
+            width,
+            height,
+            sill_height: Math.min(opening.sill_height, Math.max(0, wall.height - height)),
+        });
+    }
+    return {
+        units: "m",
+        materials: Array.isArray(source.materials) ? source.materials : [],
+        buildings,
+        walls,
+        rooms,
+        openings,
+    };
+}
+
+export function normalizedLevels(value = [], fallbackId = "") {
+    const levels = (Array.isArray(value) ? value : []).map((item, index) => ({
+        ...DEFAULT_LEVEL,
+        ...item,
+        level_id: String(item?.level_id || factoryId()),
+        name: String(item?.name || `Level ${index + 1}`),
+        elevation: finiteNumber(item?.elevation, 0, -10000, 10000),
+        height: finiteNumber(item?.height, DEFAULT_LEVEL.height, 0.1, 1000),
+        slab_thickness: finiteNumber(
+            item?.slab_thickness,
+            DEFAULT_LEVEL.slab_thickness,
+            0,
+            100,
+        ),
+        visible: item?.visible !== false,
+    }));
+    if (!levels.length) {
+        levels.push({ ...DEFAULT_LEVEL, level_id: fallbackId || factoryId() });
+    }
+    return levels.sort((left, right) => left.elevation - right.elevation);
+}

--- a/web/factory3d/editor_schema.mjs
+++ b/web/factory3d/editor_schema.mjs
@@ -160,6 +160,12 @@ export function normalizedEditorView(value = {}, activeLevelId = "") {
     const workspace = source.workspace && typeof source.workspace === "object"
         ? source.workspace
         : {};
+    const cutawaySource = source.interior_cutaway && typeof source.interior_cutaway === "object"
+        ? source.interior_cutaway
+        : {};
+    const legacyCutaway = typeof source.interior_cutaway === "boolean"
+        ? source.interior_cutaway
+        : null;
     return {
         view_mode: source.view_mode === "plan" ? "plan" : "3d",
         plan_tool: ["select", "wall", "room", "opening", "camera"].includes(source.plan_tool)
@@ -177,6 +183,12 @@ export function normalizedEditorView(value = {}, activeLevelId = "") {
             right: ["objects", "inspector", "export"].includes(workspace.right)
                 ? workspace.right
                 : "objects",
+        },
+        interior_cutaway: {
+            // Plan has historically hidden ceilings. Preserve that behavior,
+            // while keeping the 3D viewport opt-in for existing workflows.
+            plan: legacyCutaway ?? (cutawaySource.plan !== false),
+            three_d: legacyCutaway ?? (cutawaySource.three_d === true),
         },
         plan_grid: {
             visible: planGrid.visible !== false,

--- a/web/factory3d/plan_geometry.mjs
+++ b/web/factory3d/plan_geometry.mjs
@@ -9,12 +9,6 @@ const DEFAULT_SURFACE = Object.freeze({
     kind: "standard",
 });
 
-// Shadow maps shrink and soften silhouettes by a small amount at shared
-// edges. A wall assembled from independent segments therefore needs a tiny
-// shadow-only overlap even when the visible boxes already meet exactly.
-const WALL_SHADOW_SEAL_MINIMUM = 0.006;
-const WALL_SHADOW_SEAL_MAXIMUM = 0.02;
-
 function materialFromData(value = {}, texture = null) {
     const data = { ...DEFAULT_SURFACE, ...(value || {}) };
     const shared = {
@@ -24,6 +18,12 @@ function materialFromData(value = {}, texture = null) {
         opacity: Number(data.opacity),
         transparent: Number(data.opacity) < 1 || data.kind === "glass",
         side: THREE.DoubleSide,
+        // Architecture uses closed box/extruded geometry. Rendering it
+        // double-sided is useful while editing, but casting both sides into a
+        // shadow map makes the front and rear faces compete at shallow point-
+        // light angles. Back-face casting keeps the physical wall thickness
+        // as the occluder and avoids self-shadow blocks on the visible face.
+        shadowSide: data.kind === "glass" ? THREE.DoubleSide : THREE.BackSide,
         map: texture || null,
     };
     if (data.kind === "glass") {
@@ -55,12 +55,6 @@ export class FactoryMaterialRegistry {
             opacity: 0.35,
             transmission: 1,
             roughness: 0.08,
-        });
-        this.shadowSeal = new THREE.MeshBasicMaterial({
-            color: 0x000000,
-            colorWrite: false,
-            depthWrite: false,
-            side: THREE.DoubleSide,
         });
         this.openingHit = new THREE.MeshBasicMaterial({
             transparent: true,
@@ -128,7 +122,6 @@ export class FactoryMaterialRegistry {
         this.defaultFloor.dispose();
         this.defaultCeiling.dispose();
         this.defaultGlass.dispose();
-        this.shadowSeal.dispose();
         this.openingHit.dispose();
     }
 }
@@ -231,28 +224,6 @@ export function createWallObject(wall, level, openings, materials, junctions = {
         mesh.receiveShadow = true;
         mesh.userData = group.userData;
         group.add(mesh);
-
-        // Keep the visible wall dimensions exact, but dilate its shadow
-        // silhouette just enough to overlap adjacent wall cells and the room
-        // slab. This closes PCF/normal-bias leaks without changing picking,
-        // materials, exported color, or the editable architectural geometry.
-        const sealMargin = Math.min(
-            WALL_SHADOW_SEAL_MAXIMUM,
-            Math.max(WALL_SHADOW_SEAL_MINIMUM, thickness * 0.08),
-        );
-        const sealGeometry = new THREE.BoxGeometry(
-            sealedWidth + sealMargin * 2,
-            cell.height + sealMargin * 2,
-            thickness + sealMargin * 2,
-        );
-        const seal = new THREE.Mesh(sealGeometry, materials.shadowSeal);
-        seal.position.copy(mesh.position);
-        seal.castShadow = true;
-        seal.receiveShadow = false;
-        seal.userData = {
-            factoryShadowSeal: true,
-        };
-        group.add(seal);
     }
     for (const value of openingData.openings) {
         const geometry = new THREE.PlaneGeometry(value.end - value.start, value.top - value.bottom);

--- a/web/factory3d/plan_geometry.mjs
+++ b/web/factory3d/plan_geometry.mjs
@@ -1,0 +1,501 @@
+import * as THREE from "../vendor/spark/three.module.js";
+
+const DEFAULT_SURFACE = Object.freeze({
+    color: "#d7d2ca",
+    roughness: 0.78,
+    metalness: 0,
+    opacity: 1,
+    transmission: 0,
+    kind: "standard",
+});
+
+function materialFromData(value = {}, texture = null) {
+    const data = { ...DEFAULT_SURFACE, ...(value || {}) };
+    const shared = {
+        color: data.color,
+        roughness: Number(data.roughness),
+        metalness: Number(data.metalness),
+        opacity: Number(data.opacity),
+        transparent: Number(data.opacity) < 1 || data.kind === "glass",
+        side: THREE.DoubleSide,
+        map: texture || null,
+    };
+    if (data.kind === "glass") {
+        const transmission = Number(data.transmission);
+        return new THREE.MeshPhysicalMaterial({
+            ...shared,
+            transmission: Math.max(0, Math.min(1, Number.isFinite(transmission) ? transmission : 1)),
+            ior: Math.max(1, Math.min(2.5, Number(data.ior) || 1.5)),
+            depthWrite: false,
+        });
+    }
+    return new THREE.MeshStandardMaterial(shared);
+}
+
+export class FactoryMaterialRegistry {
+    constructor({ resolveTexture = () => null } = {}) {
+        this.resolveTexture = resolveTexture;
+        this.materials = new Map();
+        this.textures = new Map();
+        this.signature = "";
+        this.disposed = false;
+        this._setToken = 0;
+        this.defaultWall = materialFromData({ color: "#d7d2ca" });
+        this.defaultFloor = materialFromData({ color: "#77716e", roughness: 0.9 });
+        this.defaultCeiling = materialFromData({ color: "#eeeae4", roughness: 0.92 });
+        this.defaultGlass = materialFromData({
+            kind: "glass",
+            color: "#cde9f3",
+            opacity: 0.35,
+            transmission: 1,
+            roughness: 0.08,
+        });
+        this.openingHit = new THREE.MeshBasicMaterial({
+            transparent: true,
+            opacity: 0,
+            colorWrite: false,
+            depthWrite: false,
+            side: THREE.DoubleSide,
+        });
+    }
+
+    async set(materialEntries = []) {
+        if (this.disposed) return;
+        const signature = JSON.stringify(materialEntries);
+        if (signature === this.signature) return;
+        const token = ++this._setToken;
+        this.disposeCustom();
+        for (const entry of materialEntries) {
+            let texture = null;
+            if (entry?.texture_id) {
+                try {
+                    texture = await this.resolveTexture(entry.texture_id);
+                    if (this.disposed || token !== this._setToken) {
+                        texture?.dispose?.();
+                        return;
+                    }
+                    if (texture) {
+                        texture.colorSpace = THREE.SRGBColorSpace;
+                        texture.wrapS = texture.wrapT = THREE.RepeatWrapping;
+                        texture.repeat.fromArray(entry.uv_scale || [1, 1]);
+                        texture.rotation = THREE.MathUtils.degToRad(Number(entry.uv_rotation) || 0);
+                        texture.center.set(0.5, 0.5);
+                        this.textures.set(entry.texture_id, texture);
+                    }
+                } catch (_) {
+                    texture = null;
+                }
+            }
+            this.materials.set(entry.material_id, materialFromData(entry, texture));
+        }
+        if (!this.disposed && token === this._setToken) this.signature = signature;
+    }
+
+    get(materialId, fallback = "wall") {
+        if (materialId && this.materials.has(materialId)) return this.materials.get(materialId);
+        if (fallback === "floor") return this.defaultFloor;
+        if (fallback === "ceiling") return this.defaultCeiling;
+        if (fallback === "glass") return this.defaultGlass;
+        return this.defaultWall;
+    }
+
+    disposeCustom() {
+        for (const material of this.materials.values()) material.dispose?.();
+        for (const texture of this.textures.values()) texture.dispose?.();
+        this.materials.clear();
+        this.textures.clear();
+        this.signature = "";
+    }
+
+    dispose() {
+        if (this.disposed) return;
+        this.disposed = true;
+        this._setToken += 1;
+        this.disposeCustom();
+        this.defaultWall.dispose();
+        this.defaultFloor.dispose();
+        this.defaultCeiling.dispose();
+        this.defaultGlass.dispose();
+        this.openingHit.dispose();
+    }
+}
+
+function wallOpeningCells(length, height, openings) {
+    const minimum = -length / 2;
+    const maximum = length / 2;
+    const normalized = openings.map(opening => {
+        const center = minimum + Number(opening.offset) * length;
+        const half = Math.min(length, Number(opening.width)) / 2;
+        return {
+            opening,
+            start: Math.max(minimum, center - half),
+            end: Math.min(maximum, center + half),
+            bottom: Math.max(0, Number(opening.sill_height) || 0),
+            top: Math.min(height, (Number(opening.sill_height) || 0) + Number(opening.height)),
+        };
+    }).filter(item => item.end - item.start >= 0.001 && item.top - item.bottom >= 0.001);
+    const boundaries = Array.from(new Set([
+        minimum,
+        maximum,
+        ...normalized.flatMap(item => [item.start, item.end]),
+    ])).sort((left, right) => left - right);
+    const cells = [];
+    for (let index = 0; index < boundaries.length - 1; index += 1) {
+        const start = boundaries[index];
+        const end = boundaries[index + 1];
+        const width = end - start;
+        if (width < 0.001) continue;
+        const center = (start + end) / 2;
+        const opening = normalized.find(item => center > item.start && center < item.end);
+        if (!opening) {
+            cells.push({ x: center, y: height / 2, width, height });
+            continue;
+        }
+        if (opening.bottom > 0.001) {
+            cells.push({
+                x: center,
+                y: opening.bottom / 2,
+                width,
+                height: opening.bottom,
+            });
+        }
+        if (height - opening.top > 0.001) {
+            cells.push({
+                x: center,
+                y: opening.top + (height - opening.top) / 2,
+                width,
+                height: height - opening.top,
+            });
+        }
+    }
+    return { cells, openings: normalized };
+}
+
+export function createWallObject(wall, level, openings, materials) {
+    const start = new THREE.Vector2().fromArray(wall.start);
+    const end = new THREE.Vector2().fromArray(wall.end);
+    const direction = end.clone().sub(start);
+    const length = direction.length();
+    const group = new THREE.Group();
+    group.name = wall.name || "Wall";
+    group.userData = { factoryType: "wall", factoryId: wall.wall_id };
+    if (length < 0.001) return group;
+    const elevation = Number(level?.elevation) + Number(wall.elevation_offset || 0);
+    const height = Math.max(0.05, Number(wall.height) || Number(level?.height) || 2.8);
+    const thickness = Math.max(0.01, Number(wall.thickness) || 0.12);
+    const openingData = wallOpeningCells(
+        length,
+        height,
+        openings.filter(opening => opening.visible !== false),
+    );
+    const leftMaterial = materials.get(wall.material_left, "wall");
+    const rightMaterial = materials.get(wall.material_right, "wall");
+    const capMaterial = materials.get(wall.material_caps, "wall");
+    for (const cell of openingData.cells) {
+        const geometry = new THREE.BoxGeometry(cell.width, cell.height, thickness);
+        const mesh = new THREE.Mesh(geometry, [
+            capMaterial,
+            capMaterial,
+            capMaterial,
+            capMaterial,
+            rightMaterial,
+            leftMaterial,
+        ]);
+        mesh.position.set(cell.x, elevation + cell.y, 0);
+        mesh.castShadow = true;
+        mesh.receiveShadow = true;
+        mesh.userData = group.userData;
+        group.add(mesh);
+    }
+    for (const value of openingData.openings) {
+        const geometry = new THREE.PlaneGeometry(value.end - value.start, value.top - value.bottom);
+        const material = value.opening.kind === "window"
+            ? materials.get(value.opening.material_id, "glass")
+            : materials.openingHit;
+        const pane = new THREE.Mesh(geometry, material);
+        pane.position.set(
+            (value.start + value.end) / 2,
+            elevation + (value.bottom + value.top) / 2,
+            0,
+        );
+        pane.castShadow = false;
+        pane.receiveShadow = false;
+        pane.userData = {
+            factoryType: "opening",
+            factoryId: value.opening.opening_id,
+            wallId: wall.wall_id,
+            ignoreLightOcclusion: value.opening.kind !== "window",
+        };
+        group.add(pane);
+
+        const planSymbol = new THREE.Group();
+        planSymbol.name = `${value.opening.kind || "opening"} plan symbol`;
+        planSymbol.position.set((value.start + value.end) / 2, elevation + 0.035, 0);
+        planSymbol.userData = {
+            factoryType: "opening",
+            factoryId: value.opening.opening_id,
+            wallId: wall.wall_id,
+            factoryPlanOnly: true,
+        };
+        const symbolWidth = Math.max(0.05, value.end - value.start);
+        const symbolDepth = Math.max(0.2, thickness * 2.4);
+        const hit = new THREE.Mesh(
+            new THREE.BoxGeometry(symbolWidth, 0.025, symbolDepth),
+            new THREE.MeshBasicMaterial({
+                color: value.opening.kind === "door" ? "#ffca85" : "#69d8ff",
+                transparent: true,
+                opacity: 0.22,
+                depthTest: false,
+            }),
+        );
+        hit.material.userData.factoryOwned = true;
+        hit.userData = planSymbol.userData;
+        hit.renderOrder = 48;
+        planSymbol.add(hit);
+        const lineMaterial = new THREE.LineBasicMaterial({
+            color: value.opening.kind === "door" ? "#ffe2b5" : "#d8f5ff",
+            depthTest: false,
+        });
+        lineMaterial.userData.factoryOwned = true;
+        const halfWidth = symbolWidth / 2;
+        const linePoints = value.opening.kind === "door"
+            ? [
+                new THREE.Vector3(-halfWidth, 0.015, 0),
+                new THREE.Vector3(-halfWidth, 0.015, symbolWidth),
+                new THREE.Vector3(halfWidth, 0.015, 0),
+            ]
+            : [
+                new THREE.Vector3(-halfWidth, 0.015, -symbolDepth * 0.22),
+                new THREE.Vector3(halfWidth, 0.015, -symbolDepth * 0.22),
+                new THREE.Vector3(-halfWidth, 0.015, symbolDepth * 0.22),
+                new THREE.Vector3(halfWidth, 0.015, symbolDepth * 0.22),
+            ];
+        if (value.opening.kind === "door") {
+            const geometry = new THREE.BufferGeometry().setFromPoints(linePoints);
+            const line = new THREE.Line(geometry, lineMaterial);
+            line.userData = planSymbol.userData;
+            line.renderOrder = 50;
+            planSymbol.add(line);
+        } else {
+            for (let index = 0; index < linePoints.length; index += 2) {
+                const geometry = new THREE.BufferGeometry().setFromPoints(linePoints.slice(index, index + 2));
+                const line = new THREE.Line(geometry, lineMaterial);
+                line.userData = planSymbol.userData;
+                line.renderOrder = 50;
+                planSymbol.add(line);
+            }
+        }
+        group.add(planSymbol);
+    }
+    group.position.set((start.x + end.x) / 2, 0, (start.y + end.y) / 2);
+    group.rotation.y = -Math.atan2(direction.y, direction.x);
+    return group;
+}
+
+function roomShape(polygon) {
+    const shape = new THREE.Shape();
+    polygon.forEach((point, index) => {
+        if (index === 0) shape.moveTo(point[0], point[1]);
+        else shape.lineTo(point[0], point[1]);
+    });
+    shape.closePath();
+    return shape;
+}
+
+function createRoomSurface(room, level, surface, kind, materials) {
+    if (surface?.enabled === false || !Array.isArray(room.polygon) || room.polygon.length < 3) {
+        return null;
+    }
+    const thickness = Math.max(0.001, Number(surface.thickness) || 0.02);
+    const geometry = new THREE.ExtrudeGeometry(roomShape(room.polygon), {
+        depth: thickness,
+        bevelEnabled: false,
+        curveSegments: 1,
+        steps: 1,
+    });
+    geometry.rotateX(Math.PI / 2);
+    const material = materials.get(surface.material_id, kind);
+    const mesh = new THREE.Mesh(geometry, material);
+    const levelElevation = Number(level?.elevation) || 0;
+    mesh.position.y = kind === "ceiling"
+        ? levelElevation + (Number(surface.height) || Number(level?.height) || 2.8)
+        : levelElevation;
+    mesh.castShadow = kind === "ceiling";
+    mesh.receiveShadow = true;
+    mesh.userData = { factoryType: kind, factoryId: room.room_id };
+    return mesh;
+}
+
+export function createRoomObject(room, level, materials) {
+    const group = new THREE.Group();
+    group.name = room.name || "Room";
+    group.userData = { factoryType: "room", factoryId: room.room_id };
+    const floor = createRoomSurface(room, level, room.floor, "floor", materials);
+    const ceiling = createRoomSurface(room, level, room.ceiling, "ceiling", materials);
+    if (floor) group.add(floor);
+    if (ceiling) group.add(ceiling);
+    return group;
+}
+
+export class FactoryArchitectureRuntime {
+    constructor(scene, { resolveTexture = () => null } = {}) {
+        this.scene = scene;
+        this.root = new THREE.Group();
+        this.root.name = "VNCCS Factory architecture";
+        this.materials = new FactoryMaterialRegistry({ resolveTexture });
+        this.items = new Map();
+        this.buildingRoots = new Map();
+        this.disposed = false;
+        this._setToken = 0;
+        this.scene.add(this.root);
+    }
+
+    async set(sceneData = {}) {
+        if (this.disposed) return;
+        const token = ++this._setToken;
+        this.clear();
+        this.sceneData = sceneData;
+        const architecture = sceneData.architecture || {};
+        await this.materials.set(architecture.materials || []);
+        if (this.disposed || token !== this._setToken) return;
+        const levels = new Map((sceneData.levels || []).map(item => [item.level_id, item]));
+        const buildings = Array.isArray(architecture.buildings) ? architecture.buildings : [];
+        for (const building of buildings) {
+            const object = new THREE.Group();
+            object.name = building.name || "Building";
+            object.userData = { factoryType: "building", factoryId: building.building_id };
+            object.position.fromArray(building.position || [0, 0, 0]);
+            object.rotation.y = THREE.MathUtils.degToRad(Number(building.rotation_y) || 0);
+            object.visible = building.visible !== false;
+            this.root.add(object);
+            this.buildingRoots.set(building.building_id, object);
+            this.items.set(`building:${building.building_id}`, object);
+        }
+        const openingsByWall = new Map();
+        for (const opening of architecture.openings || []) {
+            if (opening.visible === false) continue;
+            if (!openingsByWall.has(opening.wall_id)) openingsByWall.set(opening.wall_id, []);
+            openingsByWall.get(opening.wall_id).push(opening);
+        }
+        for (const wall of architecture.walls || []) {
+            const level = levels.get(wall.level_id);
+            if (!level || level.visible === false || wall.visible === false) continue;
+            const object = createWallObject(
+                wall,
+                level,
+                openingsByWall.get(wall.wall_id) || [],
+                this.materials,
+            );
+            (this.buildingRoots.get(wall.building_id) || this.root).add(object);
+            this.items.set(`wall:${wall.wall_id}`, object);
+        }
+        for (const room of architecture.rooms || []) {
+            const level = levels.get(room.level_id);
+            if (!level || level.visible === false || room.visible === false) continue;
+            const object = createRoomObject(room, level, this.materials);
+            (this.buildingRoots.get(room.building_id) || this.root).add(object);
+            this.items.set(`room:${room.room_id}`, object);
+        }
+    }
+
+    setActiveLevel(levelId, planMode = false) {
+        this.activeLevelId = levelId;
+        this.activePlanMode = planMode;
+        for (const [key, object] of this.items) {
+            if (key.startsWith("building:")) continue;
+            const [type, sourceId] = key.split(":");
+            const source = type === "wall"
+                ? this.sceneData?.architecture?.walls?.find(item => item.wall_id === sourceId)
+                : this.sceneData?.architecture?.rooms?.find(item => item.room_id === sourceId);
+            const level = this.sceneData?.levels?.find(item => item.level_id === source?.level_id);
+            object.visible = source?.visible !== false
+                && level?.visible !== false
+                && (!planMode || !levelId || source?.level_id === levelId);
+            object.traverse(child => {
+                if (child !== object && child.userData?.factoryType === "ceiling") child.visible = !planMode;
+                if (child.userData?.factoryPlanOnly) child.visible = planMode;
+            });
+        }
+    }
+
+    updateBuilding(building) {
+        const object = this.buildingRoots.get(building?.building_id);
+        if (!object) return false;
+        object.position.fromArray(building.position || [0, 0, 0]);
+        object.rotation.y = THREE.MathUtils.degToRad(Number(building.rotation_y) || 0);
+        object.visible = building.visible !== false;
+        object.updateMatrixWorld(true);
+        return true;
+    }
+
+    updateItem(type, id, sceneData = this.sceneData) {
+        this.sceneData = sceneData || this.sceneData;
+        const architecture = this.sceneData?.architecture || {};
+        if (type === "building") {
+            const building = architecture.buildings?.find(item => item.building_id === id);
+            return building ? this.updateBuilding(building) : false;
+        }
+        let sourceType = type;
+        let sourceId = id;
+        if (type === "opening") {
+            const opening = architecture.openings?.find(item => item.opening_id === id);
+            sourceType = "wall";
+            sourceId = opening?.wall_id || "";
+        }
+        const source = sourceType === "wall"
+            ? architecture.walls?.find(item => item.wall_id === sourceId)
+            : architecture.rooms?.find(item => item.room_id === sourceId);
+        const previous = this.items.get(`${sourceType}:${sourceId}`);
+        if (!source || !previous) return false;
+        const level = this.sceneData?.levels?.find(item => item.level_id === source.level_id);
+        if (!level) return false;
+        const replacement = sourceType === "wall"
+            ? createWallObject(
+                source,
+                level,
+                (architecture.openings || []).filter(item => item.wall_id === sourceId && item.visible !== false),
+                this.materials,
+            )
+            : createRoomObject(source, level, this.materials);
+        replacement.visible = source.visible !== false
+            && level.visible !== false
+            && (this.activePlanMode !== true || !this.activeLevelId || source.level_id === this.activeLevelId);
+        previous.traverse(child => {
+            child.geometry?.dispose?.();
+            const childMaterials = Array.isArray(child.material) ? child.material : [child.material];
+            for (const material of childMaterials) {
+                if (material?.userData?.factoryOwned) material.dispose?.();
+            }
+        });
+        const parent = previous.parent;
+        if (!parent) return false;
+        parent.add(replacement);
+        parent.remove(previous);
+        this.items.set(`${sourceType}:${sourceId}`, replacement);
+        return true;
+    }
+
+    clear() {
+        for (const object of [...this.root.children]) {
+            object.traverse(child => {
+                child.geometry?.dispose?.();
+                const childMaterials = Array.isArray(child.material) ? child.material : [child.material];
+                for (const material of childMaterials) {
+                    if (material?.userData?.factoryOwned) material.dispose?.();
+                }
+            });
+            this.root.remove(object);
+        }
+        this.items.clear();
+        this.buildingRoots.clear();
+    }
+
+    dispose() {
+        if (this.disposed) return;
+        this.disposed = true;
+        this._setToken += 1;
+        this.clear();
+        this.materials.dispose();
+        this.scene.remove(this.root);
+    }
+}

--- a/web/factory3d/plan_geometry.mjs
+++ b/web/factory3d/plan_geometry.mjs
@@ -9,6 +9,12 @@ const DEFAULT_SURFACE = Object.freeze({
     kind: "standard",
 });
 
+// Shadow maps shrink and soften silhouettes by a small amount at shared
+// edges. A wall assembled from independent segments therefore needs a tiny
+// shadow-only overlap even when the visible boxes already meet exactly.
+const WALL_SHADOW_SEAL_MINIMUM = 0.006;
+const WALL_SHADOW_SEAL_MAXIMUM = 0.02;
+
 function materialFromData(value = {}, texture = null) {
     const data = { ...DEFAULT_SURFACE, ...(value || {}) };
     const shared = {
@@ -49,6 +55,12 @@ export class FactoryMaterialRegistry {
             opacity: 0.35,
             transmission: 1,
             roughness: 0.08,
+        });
+        this.shadowSeal = new THREE.MeshBasicMaterial({
+            color: 0x000000,
+            colorWrite: false,
+            depthWrite: false,
+            side: THREE.DoubleSide,
         });
         this.openingHit = new THREE.MeshBasicMaterial({
             transparent: true,
@@ -116,6 +128,7 @@ export class FactoryMaterialRegistry {
         this.defaultFloor.dispose();
         this.defaultCeiling.dispose();
         this.defaultGlass.dispose();
+        this.shadowSeal.dispose();
         this.openingHit.dispose();
     }
 }
@@ -171,7 +184,7 @@ function wallOpeningCells(length, height, openings) {
     return { cells, openings: normalized };
 }
 
-export function createWallObject(wall, level, openings, materials) {
+export function createWallObject(wall, level, openings, materials, junctions = {}) {
     const start = new THREE.Vector2().fromArray(wall.start);
     const end = new THREE.Vector2().fromArray(wall.end);
     const direction = end.clone().sub(start);
@@ -192,7 +205,19 @@ export function createWallObject(wall, level, openings, materials) {
     const rightMaterial = materials.get(wall.material_right, "wall");
     const capMaterial = materials.get(wall.material_caps, "wall");
     for (const cell of openingData.cells) {
-        const geometry = new THREE.BoxGeometry(cell.width, cell.height, thickness);
+        const minimum = -length / 2;
+        const maximum = length / 2;
+        const cellStart = cell.x - cell.width / 2;
+        const cellEnd = cell.x + cell.width / 2;
+        const startExtension = Math.abs(cellStart - minimum) < 1e-6
+            ? Math.max(0, Number(junctions?.start?.extension) || 0)
+            : 0;
+        const endExtension = Math.abs(cellEnd - maximum) < 1e-6
+            ? Math.max(0, Number(junctions?.end?.extension) || 0)
+            : 0;
+        const sealedWidth = cell.width + startExtension + endExtension;
+        const sealedX = cell.x + (endExtension - startExtension) / 2;
+        const geometry = new THREE.BoxGeometry(sealedWidth, cell.height, thickness);
         const mesh = new THREE.Mesh(geometry, [
             capMaterial,
             capMaterial,
@@ -201,11 +226,33 @@ export function createWallObject(wall, level, openings, materials) {
             rightMaterial,
             leftMaterial,
         ]);
-        mesh.position.set(cell.x, elevation + cell.y, 0);
+        mesh.position.set(sealedX, elevation + cell.y, 0);
         mesh.castShadow = true;
         mesh.receiveShadow = true;
         mesh.userData = group.userData;
         group.add(mesh);
+
+        // Keep the visible wall dimensions exact, but dilate its shadow
+        // silhouette just enough to overlap adjacent wall cells and the room
+        // slab. This closes PCF/normal-bias leaks without changing picking,
+        // materials, exported color, or the editable architectural geometry.
+        const sealMargin = Math.min(
+            WALL_SHADOW_SEAL_MAXIMUM,
+            Math.max(WALL_SHADOW_SEAL_MINIMUM, thickness * 0.08),
+        );
+        const sealGeometry = new THREE.BoxGeometry(
+            sealedWidth + sealMargin * 2,
+            cell.height + sealMargin * 2,
+            thickness + sealMargin * 2,
+        );
+        const seal = new THREE.Mesh(sealGeometry, materials.shadowSeal);
+        seal.position.copy(mesh.position);
+        seal.castShadow = true;
+        seal.receiveShadow = false;
+        seal.userData = {
+            factoryShadowSeal: true,
+        };
+        group.add(seal);
     }
     for (const value of openingData.openings) {
         const geometry = new THREE.PlaneGeometry(value.end - value.start, value.top - value.bottom);
@@ -337,6 +384,66 @@ export function createRoomObject(room, level, materials) {
     return group;
 }
 
+function wallJunctionAssignments(sceneData = {}) {
+    const architecture = sceneData.architecture || {};
+    const levels = new Map((sceneData.levels || []).map(level => [level.level_id, level]));
+    const junctions = new Map();
+    const assignments = new Map();
+    const keyFor = (wall, point) => [
+        wall.building_id || "scene",
+        wall.level_id || "level",
+        (Number(point?.[0]) || 0).toFixed(4),
+        (Number(point?.[1]) || 0).toFixed(4),
+    ].join(":");
+    for (const wall of architecture.walls || []) {
+        const level = levels.get(wall.level_id);
+        if (!level || level.visible === false || wall.visible === false) continue;
+        const thickness = Math.max(0.01, Number(wall.thickness) || 0.12);
+        for (const endpoint of ["start", "end"]) {
+            const key = keyFor(wall, wall[endpoint]);
+            if (!junctions.has(key)) junctions.set(key, []);
+            const other = wall[endpoint === "start" ? "end" : "start"];
+            const direction = new THREE.Vector2(
+                (Number(other?.[0]) || 0) - (Number(wall[endpoint]?.[0]) || 0),
+                (Number(other?.[1]) || 0) - (Number(wall[endpoint]?.[1]) || 0),
+            );
+            if (direction.lengthSq() > 1e-12) direction.normalize();
+            junctions.get(key).push({
+                wall,
+                endpoint,
+                thickness,
+                direction,
+            });
+        }
+    }
+    for (const connected of junctions.values()) {
+        if (connected.length < 2) continue;
+        const maximumThickness = Math.max(...connected.map(item => item.thickness));
+        for (const item of connected) {
+            let extension = 0;
+            for (const other of connected) {
+                if (other === item || !item.direction.lengthSq() || !other.direction.lengthSq()) continue;
+                const angle = Math.acos(THREE.MathUtils.clamp(
+                    item.direction.dot(other.direction),
+                    -1,
+                    1,
+                ));
+                const tangent = Math.tan(angle / 2);
+                const candidate = tangent > 1e-4
+                    ? (maximumThickness * 0.5) / tangent
+                    : maximumThickness * 8;
+                extension = Math.max(extension, candidate);
+            }
+            const wallAssignment = assignments.get(item.wall.wall_id) || {};
+            wallAssignment[item.endpoint] = {
+                extension: Math.max(0.002, Math.min(maximumThickness * 8, extension)),
+            };
+            assignments.set(item.wall.wall_id, wallAssignment);
+        }
+    }
+    return assignments;
+}
+
 export class FactoryArchitectureRuntime {
     constructor(scene, { resolveTexture = () => null } = {}) {
         this.scene = scene;
@@ -377,6 +484,7 @@ export class FactoryArchitectureRuntime {
             if (!openingsByWall.has(opening.wall_id)) openingsByWall.set(opening.wall_id, []);
             openingsByWall.get(opening.wall_id).push(opening);
         }
+        const wallJunctions = wallJunctionAssignments(sceneData);
         for (const wall of architecture.walls || []) {
             const level = levels.get(wall.level_id);
             if (!level || level.visible === false || wall.visible === false) continue;
@@ -385,6 +493,7 @@ export class FactoryArchitectureRuntime {
                 level,
                 openingsByWall.get(wall.wall_id) || [],
                 this.materials,
+                wallJunctions.get(wall.wall_id),
             );
             (this.buildingRoots.get(wall.building_id) || this.root).add(object);
             this.items.set(`wall:${wall.wall_id}`, object);
@@ -398,7 +507,11 @@ export class FactoryArchitectureRuntime {
         }
     }
 
-    setActiveLevel(levelId, planMode = false) {
+    setActiveLevel(
+        levelId,
+        planMode = false,
+        { hideCeilings = planMode, hiddenWallId = "" } = {},
+    ) {
         this.activeLevelId = levelId;
         this.activePlanMode = planMode;
         for (const [key, object] of this.items) {
@@ -410,9 +523,12 @@ export class FactoryArchitectureRuntime {
             const level = this.sceneData?.levels?.find(item => item.level_id === source?.level_id);
             object.visible = source?.visible !== false
                 && level?.visible !== false
-                && (!planMode || !levelId || source?.level_id === levelId);
+                && (!planMode || !levelId || source?.level_id === levelId)
+                && !(type === "wall" && sourceId === hiddenWallId);
             object.traverse(child => {
-                if (child !== object && child.userData?.factoryType === "ceiling") child.visible = !planMode;
+                if (child !== object && child.userData?.factoryType === "ceiling") {
+                    child.visible = !hideCeilings;
+                }
                 if (child.userData?.factoryPlanOnly) child.visible = planMode;
             });
         }
@@ -455,6 +571,7 @@ export class FactoryArchitectureRuntime {
                 level,
                 (architecture.openings || []).filter(item => item.wall_id === sourceId && item.visible !== false),
                 this.materials,
+                wallJunctionAssignments(this.sceneData).get(sourceId),
             )
             : createRoomObject(source, level, this.materials);
         replacement.visible = source.visible !== false

--- a/web/factory3d/support_solver.mjs
+++ b/web/factory3d/support_solver.mjs
@@ -1,0 +1,64 @@
+import * as THREE from "../vendor/spark/three.module.js";
+
+function intersectsXZ(left, right, tolerance = 1e-5) {
+    return left.max.x > right.min.x + tolerance
+        && left.min.x < right.max.x - tolerance
+        && left.max.z > right.min.z + tolerance
+        && left.min.z < right.max.z - tolerance;
+}
+
+function proxyBounds(entry) {
+    const proxy = entry?.data?.collision_proxy || {};
+    if (proxy.mode === "off") return null;
+    entry.mesh?.updateMatrixWorld?.(true);
+    if (proxy.mode === "box" && Array.isArray(proxy.center) && Array.isArray(proxy.size)) {
+        const center = new THREE.Vector3().fromArray(proxy.center);
+        const half = new THREE.Vector3().fromArray(proxy.size).multiplyScalar(0.5);
+        return new THREE.Box3(center.clone().sub(half), center.clone().add(half))
+            .applyMatrix4(entry.mesh.matrixWorld);
+    }
+    if (entry?.localBounds && entry?.mesh?.matrixWorld) {
+        return entry.localBounds.clone().applyMatrix4(entry.mesh.matrixWorld);
+    }
+    return null;
+}
+
+export function solveDropToSurface({
+    entries,
+    selectedIds,
+    floorElevations = [0],
+    clearance = 0.001,
+} = {}) {
+    const selected = new Set(selectedIds || []);
+    const selectedBounds = new THREE.Box3();
+    for (const [objectId, entry] of entries || []) {
+        if (!selected.has(objectId)) continue;
+        const bounds = proxyBounds(entry);
+        if (bounds) selectedBounds.union(bounds);
+    }
+    if (selectedBounds.isEmpty()) return null;
+    const validFloors = floorElevations.filter(Number.isFinite);
+    let supportY = validFloors.length ? Math.max(...validFloors) : 0;
+    const selectedCenterY = (selectedBounds.min.y + selectedBounds.max.y) * 0.5;
+    for (const [objectId, entry] of entries || []) {
+        if (selected.has(objectId) || entry?.mesh?.visible === false) continue;
+        if (entry?.data?.collision_proxy?.supports_objects === false) continue;
+        const bounds = proxyBounds(entry);
+        if (!bounds || bounds.isEmpty() || !intersectsXZ(selectedBounds, bounds)) continue;
+        const supportCenterY = (bounds.min.y + bounds.max.y) * 0.5;
+        const belowOrPenetratingFromBelow = bounds.max.y <= selectedBounds.min.y + clearance
+            || bounds.min.y <= selectedBounds.min.y + clearance
+            || supportCenterY < selectedCenterY;
+        if (belowOrPenetratingFromBelow) {
+            supportY = Math.max(supportY, bounds.max.y);
+        }
+    }
+    const deltaY = supportY - selectedBounds.min.y + Math.max(0, Number(clearance) || 0);
+    if (!Number.isFinite(deltaY)) return null;
+    return {
+        deltaY,
+        supportY,
+        sourceBottomY: selectedBounds.min.y,
+        bounds: selectedBounds,
+    };
+}

--- a/web/vnccs_3d_factory.css
+++ b/web/vnccs_3d_factory.css
@@ -514,6 +514,17 @@
 .vnccs-i3s__viewport { position: relative; flex: 1; min-height: 0; overflow: hidden; background: radial-gradient(circle at 50% 42%, rgba(184,169,232,.08), transparent 42%), #08080d; }
 .vnccs-i3s__viewer-host { position: absolute; inset: 0; overflow: hidden; }
 .vnccs-i3s__viewer-host > canvas { display: block; width: 100%; height: 100%; touch-action: none; }
+.vnccs-i3s__plan-marquee {
+    position: absolute;
+    z-index: 5;
+    box-sizing: border-box;
+    border: 1px solid rgba(255,143,163,.92);
+    border-radius: 2px;
+    background: rgba(255,143,163,.12);
+    box-shadow: 0 0 0 1px rgba(184,169,232,.18) inset;
+    pointer-events: none;
+}
+.vnccs-i3s__plan-marquee[hidden] { display: none; }
 .vnccs-i3s__camera-frame {
     position: absolute;
     z-index: 2;
@@ -710,26 +721,6 @@
 .vnccs-i3s__lighting-close svg { width: 14px; height: 14px; }
 .vnccs-i3s__lighting-panel { max-height: calc(100% - 92px); overflow: auto; }
 .vnccs-i3s__lighting-advanced { display: flex; flex-direction: column; gap: 8px; margin-top: 10px; padding-top: 9px; border-top: 1px solid rgba(184,169,232,.14); }
-.vnccs-i3s__lighting-local-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--i3-muted); }
-.vnccs-i3s__lighting-local-head .vnccs-i3s__button { min-height: 26px; padding: 3px 7px; font-size: .72em; }
-.vnccs-i3s__local-lights { display: flex; flex-direction: column; gap: 6px; }
-.vnccs-i3s__local-light-empty { padding: 8px; border: 1px dashed var(--i3-line); border-radius: 7px; color: var(--i3-dim); text-align: center; font-size: .72em; }
-.vnccs-i3s__local-light { border: 1px solid var(--i3-line); border-radius: 8px; background: rgba(255,255,255,.02); }
-.vnccs-i3s__local-light > summary { min-height: 32px; display: flex; align-items: center; justify-content: space-between; gap: 7px; padding: 6px 8px; color: var(--i3-text); cursor: pointer; }
-.vnccs-i3s__local-light > summary small { color: var(--i3-dim); font: .66em var(--i3-mono); text-transform: capitalize; }
-.vnccs-i3s__local-light[open] > summary { border-bottom: 1px solid var(--i3-line); }
-.vnccs-i3s__local-light-body { display: flex; flex-direction: column; gap: 5px; padding: 6px; }
-.vnccs-i3s__local-light-title { display: grid; grid-template-columns: minmax(0,1fr) 27px; gap: 5px; }
-.vnccs-i3s__local-light-title > button { display: grid; place-items: center; padding: 0; border: 0; border-radius: 6px; background: transparent; color: var(--i3-dim); cursor: pointer; }
-.vnccs-i3s__local-light-title > button:hover { background: rgba(255,91,107,.1); color: #ff9ba6; }
-.vnccs-i3s__local-light-title svg { width: 13px; height: 13px; }
-.vnccs-i3s__local-light-grid { display: grid; grid-template-columns: minmax(0,1.2fr) 32px repeat(2,minmax(0,1fr)); gap: 5px; }
-.vnccs-i3s__local-light-grid input[type="color"] { width: 32px; height: 31px; padding: 2px; border: 1px solid var(--i3-line); border-radius: 6px; background: var(--i3-surface); }
-.vnccs-i3s__local-light-position { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 5px; }
-.vnccs-i3s__local-light-position label { display: grid; grid-template-columns: 18px minmax(0,1fr); gap: 3px; align-items: center; color: var(--i3-dim); font: .7em var(--i3-mono); }
-.vnccs-i3s__local-light-flags { display: flex; flex-wrap: wrap; gap: 10px; color: var(--i3-muted); font-size: .72em; }
-.vnccs-i3s__local-light-flags label { display: inline-flex; align-items: center; gap: 5px; }
-.vnccs-i3s__local-light-flags input { accent-color: var(--i3-pink); }
 .vnccs-i3s__lighting-presets { display: grid; grid-template-columns: repeat(5, minmax(0,1fr)); gap: 5px; margin-bottom: 11px; }
 .vnccs-i3s__lighting-preset {
     min-width: 0;
@@ -968,6 +959,7 @@
 .vnccs-i3s__material-details .vnccs-i3s__material-inline { padding: 7px; }
 .vnccs-i3s__object { display: grid; grid-template-columns: 36px minmax(0,1fr) auto; gap: 6px; align-items: center; min-height: 46px; padding: 4px 5px; border: 1px solid var(--i3-line); border-radius: 8px; background: rgba(255,255,255,.022); cursor: grab; transition: opacity .15s ease, border-color .15s ease, background .15s ease, transform .15s ease; }
 .vnccs-i3s__skydome-object { cursor: pointer; border-color: rgba(184,169,232,.22); background: linear-gradient(90deg, rgba(184,169,232,.07), rgba(255,255,255,.018)); }
+.vnccs-i3s__light-object { cursor: pointer; border-color: rgba(255,241,214,.18); background: linear-gradient(90deg, rgba(255,241,214,.055), rgba(255,255,255,.018)); }
 .vnccs-i3s__skydome-object .vnccs-i3s__object-thumb { object-fit: cover; }
 .vnccs-i3s__object:hover { border-color: var(--i3-line-strong); background: rgba(255,255,255,.045); }
 .vnccs-i3s__object.is-selected { border-color: var(--i3-pink-line); background: var(--i3-pink-soft); }
@@ -981,6 +973,8 @@
 .vnccs-i3s__object.has-viewport-error { border-color: rgba(255,91,107,.62); background: rgba(255,91,107,.08); }
 .vnccs-i3s__object.has-viewport-error .vnccs-i3s__object-meta { color: #ff91a0; }
 .vnccs-i3s__object-thumb { width: 36px; height: 36px; border-radius: 6px; object-fit: contain; background: #08070c; }
+.vnccs-i3s__light-thumb { display: grid; place-items: center; box-sizing: border-box; border: 1px solid currentColor; background: rgba(255,255,255,.025); }
+.vnccs-i3s__light-thumb svg { width: 20px; height: 20px; fill: none; stroke: currentColor; stroke-width: 1.7; }
 .vnccs-i3s__object-copy { min-width: 0; }
 .vnccs-i3s__object-name { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--i3-text); font-weight: 700; cursor: text; user-select: text; }
 .vnccs-i3s__object-meta { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--i3-dim); font: .68em var(--i3-mono); text-transform: uppercase; }

--- a/web/vnccs_3d_factory.css
+++ b/web/vnccs_3d_factory.css
@@ -372,6 +372,11 @@
     letter-spacing: .025em;
     text-align: center;
 }
+.vnccs-i3s__camera-zoom-speed { margin-top: 2px; }
+.vnccs-i3s__camera-zoom-speed-value { color: var(--i3-text); font: .92em var(--i3-mono); }
+.vnccs-i3s__camera-view-presets { display: flex; flex-direction: column; gap: 5px; }
+.vnccs-i3s__camera-view-preset-grid { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 5px; }
+.vnccs-i3s__camera-view-preset-grid .vnccs-i3s__button { min-width: 0; min-height: 28px; padding-inline: 5px; font-size: .7em; }
 .vnccs-i3s__camera-manager {
     overflow: hidden;
     border: 1px solid var(--i3-line);
@@ -597,93 +602,6 @@
 .vnccs-i3s__plan-settings-popover input[type="number"] { width: 72px; min-height: 27px; }
 .vnccs-i3s__plan-settings-popover input[type="checkbox"] { accent-color: var(--i3-pink); }
 .vnccs-i3s__plan-settings-popover small { color: var(--i3-dim); font-size: .68em; line-height: 1.4; }
-.vnccs-i3s__viewport-camera {
-    position: absolute;
-    top: 52px;
-    right: 10px;
-    z-index: 3;
-    width: min(292px, calc(100% - 20px));
-    max-height: calc(100% - 64px);
-    overflow: auto;
-    border: 1px solid rgba(184,169,232,.24);
-    border-radius: 11px;
-    background: linear-gradient(155deg, rgba(25,22,33,.94), rgba(12,11,18,.94));
-    box-shadow: 0 14px 38px rgba(0,0,0,.42), 0 0 0 1px rgba(255,255,255,.02) inset;
-    color: var(--i3-text);
-    backdrop-filter: blur(14px);
-}
-.vnccs-i3s__viewport-camera[hidden] { display: none; }
-.vnccs-i3s__viewport-camera > summary {
-    min-height: 34px;
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 8px;
-    padding: 6px 9px;
-    color: var(--i3-muted);
-    cursor: pointer;
-    list-style: none;
-    user-select: none;
-}
-.vnccs-i3s__viewport-camera > summary::-webkit-details-marker { display: none; }
-.vnccs-i3s__viewport-camera > summary > span { display: flex; align-items: center; gap: 7px; }
-.vnccs-i3s__viewport-camera > summary svg { width: 15px; height: 15px; color: var(--i3-lavender); }
-.vnccs-i3s__viewport-camera > summary b { color: var(--i3-text); font-size: .78em; letter-spacing: .02em; }
-.vnccs-i3s__viewport-camera > summary::after { content: "⌃"; color: var(--i3-dim); font-size: .72em; }
-.vnccs-i3s__viewport-camera:not([open]) > summary::after { content: "⌄"; }
-.vnccs-i3s__viewport-camera-summary { margin-left: auto; color: var(--i3-dim); font: .68em var(--i3-mono); }
-.vnccs-i3s__viewport-camera-body { display: flex; flex-direction: column; gap: 8px; padding: 0 9px 9px; border-top: 1px solid rgba(184,169,232,.12); }
-.vnccs-i3s__viewport-camera-actions { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 5px; padding-top: 8px; }
-.vnccs-i3s__viewport-camera button {
-    min-width: 0;
-    min-height: 28px;
-    padding: 4px 6px;
-    border: 1px solid var(--i3-line);
-    border-radius: 7px;
-    background: rgba(255,255,255,.025);
-    color: var(--i3-muted);
-    font: 720 .69em var(--i3-font);
-    cursor: pointer;
-}
-.vnccs-i3s__viewport-camera button:hover:not(:disabled) { border-color: var(--i3-pink-line); background: var(--i3-hover); color: var(--i3-text); }
-.vnccs-i3s__viewport-camera button:focus-visible,
-.vnccs-i3s__viewport-camera input:focus-visible,
-.vnccs-i3s__viewport-camera summary:focus-visible { outline: 2px solid var(--i3-pink-hi); outline-offset: 1px; }
-.vnccs-i3s__viewport-camera button:disabled,
-.vnccs-i3s__viewport-camera input:disabled { opacity: .35; cursor: not-allowed; }
-.vnccs-i3s__viewport-camera-actions button:first-child { border-color: rgba(255,143,163,.34); background: var(--i3-pink-soft); color: var(--i3-pink-hi); }
-.vnccs-i3s__viewport-camera-presets { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 4px; }
-.vnccs-i3s__viewport-camera-presets button { min-height: 25px; padding-inline: 3px; font-size: .63em; }
-.vnccs-i3s__viewport-camera-navigation { display: grid; grid-template-columns: repeat(2,76px); justify-content: center; gap: 9px 18px; align-items: start; padding-top: 7px; border-top: 1px solid rgba(184,169,232,.12); }
-.vnccs-i3s__viewport-camera-label { display: block; margin-bottom: 4px; color: var(--i3-dim); font: .65em var(--i3-mono); text-align: center; }
-.vnccs-i3s__camera-orbit-pad,
-.vnccs-i3s__camera-pan-pad { width: 76px; display: grid; grid-template-columns: repeat(3,24px); grid-template-rows: repeat(3,24px); gap: 2px; }
-.vnccs-i3s__camera-orbit-pad button,
-.vnccs-i3s__camera-pan-pad button { width: 24px; min-height: 24px; height: 24px; padding: 0; font: 700 14px var(--i3-font); }
-.vnccs-i3s__camera-orbit-pad [data-camera-orbit="up"] { grid-column: 2; grid-row: 1; }
-.vnccs-i3s__camera-orbit-pad [data-camera-orbit="left"] { grid-column: 1; grid-row: 2; }
-.vnccs-i3s__camera-orbit-pad span,
-.vnccs-i3s__camera-pan-pad span { grid-column: 2; grid-row: 2; display: grid; place-items: center; color: var(--i3-lavender); font-size: 7px; }
-.vnccs-i3s__camera-orbit-pad [data-camera-orbit="right"] { grid-column: 3; grid-row: 2; }
-.vnccs-i3s__camera-orbit-pad [data-camera-orbit="down"] { grid-column: 2; grid-row: 3; }
-.vnccs-i3s__camera-pan-pad [data-camera-pan="forward"] { grid-column: 2; grid-row: 1; }
-.vnccs-i3s__camera-pan-pad [data-camera-pan="left"] { grid-column: 1; grid-row: 2; }
-.vnccs-i3s__camera-pan-pad [data-camera-pan="right"] { grid-column: 3; grid-row: 2; }
-.vnccs-i3s__camera-pan-pad [data-camera-pan="back"] { grid-column: 2; grid-row: 3; }
-.vnccs-i3s__viewport-camera-sliders { grid-column: 1 / -1; width: 100%; display: flex; flex-direction: column; gap: 9px; }
-.vnccs-i3s__viewport-camera-sliders > label { display: flex; flex-direction: column; gap: 4px; color: var(--i3-dim); font: .65em var(--i3-mono); }
-.vnccs-i3s__viewport-camera-sliders > label > div { min-width: 0; display: grid; grid-template-columns: minmax(50px,1fr) 62px 10px; gap: 4px; align-items: center; }
-.vnccs-i3s__viewport-camera input[type="range"] { width: 100%; min-width: 0; accent-color: var(--i3-pink); }
-.vnccs-i3s__viewport-camera input[type="number"] { min-width: 0; width: 100%; height: 26px; padding: 3px 5px; border: 1px solid var(--i3-line); border-radius: 6px; background: var(--i3-surface); color: var(--i3-text); font: .72em var(--i3-mono); text-align: right; }
-.vnccs-i3s__viewport-camera small { color: var(--i3-dim); font: .66em var(--i3-mono); }
-.vnccs-i3s__viewport-camera-exact { border-top: 1px solid rgba(184,169,232,.12); }
-.vnccs-i3s__viewport-camera-exact > summary { padding: 7px 1px 0; color: var(--i3-muted); font-size: .68em; font-weight: 720; cursor: pointer; }
-.vnccs-i3s__viewport-camera-vector { display: grid; grid-template-columns: 46px repeat(3,minmax(0,1fr)); gap: 4px; align-items: center; margin-top: 7px; }
-.vnccs-i3s__viewport-camera-vector > span { color: var(--i3-dim); font: .62em var(--i3-mono); }
-.vnccs-i3s__viewport-camera-vector label { min-width: 0; display: grid; grid-template-columns: 10px minmax(0,1fr); align-items: center; color: var(--i3-dim); font: .61em var(--i3-mono); }
-.vnccs-i3s__viewport-camera-vector input[type="number"] { height: 24px; padding-inline: 3px; }
-.vnccs-i3s__viewport-camera-fov { display: grid; grid-template-columns: minmax(0,1fr) 66px 10px; gap: 5px; align-items: center; margin-top: 7px; color: var(--i3-dim); font-size: .68em; }
-.vnccs-i3s__viewport-camera.is-playback > summary b::after { content: " · playback"; color: var(--i3-pink-hi); font-weight: 650; }
 .vnccs-i3s__lighting-panel,
 .vnccs-i3s__skydome-panel {
     position: absolute;

--- a/web/vnccs_3d_factory.css
+++ b/web/vnccs_3d_factory.css
@@ -920,6 +920,20 @@
 .vnccs-i3s__scene-frame-title { color: var(--i3-text); font-size: .82em; font-weight: 700; }
 .vnccs-i3s__scene-frame-copy { margin-top: 2px; color: var(--i3-dim); font-size: .68em; line-height: 1.35; }
 .vnccs-i3s__scene-render-summary { color: var(--i3-dim); font: .66em/1.4 var(--i3-mono); }
+.vnccs-i3s__level-panel { display: flex; flex-direction: column; gap: 6px; padding: 7px; border: 1px solid rgba(184,169,232,.2); border-radius: 9px; background: linear-gradient(145deg, rgba(184,169,232,.06), rgba(255,143,163,.025)); }
+.vnccs-i3s__level-panel[hidden] { display: none; }
+.vnccs-i3s__level-panel-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.vnccs-i3s__level-panel-head > div { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.vnccs-i3s__level-panel-head strong { color: var(--i3-text); font-size: .78em; }
+.vnccs-i3s__level-panel-head small { color: var(--i3-dim); font-size: .66em; }
+.vnccs-i3s__level-panel-head .vnccs-i3s__level-add { min-height: 27px; padding: 4px 8px; color: var(--i3-pink-hi); }
+.vnccs-i3s__level-list { max-height: 210px; overflow: auto; display: flex; flex-direction: column; gap: 4px; overscroll-behavior: contain; }
+.vnccs-i3s__level-card { width: 100%; min-height: 42px; display: flex; align-items: center; padding: 6px 8px; border: 1px solid var(--i3-line); border-radius: 7px; background: rgba(255,255,255,.018); color: var(--i3-muted); text-align: left; cursor: pointer; }
+.vnccs-i3s__level-card:hover { border-color: var(--i3-line-strong); background: var(--i3-hover); color: var(--i3-text); }
+.vnccs-i3s__level-card.is-active { border-color: rgba(184,169,232,.4); background: rgba(184,169,232,.12); color: #f0ebff; box-shadow: inset 3px 0 var(--i3-lavender); }
+.vnccs-i3s__level-card-copy { min-width: 0; display: flex; flex-direction: column; gap: 2px; }
+.vnccs-i3s__level-card-copy b { overflow: hidden; color: inherit; font-size: .76em; text-overflow: ellipsis; white-space: nowrap; }
+.vnccs-i3s__level-card-copy small { color: var(--i3-dim); font: .64em var(--i3-mono); }
 .vnccs-i3s__layer-tools { display: flex; align-items: center; gap: 7px; min-height: 29px; }
 .vnccs-i3s__layer-tools .vnccs-i3s__group-selected { min-height: 27px; padding: 4px 8px; }
 .vnccs-i3s__selection-count { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--i3-dim); font-size: .72em; }
@@ -1000,6 +1014,8 @@
 .vnccs-i3s__architecture-row:hover { border-color: var(--i3-line-strong); background: var(--i3-hover); }
 .vnccs-i3s__architecture-row.is-selected { border-color: var(--i3-pink-line); background: var(--i3-pink-soft); box-shadow: inset 3px 0 var(--i3-pink); }
 .vnccs-i3s__architecture-row.is-building { background: rgba(184,169,232,.06); }
+.vnccs-i3s__architecture-row.is-root { cursor: default; }
+.vnccs-i3s__architecture-row.is-root:hover { border-color: transparent; background: rgba(184,169,232,.06); }
 .vnccs-i3s__architecture-kind { width: 23px; height: 23px; display: grid; place-items: center; border-radius: 6px; background: rgba(184,169,232,.11); color: var(--i3-lavender); font: 700 .68em var(--i3-mono); }
 .vnccs-i3s__architecture-copy { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
 .vnccs-i3s__architecture-copy b, .vnccs-i3s__architecture-copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }

--- a/web/vnccs_3d_factory.css
+++ b/web/vnccs_3d_factory.css
@@ -30,6 +30,7 @@
     --vnccs-ps-relative-ui-scale: 1;
     --i3-bg: #09090e;
     --i3-panel: rgba(16, 14, 24, .94);
+    --i3-panel-solid: #100e18;
     --i3-raised: #1a1925;
     --i3-surface: rgba(255, 255, 255, .045);
     --i3-hover: rgba(255, 255, 255, .075);
@@ -54,7 +55,7 @@
     --i3-radius-lg: calc(15px * var(--i3-scale));
     position: relative;
     display: grid;
-    grid-template-columns: 300px minmax(330px, 1fr) 412.5px;
+    grid-template-columns: 280px minmax(420px, 1fr) 360px;
     width: 100%;
     height: 100%;
     min-width: 0;
@@ -85,6 +86,7 @@
     min-width: 0;
     padding: 10px 8px;
 }
+.vnccs-i3s__library-launcher-wrap .vnccs-ps-btn-icon svg { width: 15px; height: 15px; }
 .vnccs-i3s__ply-import svg { width: 15px; height: 15px; }
 .vnccs-i3s *, .vnccs-i3s *::before, .vnccs-i3s *::after { box-sizing: border-box; }
 .vnccs-i3s [hidden] { display: none !important; }
@@ -103,13 +105,125 @@
     flex-direction: column;
     gap: calc(8px * var(--i3-scale));
     padding: calc(10px * var(--i3-scale));
-    overflow: hidden auto;
+    overflow: hidden;
     background: linear-gradient(180deg, rgba(19,16,29,.96), rgba(10,9,15,.94));
 }
 .vnccs-i3s__side--left { border-right: 1px solid var(--i3-line); }
-.vnccs-i3s__side--right { border-left: 1px solid rgba(184,169,232,.16); }
-.vnccs-i3s__side--right .vnccs-i3s__object-section { flex: 1; min-height: 0; display: flex; flex-direction: column; }
-.vnccs-i3s__side--right .vnccs-i3s__object-section .vnccs-i3s__section-body { flex: 1; min-height: 0; }
+.vnccs-i3s__side--right {
+    border-left: 1px solid rgba(184,169,232,.16);
+}
+.vnccs-i3s__side--right > * { min-width: 0; min-height: 0; }
+.vnccs-i3s__workspace-tabs {
+    flex: 0 0 auto;
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 3px;
+    padding: 3px;
+    border: 1px solid var(--i3-line);
+    border-radius: 9px;
+    background: rgba(5, 5, 10, .52);
+}
+.vnccs-i3s__workspace-tabs--three { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+.vnccs-i3s__workspace-tab {
+    position: relative;
+    min-width: 0;
+    min-height: calc(32px * var(--i3-scale));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 5px;
+    padding: 4px 7px;
+    overflow: hidden;
+    border: 0;
+    border-radius: 6px;
+    background: transparent;
+    color: var(--i3-muted);
+    cursor: pointer;
+    touch-action: manipulation;
+    transition: color .16s ease, background .16s ease, box-shadow .16s ease;
+}
+.vnccs-i3s__workspace-tab:hover { background: var(--i3-hover); color: var(--i3-text); }
+.vnccs-i3s__workspace-tab:active { background: rgba(255,143,163,.13); color: var(--i3-pink-hi); }
+.vnccs-i3s__workspace-tab[aria-selected="true"] {
+    background: linear-gradient(135deg, rgba(255,143,163,.16), rgba(184,169,232,.1));
+    color: var(--i3-pink-hi);
+    box-shadow: inset 0 -2px var(--i3-pink), 0 0 0 1px rgba(255,143,163,.09);
+}
+.vnccs-i3s__workspace-tab > span:nth-child(2) {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.vnccs-i3s__workspace-tab svg { width: 13px; height: 13px; }
+.vnccs-i3s__context-select {
+    min-width: 92px;
+    max-width: 150px;
+    height: 30px;
+    padding: 3px 24px 3px 8px;
+    border: 1px solid var(--i3-line-strong);
+    border-radius: 7px;
+    background: var(--i3-panel-solid);
+    color: var(--i3-text);
+    cursor: pointer;
+}
+.vnccs-i3s__workspace-tab-count {
+    flex: none;
+    min-width: 18px;
+    padding: 1px 5px;
+    border-radius: 99px;
+    background: rgba(255,255,255,.07);
+    color: currentColor;
+    font: 700 .72em var(--i3-mono);
+    text-align: center;
+}
+.vnccs-i3s__workspace-tab-dot {
+    flex: none;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--i3-pink);
+    box-shadow: 0 0 6px rgba(255,143,163,.65);
+    opacity: 0;
+    transition: opacity .16s ease;
+}
+.vnccs-i3s.has-inspector-selection .vnccs-i3s__workspace-tab--inspector .vnccs-i3s__workspace-tab-dot { opacity: 1; }
+.vnccs-i3s__workspace-panels {
+    flex: 1 1 auto;
+    min-width: 0;
+    min-height: 0;
+    overflow: hidden;
+}
+.vnccs-i3s__workspace-panel {
+    width: 100%;
+    height: 100%;
+    min-width: 0;
+    min-height: 0;
+    display: flex;
+    flex-direction: column;
+    gap: calc(8px * var(--i3-scale));
+    overflow: hidden auto;
+    overscroll-behavior: contain;
+    scrollbar-gutter: stable;
+}
+.vnccs-i3s__workspace-panel--left > .vnccs-i3s__section { flex: none; }
+.vnccs-i3s__side--right .vnccs-i3s__workspace-panel {
+    position: relative;
+    gap: 0;
+    overflow: hidden;
+    isolation: isolate;
+    background: var(--i3-panel-solid);
+}
+.vnccs-i3s__side--right .vnccs-i3s__section-head { flex: none; }
+.vnccs-i3s__side--right .vnccs-i3s__section-body {
+    flex: 1 1 auto;
+    min-height: 0;
+    overflow: hidden auto;
+    overscroll-behavior: contain;
+}
+.vnccs-i3s__side--right .vnccs-i3s__object-section .vnccs-i3s__section-body {
+    overflow: hidden;
+}
 .vnccs-i3s__center { min-width: 0; min-height: 0; display: flex; flex-direction: column; overflow: hidden; position: relative; }
 
 .vnccs-i3s__donate-link { flex: 0 0 auto; display: block; width: 100%; margin-top: auto; padding: 0 4px 4px; box-sizing: border-box; z-index: 3; background: rgba(6,5,12,.92); box-shadow: 0 -8px 18px rgba(6,5,12,.82); }
@@ -295,7 +409,7 @@
     min-width: 0;
     min-height: 30px;
     display: grid;
-    grid-template-columns: 20px 20px minmax(0,1fr) 25px;
+    grid-template-columns: 20px 20px minmax(0,1fr) 25px 25px;
     align-items: center;
     gap: 4px;
     padding: 3px 3px 3px 5px;
@@ -327,7 +441,7 @@
     font-size: .76em;
     font-weight: 680;
 }
-.vnccs-i3s__camera-delete {
+.vnccs-i3s__camera-delete, .vnccs-i3s__camera-preview {
     width: 24px;
     height: 24px;
     display: grid;
@@ -339,8 +453,30 @@
     color: var(--i3-dim);
     cursor: pointer;
 }
+.vnccs-i3s__camera-preview:hover { background: rgba(184,169,232,.12); color: var(--i3-lavender); }
+.vnccs-i3s__camera-preview svg { width: 13px; height: 13px; }
+.vnccs-i3s__camera-item.is-previewing { box-shadow: inset 3px 0 0 var(--i3-lavender); }
 .vnccs-i3s__camera-delete:hover { background: rgba(255,91,107,.1); color: #ff9ba6; }
 .vnccs-i3s__camera-delete svg { width: 13px; height: 13px; }
+.vnccs-i3s__camera-track-editor { overflow: hidden; border: 1px solid rgba(184,169,232,.16); border-radius: 9px; background: rgba(5,5,9,.24); }
+.vnccs-i3s__camera-track-row, .vnccs-i3s__camera-track-actions { display: grid; grid-template-columns: minmax(0,1fr) auto auto; gap: 5px; padding: 5px 6px 0; }
+.vnccs-i3s__camera-track-row .vnccs-i3s__select { min-height: 27px; }
+.vnccs-i3s__camera-track-name { width: calc(100% - 12px); min-height: 27px; margin: 5px 6px 0; font-size: .72em; }
+.vnccs-i3s__camera-track-delete { width: 30px; min-width: 30px; padding: 4px; color: var(--i3-dim); }
+.vnccs-i3s__camera-track-delete:hover:not(:disabled) { border-color: rgba(255,91,107,.4); background: rgba(255,91,107,.1); color: #ff9ba6; }
+.vnccs-i3s__camera-track-delete svg { width: 13px; height: 13px; }
+.vnccs-i3s__camera-track-actions { grid-template-columns: repeat(2,minmax(0,1fr)); }
+.vnccs-i3s__camera-track-actions .vnccs-i3s__button { min-height: 27px; padding: 4px 6px; font-size: .72em; }
+.vnccs-i3s__camera-track-time { display: block; width: calc(100% - 12px); margin: 7px 6px 2px; }
+.vnccs-i3s__camera-track-meta { padding: 3px 7px 7px; color: var(--i3-dim); font: .66em var(--i3-mono); }
+.vnccs-i3s__camera-keyframes { max-height: 108px; overflow: auto; display: flex; flex-direction: column; gap: 3px; padding: 0 5px 5px; }
+.vnccs-i3s__camera-keyframe { min-height: 27px; display: grid; grid-template-columns: 20px minmax(0,1fr) auto; align-items: center; gap: 5px; padding: 3px 6px; border: 1px solid transparent; border-radius: 6px; background: rgba(255,255,255,.018); color: var(--i3-muted); text-align: left; cursor: pointer; }
+.vnccs-i3s__camera-keyframe:hover { border-color: var(--i3-line-strong); background: var(--i3-hover); }
+.vnccs-i3s__camera-keyframe.is-selected { border-color: var(--i3-pink-line); background: var(--i3-pink-soft); color: var(--i3-pink-hi); }
+.vnccs-i3s__camera-keyframe > span { color: var(--i3-dim); font: .68em var(--i3-mono); }
+.vnccs-i3s__camera-keyframe > b { overflow: hidden; color: var(--i3-text); font-size: .72em; text-overflow: ellipsis; white-space: nowrap; }
+.vnccs-i3s__camera-keyframe > time { font: .66em var(--i3-mono); }
+.vnccs-i3s__camera-keyframe-empty { padding: 7px; color: var(--i3-dim); font-size: .7em; text-align: center; }
 
 .vnccs-i3s__button { min-height: calc(31px * var(--i3-scale)); display: inline-flex; align-items: center; justify-content: center; gap: 6px; padding: 6px 10px; border: 1px solid var(--i3-line-strong); border-radius: var(--i3-radius-sm); background: var(--i3-surface); color: var(--i3-text); font-weight: 700; cursor: pointer; transition: transform .14s ease, border-color .14s ease, background .14s ease, color .14s ease; }
 .vnccs-i3s__button:hover:not(:disabled) { border-color: var(--i3-pink-line); background: var(--i3-hover); color: var(--i3-pink-hi); }
@@ -377,7 +513,7 @@
 
 .vnccs-i3s__viewport { position: relative; flex: 1; min-height: 0; overflow: hidden; background: radial-gradient(circle at 50% 42%, rgba(184,169,232,.08), transparent 42%), #08080d; }
 .vnccs-i3s__viewer-host { position: absolute; inset: 0; overflow: hidden; }
-.vnccs-i3s__viewer-host > canvas { display: block; width: 100%; height: 100%; }
+.vnccs-i3s__viewer-host > canvas { display: block; width: 100%; height: 100%; touch-action: none; }
 .vnccs-i3s__camera-frame {
     position: absolute;
     z-index: 2;
@@ -415,17 +551,128 @@
     font-weight: 700;
     pointer-events: none;
 }
-.vnccs-i3s__empty-view { position: absolute; inset: 0; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 8px; padding: 28px; text-align: center; color: var(--i3-dim); pointer-events: none; }
-.vnccs-i3s__empty-view-icon { width: 54px; height: 54px; display: grid; place-items: center; border: 1px solid rgba(184,169,232,.16); border-radius: 18px; background: rgba(184,169,232,.055); color: rgba(184,169,232,.6); }
-.vnccs-i3s__empty-view-icon svg { width: 27px; height: 27px; }
-.vnccs-i3s__empty-view-title { color: var(--i3-muted); font-weight: 700; }
-.vnccs-i3s.has-scene .vnccs-i3s__empty-view { display: none; }
-.vnccs-i3s__toolbar { position: absolute; top: 10px; left: 50%; transform: translateX(-50%); z-index: 4; display: flex; align-items: center; gap: 4px; max-width: calc(100% - 20px); padding: 4px; border: 1px solid rgba(255,255,255,.1); border-radius: 10px; background: rgba(15,13,21,.78); box-shadow: 0 8px 28px rgba(0,0,0,.3); backdrop-filter: blur(9px); }
+.vnccs-i3s__toolbar { position: absolute; top: 10px; left: 50%; transform: translateX(-50%); z-index: 4; display: flex; align-items: center; gap: 4px; max-width: calc(100% - 20px); overflow: auto hidden; padding: 4px; border: 1px solid rgba(255,255,255,.1); border-radius: 10px; background: rgba(15,13,21,.78); box-shadow: 0 8px 28px rgba(0,0,0,.3); backdrop-filter: blur(9px); }
 .vnccs-i3s__tool { width: 29px; height: 27px; display: grid; place-items: center; flex: none; padding: 0; border: 0; border-radius: 7px; background: transparent; color: var(--i3-muted); cursor: pointer; }
 .vnccs-i3s__tool:hover { color: var(--i3-text); background: rgba(255,255,255,.08); }
 .vnccs-i3s__tool[aria-pressed="true"] { color: var(--i3-pink-hi); background: var(--i3-pink-soft); }
 .vnccs-i3s__tool-separator { width: 1px; height: 17px; flex: none; background: var(--i3-line-strong); margin: 0 2px; }
 .vnccs-i3s__toolbar .vnccs-i3s__select { width: 94px; min-height: 27px; height: 27px; padding: 2px 6px; border: 0; background: transparent; color: var(--i3-muted); font-size: .82em; }
+.vnccs-i3s__view-switch { display: flex; align-items: center; gap: 2px; padding-right: 2px; border-right: 1px solid var(--i3-line-strong); }
+.vnccs-i3s__tool-label { min-height: 27px; flex: none; padding: 3px 7px; border: 0; border-radius: 7px; background: transparent; color: var(--i3-muted); font-size: .76em; font-weight: 750; cursor: pointer; }
+.vnccs-i3s__tool-label:hover:not(:disabled) { color: var(--i3-text); background: rgba(255,255,255,.08); }
+.vnccs-i3s__tool-label[aria-pressed="true"] { color: var(--i3-pink-hi); background: var(--i3-pink-soft); }
+.vnccs-i3s__tool-label:disabled, .vnccs-i3s__tool:disabled { opacity: .35; cursor: not-allowed; }
+.vnccs-i3s__plan-tools { position: absolute; top: 52px; left: 50%; z-index: 4; display: flex; align-items: center; gap: 3px; max-width: calc(100% - 20px); padding: 4px; transform: translateX(-50%); border: 1px solid rgba(184,169,232,.25); border-radius: 9px; background: rgba(15,13,21,.86); box-shadow: 0 7px 22px rgba(0,0,0,.28); backdrop-filter: blur(9px); }
+.vnccs-i3s__plan-tools button { min-height: 26px; padding: 3px 8px; border: 0; border-radius: 6px; background: transparent; color: var(--i3-muted); font-size: .76em; font-weight: 720; cursor: pointer; }
+.vnccs-i3s__plan-tools button:hover:not(:disabled) { color: var(--i3-text); background: var(--i3-hover); }
+.vnccs-i3s__plan-tools button:disabled { opacity: .34; cursor: not-allowed; }
+.vnccs-i3s__plan-tools button[aria-pressed="true"] { background: rgba(184,169,232,.14); color: #d7ccff; }
+.vnccs-i3s__plan-tools [data-plan-tool] { display: inline-flex; align-items: center; gap: 4px; }
+.vnccs-i3s__plan-tools [data-plan-tool] b { color: var(--i3-dim); font: 700 .75em var(--i3-mono); }
+.vnccs-i3s__opening-kind-shortcut { min-width: 0; display: flex; align-items: center; gap: 4px; color: var(--i3-dim); font: .66em var(--i3-mono); }
+.vnccs-i3s__opening-kind-shortcut .vnccs-i3s__select { width: 82px; min-height: 24px; height: 24px; padding: 2px 5px; }
+.vnccs-i3s__plan-grid-toggle { margin-left: 3px; border-left: 1px solid var(--i3-line-strong) !important; border-radius: 0 6px 6px 0 !important; }
+.vnccs-i3s__snap-grid { display: flex; align-items: center; gap: 4px; color: var(--i3-dim); font: .66em var(--i3-mono); }
+.vnccs-i3s__snap-grid input { width: 54px; height: 24px; padding: 2px 4px; border: 1px solid var(--i3-line); border-radius: 5px; background: var(--i3-surface); color: var(--i3-text); }
+.vnccs-i3s__snap-grid span { color: var(--i3-muted); }
+.vnccs-i3s__plan-hint { margin-left: 4px; color: var(--i3-dim); font: .66em var(--i3-mono); white-space: nowrap; }
+.vnccs-i3s__plan-settings { position: relative; flex: none; }
+.vnccs-i3s__plan-settings > summary { min-height: 26px; display: flex; align-items: center; padding: 3px 8px; border-radius: 6px; color: var(--i3-muted); font-size: .76em; font-weight: 720; cursor: pointer; list-style: none; }
+.vnccs-i3s__plan-settings > summary::-webkit-details-marker { display: none; }
+.vnccs-i3s__plan-settings[open] > summary, .vnccs-i3s__plan-settings > summary:hover { background: var(--i3-hover); color: var(--i3-text); }
+.vnccs-i3s__plan-settings-popover { position: absolute; top: calc(100% + 8px); right: 0; z-index: 12; width: 230px; display: flex; flex-direction: column; gap: 8px; padding: 10px; border: 1px solid rgba(184,169,232,.28); border-radius: 9px; background: rgba(15,13,21,.98); box-shadow: 0 14px 38px rgba(0,0,0,.5); }
+.vnccs-i3s__plan-settings-popover label { min-width: 0; display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--i3-muted); font-size: .75em; }
+.vnccs-i3s__plan-settings-popover label:has(input[type="checkbox"]) { justify-content: flex-start; }
+.vnccs-i3s__plan-settings-popover input[type="number"] { width: 72px; min-height: 27px; }
+.vnccs-i3s__plan-settings-popover input[type="checkbox"] { accent-color: var(--i3-pink); }
+.vnccs-i3s__plan-settings-popover small { color: var(--i3-dim); font-size: .68em; line-height: 1.4; }
+.vnccs-i3s__viewport-camera {
+    position: absolute;
+    top: 52px;
+    right: 10px;
+    z-index: 3;
+    width: min(292px, calc(100% - 20px));
+    max-height: calc(100% - 64px);
+    overflow: auto;
+    border: 1px solid rgba(184,169,232,.24);
+    border-radius: 11px;
+    background: linear-gradient(155deg, rgba(25,22,33,.94), rgba(12,11,18,.94));
+    box-shadow: 0 14px 38px rgba(0,0,0,.42), 0 0 0 1px rgba(255,255,255,.02) inset;
+    color: var(--i3-text);
+    backdrop-filter: blur(14px);
+}
+.vnccs-i3s__viewport-camera[hidden] { display: none; }
+.vnccs-i3s__viewport-camera > summary {
+    min-height: 34px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 8px;
+    padding: 6px 9px;
+    color: var(--i3-muted);
+    cursor: pointer;
+    list-style: none;
+    user-select: none;
+}
+.vnccs-i3s__viewport-camera > summary::-webkit-details-marker { display: none; }
+.vnccs-i3s__viewport-camera > summary > span { display: flex; align-items: center; gap: 7px; }
+.vnccs-i3s__viewport-camera > summary svg { width: 15px; height: 15px; color: var(--i3-lavender); }
+.vnccs-i3s__viewport-camera > summary b { color: var(--i3-text); font-size: .78em; letter-spacing: .02em; }
+.vnccs-i3s__viewport-camera > summary::after { content: "⌃"; color: var(--i3-dim); font-size: .72em; }
+.vnccs-i3s__viewport-camera:not([open]) > summary::after { content: "⌄"; }
+.vnccs-i3s__viewport-camera-summary { margin-left: auto; color: var(--i3-dim); font: .68em var(--i3-mono); }
+.vnccs-i3s__viewport-camera-body { display: flex; flex-direction: column; gap: 8px; padding: 0 9px 9px; border-top: 1px solid rgba(184,169,232,.12); }
+.vnccs-i3s__viewport-camera-actions { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 5px; padding-top: 8px; }
+.vnccs-i3s__viewport-camera button {
+    min-width: 0;
+    min-height: 28px;
+    padding: 4px 6px;
+    border: 1px solid var(--i3-line);
+    border-radius: 7px;
+    background: rgba(255,255,255,.025);
+    color: var(--i3-muted);
+    font: 720 .69em var(--i3-font);
+    cursor: pointer;
+}
+.vnccs-i3s__viewport-camera button:hover:not(:disabled) { border-color: var(--i3-pink-line); background: var(--i3-hover); color: var(--i3-text); }
+.vnccs-i3s__viewport-camera button:focus-visible,
+.vnccs-i3s__viewport-camera input:focus-visible,
+.vnccs-i3s__viewport-camera summary:focus-visible { outline: 2px solid var(--i3-pink-hi); outline-offset: 1px; }
+.vnccs-i3s__viewport-camera button:disabled,
+.vnccs-i3s__viewport-camera input:disabled { opacity: .35; cursor: not-allowed; }
+.vnccs-i3s__viewport-camera-actions button:first-child { border-color: rgba(255,143,163,.34); background: var(--i3-pink-soft); color: var(--i3-pink-hi); }
+.vnccs-i3s__viewport-camera-presets { display: grid; grid-template-columns: repeat(4,minmax(0,1fr)); gap: 4px; }
+.vnccs-i3s__viewport-camera-presets button { min-height: 25px; padding-inline: 3px; font-size: .63em; }
+.vnccs-i3s__viewport-camera-navigation { display: grid; grid-template-columns: repeat(2,76px); justify-content: center; gap: 9px 18px; align-items: start; padding-top: 7px; border-top: 1px solid rgba(184,169,232,.12); }
+.vnccs-i3s__viewport-camera-label { display: block; margin-bottom: 4px; color: var(--i3-dim); font: .65em var(--i3-mono); text-align: center; }
+.vnccs-i3s__camera-orbit-pad,
+.vnccs-i3s__camera-pan-pad { width: 76px; display: grid; grid-template-columns: repeat(3,24px); grid-template-rows: repeat(3,24px); gap: 2px; }
+.vnccs-i3s__camera-orbit-pad button,
+.vnccs-i3s__camera-pan-pad button { width: 24px; min-height: 24px; height: 24px; padding: 0; font: 700 14px var(--i3-font); }
+.vnccs-i3s__camera-orbit-pad [data-camera-orbit="up"] { grid-column: 2; grid-row: 1; }
+.vnccs-i3s__camera-orbit-pad [data-camera-orbit="left"] { grid-column: 1; grid-row: 2; }
+.vnccs-i3s__camera-orbit-pad span,
+.vnccs-i3s__camera-pan-pad span { grid-column: 2; grid-row: 2; display: grid; place-items: center; color: var(--i3-lavender); font-size: 7px; }
+.vnccs-i3s__camera-orbit-pad [data-camera-orbit="right"] { grid-column: 3; grid-row: 2; }
+.vnccs-i3s__camera-orbit-pad [data-camera-orbit="down"] { grid-column: 2; grid-row: 3; }
+.vnccs-i3s__camera-pan-pad [data-camera-pan="forward"] { grid-column: 2; grid-row: 1; }
+.vnccs-i3s__camera-pan-pad [data-camera-pan="left"] { grid-column: 1; grid-row: 2; }
+.vnccs-i3s__camera-pan-pad [data-camera-pan="right"] { grid-column: 3; grid-row: 2; }
+.vnccs-i3s__camera-pan-pad [data-camera-pan="back"] { grid-column: 2; grid-row: 3; }
+.vnccs-i3s__viewport-camera-sliders { grid-column: 1 / -1; width: 100%; display: flex; flex-direction: column; gap: 9px; }
+.vnccs-i3s__viewport-camera-sliders > label { display: flex; flex-direction: column; gap: 4px; color: var(--i3-dim); font: .65em var(--i3-mono); }
+.vnccs-i3s__viewport-camera-sliders > label > div { min-width: 0; display: grid; grid-template-columns: minmax(50px,1fr) 62px 10px; gap: 4px; align-items: center; }
+.vnccs-i3s__viewport-camera input[type="range"] { width: 100%; min-width: 0; accent-color: var(--i3-pink); }
+.vnccs-i3s__viewport-camera input[type="number"] { min-width: 0; width: 100%; height: 26px; padding: 3px 5px; border: 1px solid var(--i3-line); border-radius: 6px; background: var(--i3-surface); color: var(--i3-text); font: .72em var(--i3-mono); text-align: right; }
+.vnccs-i3s__viewport-camera small { color: var(--i3-dim); font: .66em var(--i3-mono); }
+.vnccs-i3s__viewport-camera-exact { border-top: 1px solid rgba(184,169,232,.12); }
+.vnccs-i3s__viewport-camera-exact > summary { padding: 7px 1px 0; color: var(--i3-muted); font-size: .68em; font-weight: 720; cursor: pointer; }
+.vnccs-i3s__viewport-camera-vector { display: grid; grid-template-columns: 46px repeat(3,minmax(0,1fr)); gap: 4px; align-items: center; margin-top: 7px; }
+.vnccs-i3s__viewport-camera-vector > span { color: var(--i3-dim); font: .62em var(--i3-mono); }
+.vnccs-i3s__viewport-camera-vector label { min-width: 0; display: grid; grid-template-columns: 10px minmax(0,1fr); align-items: center; color: var(--i3-dim); font: .61em var(--i3-mono); }
+.vnccs-i3s__viewport-camera-vector input[type="number"] { height: 24px; padding-inline: 3px; }
+.vnccs-i3s__viewport-camera-fov { display: grid; grid-template-columns: minmax(0,1fr) 66px 10px; gap: 5px; align-items: center; margin-top: 7px; color: var(--i3-dim); font-size: .68em; }
+.vnccs-i3s__viewport-camera.is-playback > summary b::after { content: " · playback"; color: var(--i3-pink-hi); font-weight: 650; }
 .vnccs-i3s__lighting-panel,
 .vnccs-i3s__skydome-panel {
     position: absolute;
@@ -461,6 +708,28 @@
 }
 .vnccs-i3s__lighting-close:hover { border-color: var(--i3-line-strong); background: rgba(255,255,255,.05); color: var(--i3-text); }
 .vnccs-i3s__lighting-close svg { width: 14px; height: 14px; }
+.vnccs-i3s__lighting-panel { max-height: calc(100% - 92px); overflow: auto; }
+.vnccs-i3s__lighting-advanced { display: flex; flex-direction: column; gap: 8px; margin-top: 10px; padding-top: 9px; border-top: 1px solid rgba(184,169,232,.14); }
+.vnccs-i3s__lighting-local-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; color: var(--i3-muted); }
+.vnccs-i3s__lighting-local-head .vnccs-i3s__button { min-height: 26px; padding: 3px 7px; font-size: .72em; }
+.vnccs-i3s__local-lights { display: flex; flex-direction: column; gap: 6px; }
+.vnccs-i3s__local-light-empty { padding: 8px; border: 1px dashed var(--i3-line); border-radius: 7px; color: var(--i3-dim); text-align: center; font-size: .72em; }
+.vnccs-i3s__local-light { border: 1px solid var(--i3-line); border-radius: 8px; background: rgba(255,255,255,.02); }
+.vnccs-i3s__local-light > summary { min-height: 32px; display: flex; align-items: center; justify-content: space-between; gap: 7px; padding: 6px 8px; color: var(--i3-text); cursor: pointer; }
+.vnccs-i3s__local-light > summary small { color: var(--i3-dim); font: .66em var(--i3-mono); text-transform: capitalize; }
+.vnccs-i3s__local-light[open] > summary { border-bottom: 1px solid var(--i3-line); }
+.vnccs-i3s__local-light-body { display: flex; flex-direction: column; gap: 5px; padding: 6px; }
+.vnccs-i3s__local-light-title { display: grid; grid-template-columns: minmax(0,1fr) 27px; gap: 5px; }
+.vnccs-i3s__local-light-title > button { display: grid; place-items: center; padding: 0; border: 0; border-radius: 6px; background: transparent; color: var(--i3-dim); cursor: pointer; }
+.vnccs-i3s__local-light-title > button:hover { background: rgba(255,91,107,.1); color: #ff9ba6; }
+.vnccs-i3s__local-light-title svg { width: 13px; height: 13px; }
+.vnccs-i3s__local-light-grid { display: grid; grid-template-columns: minmax(0,1.2fr) 32px repeat(2,minmax(0,1fr)); gap: 5px; }
+.vnccs-i3s__local-light-grid input[type="color"] { width: 32px; height: 31px; padding: 2px; border: 1px solid var(--i3-line); border-radius: 6px; background: var(--i3-surface); }
+.vnccs-i3s__local-light-position { display: grid; grid-template-columns: repeat(3,minmax(0,1fr)); gap: 5px; }
+.vnccs-i3s__local-light-position label { display: grid; grid-template-columns: 18px minmax(0,1fr); gap: 3px; align-items: center; color: var(--i3-dim); font: .7em var(--i3-mono); }
+.vnccs-i3s__local-light-flags { display: flex; flex-wrap: wrap; gap: 10px; color: var(--i3-muted); font-size: .72em; }
+.vnccs-i3s__local-light-flags label { display: inline-flex; align-items: center; gap: 5px; }
+.vnccs-i3s__local-light-flags input { accent-color: var(--i3-pink); }
 .vnccs-i3s__lighting-presets { display: grid; grid-template-columns: repeat(5, minmax(0,1fr)); gap: 5px; margin-bottom: 11px; }
 .vnccs-i3s__lighting-preset {
     min-width: 0;
@@ -655,7 +924,34 @@
 .vnccs-i3s__layer-tools .vnccs-i3s__group-selected { min-height: 27px; padding: 4px 8px; }
 .vnccs-i3s__selection-count { min-width: 0; flex: 1; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; color: var(--i3-dim); font-size: .72em; }
 .vnccs-i3s__object-list { min-height: 86px; max-height: 300px; overflow: auto; display: flex; flex-direction: column; gap: 6px; padding: 2px; }
-.vnccs-i3s__object-section .vnccs-i3s__object-list { flex: 1; max-height: none; }
+.vnccs-i3s__object-section .vnccs-i3s__object-list { flex: 1 1 auto; min-height: 0; max-height: none; }
+.vnccs-i3s__inspector-section { min-height: 0; overflow: hidden; display: flex; flex-direction: column; }
+.vnccs-i3s__inspector-kind { flex: none; max-width: 48%; overflow: hidden; color: var(--i3-lavender); font: .72em var(--i3-mono); text-overflow: ellipsis; white-space: nowrap; text-transform: none; letter-spacing: 0; }
+.vnccs-i3s__inspector { flex: 1 1 auto; min-height: 0; overflow: hidden auto; overscroll-behavior: contain; user-select: text; }
+.vnccs-i3s__inspector-empty { min-height: 90px; display: grid; place-items: center; padding: 15px; color: var(--i3-dim); text-align: center; }
+.vnccs-i3s__inspector-title { color: var(--i3-text); font-size: .94em; font-weight: 780; overflow-wrap: anywhere; }
+.vnccs-i3s__inspector-group { display: flex; flex-direction: column; gap: 4px; padding: 7px; border: 1px solid var(--i3-line); border-radius: 8px; background: rgba(255,255,255,.018); }
+.vnccs-i3s__inspector-group > b { margin-bottom: 2px; color: var(--i3-muted); font-size: .7em; text-transform: uppercase; letter-spacing: .07em; }
+.vnccs-i3s__precision-row { display: grid; grid-template-columns: 68px minmax(46px,1fr) 74px; gap: 5px; align-items: center; color: var(--i3-dim); font: .72em var(--i3-mono); }
+.vnccs-i3s__precision-row:has(> input:nth-child(2):last-child) { grid-template-columns: minmax(70px,1fr) 84px; }
+.vnccs-i3s__precision-row input[type="range"] { width: 100%; accent-color: var(--i3-pink); cursor: ew-resize; touch-action: none; }
+.vnccs-i3s__precision-row .vnccs-i3s__input { min-height: 25px; height: 25px; padding: 2px 5px; text-align: right; }
+.vnccs-i3s__inspector-grid { display: grid; grid-template-columns: repeat(2,minmax(0,1fr)); gap: 6px; }
+.vnccs-i3s__inspector-grid label { min-width: 0; display: flex; flex-direction: column; gap: 4px; color: var(--i3-muted); font-size: .72em; }
+.vnccs-i3s__inspector-check { display: flex; align-items: center; gap: 7px; color: var(--i3-muted); font-size: .78em; }
+.vnccs-i3s__inspector-check input { accent-color: var(--i3-pink); }
+.vnccs-i3s__inspector-actions { display: flex; flex-wrap: wrap; gap: 6px; }
+.vnccs-i3s__inspector-actions .vnccs-i3s__button { flex: 1 1 120px; min-height: 28px; padding: 4px 7px; font-size: .72em; }
+.vnccs-i3s__material-control { display: flex; flex-direction: column; gap: 4px; }
+.vnccs-i3s__material-inline { display: grid; grid-template-columns: 29px minmax(0,1fr); gap: 5px; align-items: center; }
+.vnccs-i3s__material-inline input[type="color"] { width: 29px; height: 27px; padding: 2px; border: 1px solid var(--i3-line); border-radius: 6px; background: var(--i3-surface); }
+.vnccs-i3s__material-inline .vnccs-i3s__input { min-height: 27px; height: 27px; }
+.vnccs-i3s__material-inline > .vnccs-i3s__select { grid-column: 1 / -1; }
+.vnccs-i3s__material-inline > label { grid-column: 1 / -1; display: grid; grid-template-columns: 52px minmax(0,1fr); align-items: center; gap: 5px; color: var(--i3-dim); font: .69em var(--i3-mono); }
+.vnccs-i3s__material-details { border: 1px solid var(--i3-line); border-radius: 7px; background: rgba(255,255,255,.015); }
+.vnccs-i3s__material-details > summary { padding: 6px 7px; overflow: hidden; color: var(--i3-muted); font-size: .72em; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
+.vnccs-i3s__material-details[open] > summary { border-bottom: 1px solid var(--i3-line); color: var(--i3-text); }
+.vnccs-i3s__material-details .vnccs-i3s__material-inline { padding: 7px; }
 .vnccs-i3s__object { display: grid; grid-template-columns: 36px minmax(0,1fr) auto; gap: 6px; align-items: center; min-height: 46px; padding: 4px 5px; border: 1px solid var(--i3-line); border-radius: 8px; background: rgba(255,255,255,.022); cursor: grab; transition: opacity .15s ease, border-color .15s ease, background .15s ease, transform .15s ease; }
 .vnccs-i3s__skydome-object { cursor: pointer; border-color: rgba(184,169,232,.22); background: linear-gradient(90deg, rgba(184,169,232,.07), rgba(255,255,255,.018)); }
 .vnccs-i3s__skydome-object .vnccs-i3s__object-thumb { object-fit: cover; }
@@ -694,6 +990,21 @@
 .vnccs-i3s__group.is-collapsed > .vnccs-i3s__group-children { display: none; }
 .vnccs-i3s__group-children .vnccs-i3s__object { background: rgba(255,255,255,.016); }
 .vnccs-i3s__group-empty { padding: 8px; border: 1px dashed rgba(184,169,232,.18); border-radius: 7px; color: var(--i3-dim); text-align: center; font-size: .75em; }
+.vnccs-i3s__architecture-group { display: flex; flex-direction: column; gap: 3px; padding: 4px; border: 1px solid rgba(184,169,232,.18); border-radius: 8px; background: rgba(184,169,232,.035); }
+.vnccs-i3s__architecture-children { display: flex; flex-direction: column; gap: 3px; margin-left: 12px; padding-left: 7px; border-left: 1px solid rgba(184,169,232,.2); }
+.vnccs-i3s__architecture-empty { align-items: center; display: flex; gap: 10px; justify-content: space-between; margin: 4px 0 10px; padding: 11px; border: 1px dashed var(--i3-line-strong); border-radius: 10px; background: rgba(184,169,232,.025); }
+.vnccs-i3s__architecture-empty-copy { min-width: 0; display: grid; gap: 3px; }
+.vnccs-i3s__architecture-empty-copy b { color: var(--i3-text); font-size: .8em; }
+.vnccs-i3s__architecture-empty-copy small { color: var(--i3-dim); font-size: .7em; line-height: 1.4; }
+.vnccs-i3s__architecture-row { min-width: 0; min-height: 34px; display: grid; grid-template-columns: 25px minmax(0,1fr); align-items: center; gap: 6px; padding: 4px 6px; border: 1px solid transparent; border-radius: 6px; background: transparent; color: var(--i3-muted); text-align: left; cursor: pointer; }
+.vnccs-i3s__architecture-row:hover { border-color: var(--i3-line-strong); background: var(--i3-hover); }
+.vnccs-i3s__architecture-row.is-selected { border-color: var(--i3-pink-line); background: var(--i3-pink-soft); box-shadow: inset 3px 0 var(--i3-pink); }
+.vnccs-i3s__architecture-row.is-building { background: rgba(184,169,232,.06); }
+.vnccs-i3s__architecture-kind { width: 23px; height: 23px; display: grid; place-items: center; border-radius: 6px; background: rgba(184,169,232,.11); color: var(--i3-lavender); font: 700 .68em var(--i3-mono); }
+.vnccs-i3s__architecture-copy { min-width: 0; display: flex; flex-direction: column; gap: 1px; }
+.vnccs-i3s__architecture-copy b, .vnccs-i3s__architecture-copy small { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.vnccs-i3s__architecture-copy b { color: var(--i3-text); font-size: .78em; }
+.vnccs-i3s__architecture-copy small { color: var(--i3-dim); font: .65em var(--i3-mono); }
 .vnccs-i3s__scene-cards { display: flex; flex-direction: column; gap: 7px; }
 .vnccs-i3s__scene-card { display: grid; grid-template-columns: minmax(0,1fr) auto; gap: 9px; align-items: center; padding: 9px 10px; border: 1px solid var(--i3-line); border-radius: 9px; background: rgba(255,255,255,.025); }
 .vnccs-i3s__scene-card.is-current { border-color: var(--i3-pink-line); background: var(--i3-pink-soft); }
@@ -802,10 +1113,33 @@
 @keyframes vnccs-i3s-pulse { 50% { opacity: .45; } }
 @keyframes vnccs-i3s-toast-in { from { opacity: 0; transform: translateY(-5px); } }
 
+@media (prefers-reduced-motion: reduce) {
+    .vnccs-i3s *,
+    .vnccs-i3s *::before,
+    .vnccs-i3s *::after {
+        scroll-behavior: auto !important;
+        animation-duration: .01ms !important;
+        animation-iteration-count: 1 !important;
+        transition-duration: .01ms !important;
+    }
+}
+
 @container (max-width: 880px) {
     .vnccs-i3s { grid-template-columns: 200px minmax(290px, 1fr) 220px; }
     .vnccs-i3s__project-id, .vnccs-i3s__viewport-help { display: none; }
 }
+.vnccs-i3s.is-compact { grid-template-columns: 220px minmax(320px, 1fr) 280px; }
+.vnccs-i3s.is-compact .vnccs-i3s__project-id,
+.vnccs-i3s.is-compact .vnccs-i3s__viewport-help { display: none; }
+.vnccs-i3s.is-compact .vnccs-i3s__precision-row { grid-template-columns: 56px minmax(38px,1fr) 68px; }
+.vnccs-i3s.is-narrow { grid-template-columns: 190px minmax(280px, 1fr) 220px; }
+.vnccs-i3s.is-narrow .vnccs-i3s__plan-hint { display: none; }
+.vnccs-i3s.is-narrow .vnccs-i3s__snap-grid { display: none; }
+.vnccs-i3s.is-narrow .vnccs-i3s__plan-tools [data-plan-tool] { min-width: 28px; justify-content: center; padding-inline: 6px; }
+.vnccs-i3s.is-narrow .vnccs-i3s__plan-tools { width: calc(100% - 20px); flex-wrap: wrap; justify-content: center; }
+.vnccs-i3s.is-narrow .vnccs-i3s__context-select { min-width: 76px; max-width: 104px; }
+.vnccs-i3s.is-narrow .vnccs-i3s__precision-row { grid-template-columns: minmax(54px,1fr) 72px; }
+.vnccs-i3s.is-narrow .vnccs-i3s__precision-row input[type="range"] { display: none; }
 @container (max-width: 760px) {
     .vnccs-i3s__setup-grid { grid-template-columns: minmax(0,1fr); }
     .vnccs-i3s__library-toolbar { grid-template-columns: minmax(0,1fr) 120px; }

--- a/web/vnccs_3d_factory.js
+++ b/web/vnccs_3d_factory.js
@@ -4,7 +4,6 @@ import { installCustomSelects } from "./vnccs_custom_select.mjs";
 import { Factory3DViewer } from "./vnccs_3d_factory_viewer.js?v=20260825.16";
 import {
     FACTORY_EDITOR_SCHEMA_VERSION,
-    DEFAULT_BUILDING,
     DEFAULT_LEVEL,
     DEFAULT_ROOM,
     DEFAULT_WALL,
@@ -762,10 +761,6 @@ class Factory3DWidget {
                             <button class="vnccs-i3s__tool-label vnccs-i3s__view-3d" type="button" aria-pressed="true">3D</button>
                             <button class="vnccs-i3s__tool-label vnccs-i3s__view-plan" type="button" aria-pressed="false">Plan</button>
                         </div>
-                        <select class="vnccs-i3s__context-select vnccs-i3s__building-select" aria-label="Active building" title="New walls, rooms, models, cameras, camera paths, and lights are assigned to this building"></select>
-                        <select class="vnccs-i3s__context-select vnccs-i3s__level-select" aria-label="Active floor level"></select>
-                        <button class="vnccs-i3s__tool-label vnccs-i3s__level-add" type="button" title="Add floor level">+ Floor</button>
-                        <button class="vnccs-i3s__tool-label vnccs-i3s__building-add" type="button" title="Add a movable building container">+ Building</button>
                         <button class="vnccs-i3s__tool-label vnccs-i3s__undo" type="button" title="Undo (Ctrl/Cmd+Z)" disabled>Undo</button>
                         <button class="vnccs-i3s__tool-label vnccs-i3s__redo" type="button" title="Redo (Ctrl/Cmd+Shift+Z)" disabled>Redo</button>
                         <span class="vnccs-i3s__tool-separator"></span>
@@ -1042,6 +1037,13 @@ class Factory3DWidget {
                     data-workspace-side="right" data-workspace-panel="objects">
                     <div class="vnccs-i3s__section-head"><span>Scene hierarchy</span></div>
                     <div class="vnccs-i3s__section-body">
+                        <section class="vnccs-i3s__level-panel" aria-label="Floor levels" hidden>
+                            <div class="vnccs-i3s__level-panel-head">
+                                <div><strong>Levels</strong><small>Active drawing plane</small></div>
+                                <button class="vnccs-i3s__button vnccs-i3s__button--quiet vnccs-i3s__level-add" type="button">Add level</button>
+                            </div>
+                            <div class="vnccs-i3s__level-list" role="listbox" aria-label="Floor levels"></div>
+                        </section>
                         <label class="vnccs-i3s__search">${ICONS.search}<input class="vnccs-i3s__input vnccs-i3s__object-search" type="search" placeholder="Filter objects" /></label>
                         <div class="vnccs-i3s__layer-tools">
                             <button class="vnccs-i3s__button vnccs-i3s__group-selected" type="button" disabled>${ICONS.folder}<span>Group</span></button>
@@ -1166,10 +1168,9 @@ class Factory3DWidget {
             viewerHost: $(".vnccs-i3s__viewer-host"),
             view3d: $(".vnccs-i3s__view-3d"),
             viewPlan: $(".vnccs-i3s__view-plan"),
-            levelSelect: $(".vnccs-i3s__level-select"),
-            buildingSelect: $(".vnccs-i3s__building-select"),
+            levelPanel: $(".vnccs-i3s__level-panel"),
+            levelList: $(".vnccs-i3s__level-list"),
             levelAdd: $(".vnccs-i3s__level-add"),
-            buildingAdd: $(".vnccs-i3s__building-add"),
             undo: $(".vnccs-i3s__undo"),
             redo: $(".vnccs-i3s__redo"),
             planTools: $(".vnccs-i3s__plan-tools"),
@@ -1545,19 +1546,6 @@ class Factory3DWidget {
         this._listen(this.els.cameraFov, "input", () => this._applyViewportCameraExact());
         this._listen(this.els.view3d, "click", () => this._setViewMode("3d"));
         this._listen(this.els.viewPlan, "click", () => this._setViewMode("plan"));
-        this._listen(this.els.levelSelect, "change", () => {
-            this.editorView.active_level_id = this.els.levelSelect.value;
-            this.viewer.setActiveLevel(this.editorView.active_level_id);
-            this._selectArchitecture({ type: "level", id: this.editorView.active_level_id });
-            this._syncToolbar();
-            this._scheduleStateSave(0);
-        });
-        this._listen(this.els.buildingSelect, "change", () => {
-            this.editorView.active_building_id = this._validBuildingId(this.els.buildingSelect.value);
-            this._selectArchitecture({ type: "building", id: this.editorView.active_building_id });
-            this._syncToolbar();
-            this._scheduleStateSave(0);
-        });
         this._listen(this.els.levelAdd, "click", () => {
             if (!this.scene) return;
             if (this.scene.levels.length >= 64) {
@@ -1574,13 +1562,11 @@ class Factory3DWidget {
                 };
                 this.scene.levels.push(level);
                 this.editorView.active_level_id = level.level_id;
-                this.selectedArchitecture = { type: "level", id: level.level_id };
                 void this._commitArchitecture();
                 this.viewer.setActiveLevel(level.level_id);
                 this._syncToolbar();
             });
         });
-        this._listen(this.els.buildingAdd, "click", () => this._addBuilding());
         this._listen(this.els.undo, "click", () => {
             this.history.undo();
             this._syncToolbar();
@@ -2193,27 +2179,6 @@ class Factory3DWidget {
         this._scheduleStateSave(0);
     }
 
-    _addBuilding() {
-        if (!this.scene) return;
-        if ((this.scene.architecture?.buildings?.length || 0) >= 64) {
-            this.toast("A scene can contain up to 64 buildings.", "error");
-            return;
-        }
-        this._recordEditorCommand("Add building", () => {
-            const architecture = this.scene.architecture ||= normalizedArchitecture({}, this.scene.levels);
-            const building = {
-                ...DEFAULT_BUILDING,
-                building_id: factoryId(),
-                name: `Building ${(architecture.buildings?.length || 0) + 1}`,
-                position: [0, 0, 0],
-            };
-            architecture.buildings.push(building);
-            this.editorView.active_building_id = building.building_id;
-            this.selectedArchitecture = { type: "building", id: building.building_id };
-            void this._commitArchitecture();
-        });
-    }
-
     _clearPlanHover() {
         if (this._planHoverFrame) cancelAnimationFrame(this._planHoverFrame);
         this._planHoverFrame = 0;
@@ -2327,9 +2292,7 @@ class Factory3DWidget {
             const owner = buildings.find(item => item.building_id === track?.building_id);
             if (owner) return owner;
         }
-        const active = buildings.find(item => item.building_id === this.editorView.active_building_id);
-        if (active) return active;
-        return buildings[0] || null;
+        return null;
     }
 
     _buildingForItem(item) {
@@ -6357,19 +6320,6 @@ class Factory3DWidget {
         const fragment = document.createDocumentFragment();
         this._syncSelectionControls();
         let rendered = 0;
-        if (this.scene && !this.scene.architecture?.buildings?.length && !query) {
-            const emptyArchitecture = element("section", "vnccs-i3s__architecture-empty");
-            const copy = element("div", "vnccs-i3s__architecture-empty-copy");
-            copy.append(
-                element("b", "", "No buildings"),
-                element("small", "", "Create one only when you need walls, rooms, or openings."),
-            );
-            const create = button("vnccs-i3s__button vnccs-i3s__button--quiet", "Create building", "plus");
-            create.addEventListener("click", () => this._addBuilding());
-            emptyArchitecture.append(copy, create);
-            fragment.appendChild(emptyArchitecture);
-            rendered += 1;
-        }
         for (const entry of this._createArchitectureTree(query)) {
             fragment.appendChild(entry);
             rendered += 1;
@@ -6452,6 +6402,47 @@ class Factory3DWidget {
             row.addEventListener("click", () => this._selectArchitecture({ type, id }));
             return row;
         };
+        const rootWalls = (architecture.walls || []).filter(
+            item => !item.building_id && item.level_id === activeLevelId,
+        );
+        const rootRooms = (architecture.rooms || []).filter(
+            item => !item.building_id && item.level_id === activeLevelId,
+        );
+        const rootRoomWallIds = new Set(rootRooms.flatMap(room => room.wall_ids || []));
+        const rootStandaloneWalls = rootWalls.filter(wall => !rootRoomWallIds.has(wall.wall_id));
+        const rootEntries = [
+            ...rootRooms.map(item => ({
+                type: "room",
+                id: item.room_id,
+                name: item.name || "Room",
+                meta: `Complete room · walls, floor and ceiling${item.locked ? " · Locked" : ""}${item.visible === false ? " · Hidden" : ""}`,
+            })),
+            ...rootStandaloneWalls.map(item => ({
+                type: "wall",
+                id: item.wall_id,
+                name: item.name || "Wall",
+                meta: `${Math.hypot(item.end[0] - item.start[0], item.end[1] - item.start[1]).toFixed(2)} m${item.locked ? " · Locked" : ""}${item.visible === false ? " · Hidden" : ""}`,
+            })),
+            ...rootWalls.flatMap(wall => openingsByWall.get(wall.wall_id) || []).map(item => ({
+                type: "opening",
+                id: item.opening_id,
+                name: item.name || "Opening",
+                meta: `${item.kind} · ${Number(item.width).toFixed(2)} m${item.locked ? " · Locked" : ""}${item.visible === false ? " · Hidden" : ""}`,
+            })),
+        ].filter(item => !query || `${item.name} ${item.type} ${item.meta}`.toLowerCase().includes(query));
+        if (rootEntries.length) {
+            const wrapper = element("section", "vnccs-i3s__architecture-group");
+            const heading = element("div", "vnccs-i3s__architecture-row is-building is-root");
+            heading.innerHTML = `<span class="vnccs-i3s__architecture-kind">A</span><span class="vnccs-i3s__architecture-copy"><b></b><small></small></span>`;
+            heading.querySelector("b").textContent = "Architecture";
+            heading.querySelector("small").textContent = `${rootRooms.length} rooms · ${rootStandaloneWalls.length} standalone walls`;
+            const children = element("div", "vnccs-i3s__architecture-children");
+            for (const entry of rootEntries) {
+                children.appendChild(createRow(entry.type, entry.id, entry.name, entry.meta));
+            }
+            wrapper.append(heading, children);
+            output.push(wrapper);
+        }
         for (const building of architecture.buildings || []) {
             const walls = (architecture.walls || []).filter(
                 item => item.building_id === building.building_id && item.level_id === activeLevelId,
@@ -9509,42 +9500,56 @@ class Factory3DWidget {
         const selectedLevelId = levels.some(level => level.level_id === this.editorView.active_level_id)
             ? this.editorView.active_level_id
             : levels[0]?.level_id || "";
-        if (this.els.levelSelect.dataset.signature !== levels.map(level => `${level.level_id}:${level.name}`).join("|")) {
-            this.els.levelSelect.replaceChildren(...levels.map(level => {
-                const option = element("option", "", `${level.name} · ${Number(level.elevation).toFixed(2)} m`);
-                option.value = level.level_id;
-                return option;
-            }));
-            this.els.levelSelect.dataset.signature = levels.map(level => `${level.level_id}:${level.name}`).join("|");
-        }
         this.editorView.active_level_id = selectedLevelId;
-        this.els.levelSelect.value = selectedLevelId;
-        this.els.levelSelect.hidden = !this.scene;
-        const buildings = this.scene?.architecture?.buildings || [];
-        const selectedBuildingId = buildings.some(
-            building => building.building_id === this.editorView.active_building_id,
-        ) ? this.editorView.active_building_id : buildings[0]?.building_id || "";
-        const buildingSignature = buildings.map(
-            building => `${building.building_id}:${building.name}`,
+        const activeLevel = levels.find(level => level.level_id === selectedLevelId);
+        const architectureToolActive = plan
+            && ["wall", "room", "opening"].includes(this.editorView.plan_tool);
+        this.els.levelPanel.hidden = !architectureToolActive;
+        this.els.levelPanel.setAttribute(
+            "aria-label",
+            activeLevel
+                ? `Floor levels, ${activeLevel.name} active`
+                : "Floor levels",
+        );
+        const levelSignature = levels.map(
+            level => `${level.level_id}:${level.name}:${level.elevation}:${level.height}:${level.visible}`,
         ).join("|");
-        if (this.els.buildingSelect.dataset.signature !== buildingSignature) {
-            const noBuildings = element("option", "", "No buildings");
-            noBuildings.value = "";
-            noBuildings.disabled = true;
-            noBuildings.selected = !buildings.length;
-            this.els.buildingSelect.replaceChildren(...(buildings.length ? buildings.map(building => {
-                const option = element("option", "", building.name || "Building");
-                option.value = building.building_id;
-                return option;
-            }) : [noBuildings]));
-            this.els.buildingSelect.dataset.signature = buildingSignature;
+        if (this.els.levelList.dataset.signature !== levelSignature) {
+            this.els.levelList.replaceChildren(...levels.map(level => {
+                const control = button(
+                    "vnccs-i3s__level-card",
+                    "",
+                );
+                control.type = "button";
+                control.dataset.levelId = level.level_id;
+                control.setAttribute("role", "option");
+                const copy = element("span", "vnccs-i3s__level-card-copy");
+                copy.append(
+                    element("b", "", level.name || "Level"),
+                    element(
+                        "small",
+                        "",
+                        `${Number(level.elevation).toFixed(2)} m · height ${Number(level.height).toFixed(2)} m`,
+                    ),
+                );
+                control.appendChild(copy);
+                control.addEventListener("click", () => {
+                    this.editorView.active_level_id = level.level_id;
+                    this.viewer.setActiveLevel(level.level_id);
+                    this._renderObjects();
+                    this._syncToolbar();
+                    this._scheduleStateSave(0);
+                });
+                return control;
+            }));
+            this.els.levelList.dataset.signature = levelSignature;
         }
-        this.editorView.active_building_id = selectedBuildingId;
-        this.els.buildingSelect.value = selectedBuildingId;
-        this.els.buildingSelect.hidden = !this.scene;
-        this.els.buildingSelect.disabled = !buildings.length;
-        this.els.levelAdd.disabled = !this.scene;
-        this.els.buildingAdd.disabled = !this.scene || (this.scene.architecture?.buildings?.length || 0) >= 64;
+        for (const control of this.els.levelList.querySelectorAll("[data-level-id]")) {
+            const selected = control.dataset.levelId === selectedLevelId;
+            control.classList.toggle("is-active", selected);
+            control.setAttribute("aria-selected", String(selected));
+        }
+        this.els.levelAdd.disabled = !this.scene || levels.length >= 64;
         if (this.els.undo) this.els.undo.disabled = !this.history.canUndo;
         if (this.els.redo) this.els.redo.disabled = !this.history.canRedo;
     }

--- a/web/vnccs_3d_factory.js
+++ b/web/vnccs_3d_factory.js
@@ -98,8 +98,8 @@ const DEFAULT_LIGHTING = Object.freeze({
     shadows: Object.freeze({
         enabled: true,
         quality: "medium",
-        bias: -0.0004,
-        normal_bias: 0.015,
+        bias: -0.0002,
+        normal_bias: 0.0015,
     }),
     lights: Object.freeze([]),
 });
@@ -424,8 +424,12 @@ class Factory3DWidget {
         this.selectedGroupId = "";
         this.selectedSkydome = false;
         this.selectedCameraId = "";
+        this.selectedCameraIds = new Set();
+        this.selectedLightId = "";
         this.previewCameraId = "";
         this.selectedArchitecture = null;
+        this.selectedArchitectureItems = new Map();
+        this.selectionClipboard = null;
         this.editorView = normalizedEditorView();
         this.planDraft = null;
         this.planHover = null;
@@ -456,7 +460,7 @@ class Factory3DWidget {
         this._previewIdleHandle = 0;
         this._lightingApplyTimer = 0;
         this._lightingHistoryBefore = null;
-        this._expandedLightId = "";
+        this._lightTransformHistoryBefore = null;
         this._searchRenderFrame = 0;
         this._sceneSaveSerial = Promise.resolve();
         this._architectureCommitSerial = Promise.resolve();
@@ -507,8 +511,17 @@ class Factory3DWidget {
                 additive: Boolean(options?.additive),
             }),
             onTransformChange: (id, transform, options) => this._onViewerTransform(id, transform, options),
-            onArchitectureSelection: selection => this._selectArchitecture(selection),
+            onArchitectureSelection: selection => this._selectArchitecture(selection, {
+                additive: Boolean(selection?.additive),
+            }),
             onArchitectureEdit: change => this._onArchitectureEdit(change),
+            onLightSelection: lightId => this._selectLight(lightId),
+            onLightTransform: (lightId, position, options) => this._onViewerLightTransform(
+                lightId,
+                position,
+                options,
+            ),
+            onPlanMarqueeSelection: (items, options) => this._selectPlanItems(items, options),
             snapPlanPoint: (point, event, context) => this._snapPlanPoint(
                 point,
                 event,
@@ -764,7 +777,14 @@ class Factory3DWidget {
                         <button class="vnccs-i3s__tool-label vnccs-i3s__undo" type="button" title="Undo (Ctrl/Cmd+Z)" disabled>Undo</button>
                         <button class="vnccs-i3s__tool-label vnccs-i3s__redo" type="button" title="Redo (Ctrl/Cmd+Shift+Z)" disabled>Redo</button>
                         <span class="vnccs-i3s__tool-separator"></span>
+                        <button class="vnccs-i3s__tool-label vnccs-i3s__selection-copy" type="button" title="Copy selected scene objects (Ctrl/Cmd+C)" disabled>Copy</button>
+                        <button class="vnccs-i3s__tool-label vnccs-i3s__selection-paste" type="button" title="Paste copied scene objects (Ctrl/Cmd+V)" disabled>Paste</button>
+                        <span class="vnccs-i3s__tool-separator"></span>
                         <button class="vnccs-i3s__tool vnccs-i3s__fit" type="button" title="Fit scene" aria-label="Fit scene">${ICONS.fit}</button>
+                        <button class="vnccs-i3s__tool-label vnccs-i3s__cutaway" type="button"
+                            title="Interior cutaway (viewport only): hide ceilings and the nearest blocking wall"
+                            aria-label="Toggle viewport-only interior cutaway for this mode"
+                            aria-pressed="false">Cutaway</button>
                         <span class="vnccs-i3s__tool-separator"></span>
                         <button class="vnccs-i3s__tool vnccs-i3s__mode-move" type="button" title="Move" aria-label="Move selected objects" aria-pressed="true">${ICONS.move}</button>
                         <button class="vnccs-i3s__tool vnccs-i3s__mode-rotate" type="button" title="Rotate" aria-label="Rotate selected objects" aria-pressed="false">${ICONS.rotate}</button>
@@ -772,7 +792,7 @@ class Factory3DWidget {
                         <button class="vnccs-i3s__tool-label vnccs-i3s__drop-surface" type="button" title="Drop selection to the nearest surface (End)">Drop</button>
                         <span class="vnccs-i3s__tool-separator"></span>
                         <button class="vnccs-i3s__tool vnccs-i3s__skydome-open" type="button" title="Skydome" aria-label="Open skydome controls" aria-pressed="false">${ICONS.image}</button>
-                        <button class="vnccs-i3s__tool vnccs-i3s__lighting-open" type="button" title="Scene lighting" aria-label="Open scene lighting controls" aria-pressed="false">${ICONS.sun}</button>
+                        <button class="vnccs-i3s__tool vnccs-i3s__lighting-open" type="button" title="Scene lighting and point lights" aria-label="Open scene lighting and point light controls" aria-pressed="false">${ICONS.sun}</button>
                         <button class="vnccs-i3s__tool vnccs-i3s__grid" type="button" title="Grid" aria-label="Toggle 3D grid" aria-pressed="false">${ICONS.grid}</button>
                     </div>
                     <div class="vnccs-i3s__plan-tools" role="toolbar" aria-label="Floor plan tools" hidden>
@@ -976,9 +996,7 @@ class Factory3DWidget {
                                     <option value="low">Low · 512</option><option value="medium">Medium · 1024</option><option value="high">High · 2048</option><option value="ultra">Ultra · 4096</option>
                                 </select>
                             </label>
-                            <div class="vnccs-i3s__hint">Local shadow-map budget: Low 2 · Medium 4 · High 6 · Ultra 8. Additional lights still illuminate without a shadow map.</div>
-                            <div class="vnccs-i3s__lighting-local-head"><b>Local lights</b><button class="vnccs-i3s__button vnccs-i3s__local-light-add" type="button">Add light</button></div>
-                            <div class="vnccs-i3s__local-lights"></div>
+                            <div class="vnccs-i3s__hint">Active shadow-casting point lights: Low 2 · Medium 4 · High 6 · Ultra 8. Lights beyond the active budget stay stored but do not illuminate until the budget is available.</div>
                         </div>
                     </section>
                     <div class="vnccs-i3s__viewport-help">Click: select · Shift-click: multi-select · Drag gizmo: transform · W/E/R: move/rotate/scale · End: drop · F: frame</div>
@@ -1035,7 +1053,12 @@ class Factory3DWidget {
                     id="${this._workspaceId}-right-objects" role="tabpanel"
                     aria-labelledby="${this._workspaceId}-right-objects-tab"
                     data-workspace-side="right" data-workspace-panel="objects">
-                    <div class="vnccs-i3s__section-head"><span>Scene hierarchy</span></div>
+                    <div class="vnccs-i3s__section-head">
+                        <span>Scene hierarchy</span>
+                        <button class="vnccs-i3s__button vnccs-i3s__button--quiet vnccs-i3s__local-light-add" type="button" title="Add a point light to the scene">
+                            ${ICONS.sun}<span>Add light</span>
+                        </button>
+                    </div>
                     <div class="vnccs-i3s__section-body">
                         <section class="vnccs-i3s__level-panel" aria-label="Floor levels" hidden>
                             <div class="vnccs-i3s__level-panel-head">
@@ -1061,7 +1084,7 @@ class Factory3DWidget {
                         <span class="vnccs-i3s__inspector-kind">Nothing selected</span>
                     </div>
                     <div class="vnccs-i3s__section-body vnccs-i3s__inspector" data-preserve-scroll="inspector">
-                        <div class="vnccs-i3s__inspector-empty">Select an object, wall, room, opening, or camera.</div>
+                        <div class="vnccs-i3s__inspector-empty">Select an object, light, wall, room, opening, or camera.</div>
                     </div>
                 </section>
                 <section class="vnccs-i3s__section vnccs-i3s__workspace-panel vnccs-i3s__export-section"
@@ -1173,6 +1196,8 @@ class Factory3DWidget {
             levelAdd: $(".vnccs-i3s__level-add"),
             undo: $(".vnccs-i3s__undo"),
             redo: $(".vnccs-i3s__redo"),
+            selectionCopy: $(".vnccs-i3s__selection-copy"),
+            selectionPaste: $(".vnccs-i3s__selection-paste"),
             planTools: $(".vnccs-i3s__plan-tools"),
             planToolButtons: Array.from(this.container.querySelectorAll("[data-plan-tool]")),
             openingKindShortcut: $(".vnccs-i3s__opening-kind-shortcut"),
@@ -1195,6 +1220,7 @@ class Factory3DWidget {
             cameraVectors: Array.from(this.container.querySelectorAll("[data-camera-vector]")),
             cameraFov: $("[data-camera-fov]"),
             fit: $(".vnccs-i3s__fit"),
+            cutaway: $(".vnccs-i3s__cutaway"),
             modeMove: $(".vnccs-i3s__mode-move"),
             modeRotate: $(".vnccs-i3s__mode-rotate"),
             modeScale: $(".vnccs-i3s__mode-scale"),
@@ -1235,7 +1261,6 @@ class Factory3DWidget {
             shadowEnabled: $(".vnccs-i3s__shadow-enabled"),
             shadowQuality: $(".vnccs-i3s__shadow-quality"),
             localLightAdd: $(".vnccs-i3s__local-light-add"),
-            localLights: $(".vnccs-i3s__local-lights"),
             lightAzimuthValue: $(".vnccs-i3s__light-azimuth-value"),
             lightElevationValue: $(".vnccs-i3s__light-elevation-value"),
             grid: $(".vnccs-i3s__grid"),
@@ -1546,6 +1571,13 @@ class Factory3DWidget {
         this._listen(this.els.cameraFov, "input", () => this._applyViewportCameraExact());
         this._listen(this.els.view3d, "click", () => this._setViewMode("3d"));
         this._listen(this.els.viewPlan, "click", () => this._setViewMode("plan"));
+        this._listen(this.els.cutaway, "click", () => {
+            const key = this.editorView.view_mode === "plan" ? "plan" : "three_d";
+            this.editorView.interior_cutaway[key] = !this.editorView.interior_cutaway[key];
+            this.viewer.setInteriorCutaway(this.editorView.interior_cutaway[key]);
+            this._syncToolbar();
+            this._scheduleStateSave(0);
+        });
         this._listen(this.els.levelAdd, "click", () => {
             if (!this.scene) return;
             if (this.scene.levels.length >= 64) {
@@ -1575,6 +1607,8 @@ class Factory3DWidget {
             this.history.redo();
             this._syncToolbar();
         });
+        this._listen(this.els.selectionCopy, "click", () => this._copySelection());
+        this._listen(this.els.selectionPaste, "click", () => void this._pasteSelection());
         for (const control of this.els.planToolButtons) {
             this._listen(control, "click", () => this._setPlanTool(control.dataset.planTool));
         }
@@ -1704,6 +1738,41 @@ class Factory3DWidget {
                 this.els.planSettingsPanel.open = false;
             }
         });
+        // Match Pose Studio's timeline shortcut routing: capture the command
+        // before ComfyUI's global graph handlers, but only while this Factory
+        // editor owns focus and never while the user edits a form control.
+        this._listen(window, "keydown", event => {
+            const activeWithin = this.container.contains(event.target)
+                || this.container.contains(document.activeElement);
+            if (!activeWithin) return;
+            if (
+                this.els.modalLayer.classList.contains("is-open")
+                || this.libraryOverlay?.isConnected
+            ) return;
+            const target = event.target;
+            const editing = target instanceof HTMLInputElement
+                || target instanceof HTMLTextAreaElement
+                || target instanceof HTMLSelectElement
+                || target?.isContentEditable;
+            if (editing) return;
+            if (event.key === "Delete" || event.key === "Backspace") {
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                const deleteControl = this.els.inspector.querySelector(
+                    '[data-inspector-action="delete"]',
+                );
+                if (deleteControl && !deleteControl.disabled) deleteControl.click();
+                return;
+            }
+            const command = event.ctrlKey || event.metaKey;
+            if (!command || event.altKey || event.shiftKey) return;
+            const key = String(event.key || "").toLowerCase();
+            if (key !== "c" && key !== "v") return;
+            event.preventDefault();
+            event.stopImmediatePropagation();
+            if (key === "c") this._copySelection();
+            else void this._pasteSelection();
+        }, true);
         this._listen(document, "keydown", event => {
             const activeWithin = this.container.contains(event.target)
                 || this.container.contains(document.activeElement);
@@ -1846,6 +1915,17 @@ class Factory3DWidget {
                 this.toast("A scene can contain up to 32 local lights.", "error");
                 return;
             }
+            const shadowBudget = { low: 2, medium: 4, high: 6, ultra: 8 }[
+                this.lighting.shadows?.quality
+            ] || 0;
+            const activeShadowLights = this.lighting.lights.filter(
+                light => light.visible !== false && light.cast_shadow !== false,
+            ).length;
+            const shadowBudgetExhausted = Boolean(
+                this.lighting.shadows?.enabled
+                && this.lighting.shadows?.quality !== "off"
+                && activeShadowLights >= shadowBudget
+            );
             const before = this._captureEditorSnapshot();
             const level = this.scene?.levels?.find(value => value.level_id === this.editorView.active_level_id);
             const building = this._activeBuilding();
@@ -1869,14 +1949,22 @@ class Factory3DWidget {
                 distance: 8,
                 angle: 45,
                 penumbra: 0.2,
-                cast_shadow: true,
+                cast_shadow: !shadowBudgetExhausted,
                 visible: true,
             });
-            this._expandedLightId = lightId;
+            this._selectLight(lightId);
             if (before) this.history.push("Add light", before, this._captureEditorSnapshot());
             this._syncLighting();
             this._commitLighting({ final: true });
+            this._renderObjects();
+            this._updateSceneSummary();
             this._syncToolbar();
+            if (shadowBudgetExhausted) {
+                this.toast(
+                    `Light added without shadows. ${this.lighting.shadows.quality} quality supports ${shadowBudget} shadow-casting point light${shadowBudget === 1 ? "" : "s"}.`,
+                    "info",
+                );
+            }
         });
         this._bindLightingRadar();
         this._listen(this.els.grid, "click", () => this.viewer.setGrid(!this.viewerState.grid));
@@ -2066,7 +2154,10 @@ class Factory3DWidget {
         this.viewer.setViewMode(this.editorView.view_mode);
         this.viewer.setPlanTool(this.editorView.plan_tool);
         this.viewer.setActiveLevel(this.editorView.active_level_id);
-        this.viewer.setArchitectureSelection(this.selectedArchitecture);
+        this.viewer.setArchitectureSelection(
+            this.selectedArchitecture,
+            this._selectedArchitectureRefs(),
+        );
         this.viewer.applySceneVisibility(this.scene);
         this.viewer.setCameraMarkers(this.scene.cameras || []);
         this.viewer.setLighting(this.lighting);
@@ -2087,6 +2178,8 @@ class Factory3DWidget {
         this.editorView.view_mode = mode === "plan" ? "plan" : "3d";
         if (this.editorView.view_mode !== "plan") this._cancelPlanDraft();
         this.viewer.setViewMode(this.editorView.view_mode);
+        const cutawayKey = this.editorView.view_mode === "plan" ? "plan" : "three_d";
+        this.viewer.setInteriorCutaway(this.editorView.interior_cutaway[cutawayKey]);
         this._syncToolbar();
         this._scheduleStateSave(0);
     }
@@ -2610,7 +2703,14 @@ class Factory3DWidget {
                 locked: false,
             });
             this.selectedArchitecture = { type: "opening", id: openingId };
-            this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            this.selectedArchitectureItems = new Map([[
+                this._architectureSelectionKey(this.selectedArchitecture),
+                this.selectedArchitecture,
+            ]]);
+            this.viewer.setArchitectureSelection(
+                this.selectedArchitecture,
+                this._selectedArchitectureRefs(),
+            );
             void this._commitArchitecture();
         });
         return true;
@@ -2978,7 +3078,14 @@ class Factory3DWidget {
                 wall_ids: wallIds,
             });
             this.selectedArchitecture = { type: "room", id: roomId };
-            this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            this.selectedArchitectureItems = new Map([[
+                this._architectureSelectionKey(this.selectedArchitecture),
+                this.selectedArchitecture,
+            ]]);
+            this.viewer.setArchitectureSelection(
+                this.selectedArchitecture,
+                this._selectedArchitectureRefs(),
+            );
             void this._commitArchitecture();
         });
         return true;
@@ -3057,7 +3164,10 @@ class Factory3DWidget {
         this.viewer.setViewMode(this.editorView.view_mode);
         this.viewer.setPlanTool(this.editorView.plan_tool);
         this.viewer.setActiveLevel(this.editorView.active_level_id);
-        this.viewer.setArchitectureSelection(this.selectedArchitecture);
+        this.viewer.setArchitectureSelection(
+            this.selectedArchitecture,
+            this._selectedArchitectureRefs(),
+        );
         if (!targeted) this._renderInspector();
         if (this.selectedArchitecture) this._setWorkspaceTab("right", "inspector");
         this._updateSceneSummary();
@@ -3138,12 +3248,52 @@ class Factory3DWidget {
         this._scheduleStateSave(220);
     }
 
-    _selectArchitecture(selection) {
+    _architectureSelectionKey(selection) {
+        return selection?.id ? `${selection.type}:${selection.id}` : "";
+    }
+
+    _selectedArchitectureRefs() {
+        if (this.selectedArchitectureItems?.size) {
+            return Array.from(this.selectedArchitectureItems.values());
+        }
+        return this.selectedArchitecture?.id ? [{ ...this.selectedArchitecture }] : [];
+    }
+
+    _isArchitectureSelected(type, id) {
+        const key = this._architectureSelectionKey({ type, id });
+        return Boolean(
+            this.selectedArchitectureItems?.has(key)
+            || (!this.selectedArchitectureItems?.size
+                && this.selectedArchitecture?.type === type
+                && this.selectedArchitecture?.id === id),
+        );
+    }
+
+    _selectArchitecture(selection, { additive = false } = {}) {
         if (selection?.type === "camera") {
             this._selectCamera(selection.id);
             return;
         }
-        this.selectedArchitecture = this._normalizeArchitectureSelection(selection);
+        this.selectedLightId = "";
+        this.viewer.selectLightMarker("");
+        const normalizedSelection = this._normalizeArchitectureSelection(selection);
+        const selectionKey = this._architectureSelectionKey(normalizedSelection);
+        if (!additive) {
+            this.selectedArchitectureItems.clear();
+            this.selectedObjectIds.clear();
+            this.selectedObjectId = "";
+            this.selectedCameraIds.clear();
+        }
+        if (selectionKey) {
+            if (additive && this.selectedArchitectureItems.has(selectionKey)) {
+                this.selectedArchitectureItems.delete(selectionKey);
+            } else {
+                this.selectedArchitectureItems.set(selectionKey, normalizedSelection);
+            }
+        }
+        this.selectedArchitecture = this.selectedArchitectureItems.has(selectionKey)
+            ? normalizedSelection
+            : Array.from(this.selectedArchitectureItems.values()).at(-1) || null;
         const selected = this._selectedArchitectureValue();
         const owner = this.selectedArchitecture?.type === "building"
             ? this.scene?.architecture?.buildings?.find(
@@ -3151,17 +3301,68 @@ class Factory3DWidget {
             )
             : this._buildingForItem(selected);
         if (owner) this.editorView.active_building_id = owner.building_id;
-        this.selectedCameraId = "";
+        if (!additive) this.selectedCameraId = "";
         this.selectedCameraKeyframeId = "";
-        this.selectedObjectId = "";
-        this.selectedObjectIds.clear();
         this.selectedGroupId = "";
         this.selectedSkydome = false;
-        this.viewer.setArchitectureSelection(this.selectedArchitecture);
+        this.viewer.select(this.selectedObjectId, { additive: true, emit: false });
+        this.viewer.setArchitectureSelection(
+            this.selectedArchitecture,
+            this._selectedArchitectureRefs(),
+        );
         this._renderObjects();
+        this._renderCameras();
         this._renderInspector();
         this._syncToolbar();
         if (this.selectedArchitecture) this._setWorkspaceTab("right", "inspector");
+        this._scheduleStateSave(0);
+    }
+
+    _selectPlanItems(items = [], { additive = false, emptyClick = false } = {}) {
+        if (!this.scene) return;
+        this.selectedLightId = "";
+        this.viewer.selectLightMarker("");
+        if (!additive) {
+            this.selectedObjectIds.clear();
+            this.selectedArchitectureItems.clear();
+            this.selectedCameraIds.clear();
+        }
+        for (const item of items) {
+            if (item?.kind === "object" && this.scene.objects?.some(value => value.object_id === item.id)) {
+                this.selectedObjectIds.add(item.id);
+                continue;
+            }
+            if (item?.kind !== "architecture") continue;
+            const normalized = this._normalizeArchitectureSelection(item);
+            const key = this._architectureSelectionKey(normalized);
+            if (key) this.selectedArchitectureItems.set(key, normalized);
+        }
+        for (const item of items) {
+            if (item?.kind === "camera" && this.scene.cameras?.some(camera => camera.camera_id === item.id)) {
+                this.selectedCameraIds.add(item.id);
+            }
+        }
+        if (emptyClick && !additive) {
+            this.selectedObjectIds.clear();
+            this.selectedArchitectureItems.clear();
+            this.selectedCameraIds.clear();
+        }
+        this.selectedObjectId = Array.from(this.selectedObjectIds).at(-1) || "";
+        this.selectedArchitecture = Array.from(this.selectedArchitectureItems.values()).at(-1) || null;
+        this.selectedGroupId = "";
+        this.selectedSkydome = false;
+        this.selectedCameraId = Array.from(this.selectedCameraIds).at(-1) || "";
+        this.selectedCameraKeyframeId = "";
+        this.viewer.select(this.selectedObjectId, { additive: true, emit: false });
+        this.viewer.setArchitectureSelection(
+            this.selectedArchitecture,
+            this._selectedArchitectureRefs(),
+        );
+        this._renderObjects();
+        this._renderCameras();
+        this._renderInspector();
+        this._syncToolbar();
+        this._scheduleStateSave(0);
     }
 
     _onArchitectureEdit(change) {
@@ -3442,10 +3643,17 @@ class Factory3DWidget {
             const item = this.scene?.objects?.find(value => value.object_id === this.selectedObjectId);
             const architecture = this._selectedArchitectureValue();
             const camera = this.scene?.cameras?.find(value => value.camera_id === this.selectedCameraId);
+            const light = this.lighting?.lights?.find(value => value.light_id === this.selectedLightId);
             const group = this._groupById(this.selectedGroupId);
             const track = this._activeCameraTrack();
             const keyframe = track?.keyframes?.find(value => value.keyframe_id === this.selectedCameraKeyframeId);
-            const hasSelection = Boolean(item || architecture || camera || keyframe || group);
+            const architectureSelectionCount = this._selectedArchitectureRefs().length;
+            const cameraSelectionCount = this.selectedCameraIds.size;
+            const directSelectionCount = this.selectedObjectIds.size
+                + architectureSelectionCount
+                + cameraSelectionCount
+                + (light ? 1 : 0);
+            const hasSelection = Boolean(item || architecture || camera || light || keyframe || group);
             this.container.classList.toggle("has-inspector-selection", hasSelection);
             const inspectorTab = this.els.workspaceTabs.find(
                 button => button.dataset.workspaceSide === "right"
@@ -3455,17 +3663,126 @@ class Factory3DWidget {
                 "aria-label",
                 hasSelection ? "Inspector, selection available" : "Inspector",
             );
-            if (!item && !architecture && !camera && !keyframe && !group) {
+            if (!item && !architecture && !camera && !light && !keyframe && !group) {
                 this.els.inspectorKind.textContent = "Nothing selected";
-                this.els.inspector.innerHTML = '<div class="vnccs-i3s__inspector-empty">Select an object, wall, room, opening, or camera.</div>';
+                this.els.inspector.innerHTML = '<div class="vnccs-i3s__inspector-empty">Select an object, light, wall, room, opening, or camera.</div>';
                 return;
             }
-            if (item) this._renderObjectInspector(item);
+            if (directSelectionCount > 1) {
+                const modelCount = this.selectedObjectIds.size;
+                this.els.inspectorKind.textContent = "Multiple selection";
+                this.els.inspector.innerHTML = `
+                    <section class="vnccs-i3s__inspector-section">
+                        <div class="vnccs-i3s__inspector-title">${directSelectionCount} objects selected</div>
+                        <div class="vnccs-i3s__hint">${modelCount} model${modelCount === 1 ? "" : "s"} · ${architectureSelectionCount} architecture object${architectureSelectionCount === 1 ? "" : "s"} · ${cameraSelectionCount} camera${cameraSelectionCount === 1 ? "" : "s"}</div>
+                        <div class="vnccs-i3s__hint">Use Copy to place this complete selection in the Factory clipboard.</div>
+                    </section>`;
+                return;
+            }
+            if (light) this._renderLightInspector(light);
+            else if (item) this._renderObjectInspector(item);
             else if (group) this._renderGroupInspector(group);
             else if (camera) this._renderCameraInspector(camera);
             else if (keyframe) this._renderKeyframeInspector(track, keyframe);
             else this._renderArchitectureInspector(architecture);
         });
+    }
+
+    _renderLightInspector(light) {
+        const lightId = light.light_id;
+        const currentLight = () => this.lighting?.lights?.find(
+            item => item.light_id === lightId,
+        );
+        this.els.inspectorKind.textContent = "Point light";
+        this.els.inspector.innerHTML = `
+            <div class="vnccs-i3s__inspector-title">${escapeHTML(light.name || "Point light")}</div>
+            <div class="vnccs-i3s__hint">Scene object · editor sphere is excluded from camera exports.</div>
+            <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Name</span><input class="vnccs-i3s__input" data-light-property="name" value="${escapeHTML(light.name || "Point light")}" maxlength="80" /></label>
+            <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Floor level</span><select class="vnccs-i3s__select" data-light-property="level_id">
+                ${(this.scene?.levels || []).map(level => `<option value="${level.level_id}"${light.level_id === level.level_id ? " selected" : ""}>${escapeHTML(level.name)}</option>`).join("")}
+            </select></label>
+            <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Building</span><select class="vnccs-i3s__select" data-light-property="building_id">${this._buildingOptions(light.building_id)}</select></label>
+            <div class="vnccs-i3s__inspector-group"><b>Position · m</b>
+                ${["X", "Y", "Z"].map((axis, index) => this._numericControl(axis, `light.position.${index}`, light.position[index], { minimum: -10000, maximum: 10000, step: 0.01 })).join("")}
+            </div>
+            <div class="vnccs-i3s__inspector-group"><b>Emission</b>
+                <label class="vnccs-i3s__lighting-color-row"><span><b>Color</b></span><span class="vnccs-i3s__lighting-color-control"><input type="color" data-light-property="color" value="${light.color}" aria-label="Point light color" /><output>${escapeHTML(light.color.toUpperCase())}</output></span></label>
+                ${this._numericControl("Strength", "light.intensity", light.intensity, { minimum: 0, maximum: 100000, sliderMinimum: 0, sliderMaximum: 50, step: 0.1 })}
+                ${this._numericControl("Range", "light.distance", light.distance, { minimum: 0, maximum: 1000000, sliderMinimum: 0, sliderMaximum: 100, step: 0.1 })}
+            </div>
+            <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-light-property="visible"${light.visible !== false ? " checked" : ""} /> Light visible</label>
+            <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-light-property="cast_shadow"${light.cast_shadow !== false ? " checked" : ""} /> Cast shadow</label>
+            <button class="vnccs-i3s__button vnccs-i3s__button--danger" type="button" data-inspector-action="delete" title="Delete light (Delete/Backspace)">Delete light</button>`;
+        let before = null;
+        const begin = () => { before ||= this._captureEditorSnapshot(); };
+        const apply = () => {
+            this._commitLighting();
+            this.viewer?.selectLightMarker?.(lightId);
+        };
+        for (const control of this.els.inspector.querySelectorAll("[data-editor-path]")) {
+            control.addEventListener("pointerdown", begin);
+            control.addEventListener("focus", begin);
+            control.addEventListener("input", () => {
+                const [, key, rawIndex] = control.dataset.editorPath.split(".");
+                const value = Number(control.value);
+                const target = currentLight();
+                if (!target || !Number.isFinite(value)) return;
+                if (rawIndex !== undefined) target[key][Number(rawIndex)] = value;
+                else target[key] = value;
+                for (const peer of this.els.inspector.querySelectorAll(`[data-editor-path="${control.dataset.editorPath}"]`)) {
+                    if (peer !== control) peer.value = String(value);
+                }
+                apply();
+            });
+            control.addEventListener("change", () => {
+                if (before) this.history.push("Edit light", before, this._captureEditorSnapshot());
+                before = null;
+                this._commitLighting({ final: true });
+                this._renderObjects();
+                this._syncToolbar();
+            });
+        }
+        for (const control of this.els.inspector.querySelectorAll("[data-light-property]")) {
+            control.addEventListener("pointerdown", begin);
+            control.addEventListener("focus", begin);
+            const applyProperty = () => {
+                const key = control.dataset.lightProperty;
+                const value = control.type === "checkbox" ? control.checked : control.value;
+                const target = currentLight();
+                if (!target) return;
+                if (key === "level_id") {
+                    const previous = this.scene?.levels?.find(level => level.level_id === target.level_id);
+                    const next = this.scene?.levels?.find(level => level.level_id === value);
+                    const delta = (Number(next?.elevation) || 0) - (Number(previous?.elevation) || 0);
+                    target.position[1] += delta;
+                    target.target[1] += delta;
+                    target.level_id = value;
+                } else if (key === "building_id") {
+                    target.building_id = this._validBuildingId(value);
+                    if (target.building_id) this.editorView.active_building_id = target.building_id;
+                } else {
+                    target[key] = value;
+                }
+                if (key === "color") {
+                    control.closest(".vnccs-i3s__lighting-color-control")?.querySelector("output")?.replaceChildren(target.color.toUpperCase());
+                }
+                apply();
+            };
+            control.addEventListener("input", applyProperty);
+            control.addEventListener("change", () => {
+                applyProperty();
+                if (before) this.history.push("Edit light", before, this._captureEditorSnapshot());
+                before = null;
+                this._commitLighting({ final: true });
+                this._renderObjects();
+                this._renderInspector();
+                this._syncToolbar();
+            });
+        }
+        this.els.inspector.querySelector('[data-inspector-action="delete"]')?.addEventListener("click", () => {
+            this._deleteLight(lightId);
+        });
+        this._customSelects?.refresh?.();
     }
 
     _renderGroupInspector(group) {
@@ -4185,7 +4502,7 @@ class Factory3DWidget {
                 ${this._materialControls("ceiling.material_id", item.ceiling?.material_id, "Ceiling material")}
                 <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-architecture-property="visible"${item.visible !== false ? " checked" : ""} /> Room visible</label>
                 <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-architecture-property="locked"${item.locked ? " checked" : ""} /> Lock room</label>
-                <button class="vnccs-i3s__button vnccs-i3s__button--danger" type="button" data-inspector-action="delete">Delete room and perimeter walls</button>`;
+                <button class="vnccs-i3s__button vnccs-i3s__button--danger" type="button" data-inspector-action="delete" title="Delete room (Delete/Backspace)">Delete room and perimeter walls</button>`;
         }
         const ownerBuilding = type === "opening"
             ? this._buildingForItem(this.scene.architecture.walls.find(wall => wall.wall_id === item.wall_id))
@@ -4538,6 +4855,7 @@ class Factory3DWidget {
                     architecture.rooms = architecture.rooms.filter(value => value.room_id !== item.room_id);
                 }
                 this.selectedArchitecture = null;
+                this.selectedArchitectureItems.clear();
                 void this._commitArchitecture();
             });
             if (type === "building") {
@@ -4741,7 +5059,9 @@ class Factory3DWidget {
                 this.editorView.active_building_id = this._validBuildingId(active.building_id);
                 this.selectedCameraKeyframeId = frame.keyframe_id;
                 this.selectedCameraId = "";
+                this.selectedCameraIds.clear();
                 this.selectedArchitecture = null;
+                this.selectedArchitectureItems.clear();
                 this.viewer.setArchitectureSelection(null);
                 this.selectedObjectId = "";
                 this.selectedObjectIds.clear();
@@ -4948,9 +5268,13 @@ class Factory3DWidget {
             this.selectedGroupId = "";
             this.selectedSkydome = false;
             this.selectedArchitecture = null;
+            this.selectedArchitectureItems.clear();
+            this.selectedLightId = "";
+            this.viewer.selectLightMarker("");
             this.viewer.setArchitectureSelection(null);
             this.viewer.select("");
             this.selectedCameraId = cameraId;
+            this.selectedCameraIds = new Set([cameraId]);
         } finally {
             this._cameraSelectionTransition = false;
         }
@@ -5016,6 +5340,7 @@ class Factory3DWidget {
         const before = this._captureEditorSnapshot();
         if (this.previewCameraId === cameraId) this._exitCameraView({ restore: true });
         if (this.selectedCameraId === cameraId) this.selectedCameraId = "";
+        this.selectedCameraIds.delete(cameraId);
         this.scene.cameras = this.scene.cameras.filter(
             item => item.camera_id !== cameraId,
         );
@@ -5033,7 +5358,7 @@ class Factory3DWidget {
     _renderCameras() {
         const cameras = this._normalizeSceneCameras(this.scene?.cameras);
         if (this.scene) this.scene.cameras = cameras;
-        this.viewer?.setCameraMarkers?.(cameras);
+        this.viewer?.setCameraMarkers?.(cameras, this.selectedCameraIds);
         this.els.cameraCount.textContent = String(cameras.length);
         this.els.cameraGroupCount.textContent = String(cameras.length);
         this.els.cameraAdd.disabled = !this.scene || cameras.length >= 32;
@@ -5049,14 +5374,14 @@ class Factory3DWidget {
             const card = element(
                 "div",
                 `vnccs-i3s__camera-item${
-                    camera.camera_id === this.selectedCameraId ? " is-selected" : ""
+                    this.selectedCameraIds.has(camera.camera_id) ? " is-selected" : ""
                 }${camera.camera_id === this.previewCameraId ? " is-previewing" : ""}`,
             );
             card.dataset.cameraId = camera.camera_id;
             card.title = `${camera.name} · ${this.scene?.levels?.find(level => level.level_id === camera.level_id)?.name || "Unassigned floor"}`;
             card.tabIndex = 0;
             card.setAttribute("role", "button");
-            card.setAttribute("aria-pressed", String(camera.camera_id === this.selectedCameraId));
+            card.setAttribute("aria-pressed", String(this.selectedCameraIds.has(camera.camera_id)));
             card.innerHTML = `
                 <span class="vnccs-i3s__camera-index">${index + 1}</span>
                 <span class="vnccs-i3s__camera-item-icon">${ICONS.camera}</span>
@@ -5100,6 +5425,11 @@ class Factory3DWidget {
         const data = { ...DEFAULT_LIGHTING, ...safeObject(value) };
         const shadowSource = { ...DEFAULT_LIGHTING.shadows, ...safeObject(data.shadows) };
         const validColor = color => /^#[0-9a-f]{6}$/i.test(String(color || ""));
+        const requestedNormalBias = Number(shadowSource.normal_bias);
+        const normalBias = !Number.isFinite(requestedNormalBias)
+            || [0.015, 0.02].some(legacy => Math.abs(requestedNormalBias - legacy) < 1e-9)
+            ? DEFAULT_LIGHTING.shadows.normal_bias
+            : requestedNormalBias;
         const lights = (Array.isArray(data.lights) ? data.lights : []).slice(0, 32).map((raw, index) => {
             const light = safeObject(raw);
             const vector = (key, fallback) => Array.isArray(light[key]) && light[key].length === 3
@@ -5145,7 +5475,7 @@ class Factory3DWidget {
                     ? shadowSource.quality
                     : "medium",
                 bias: clamp(shadowSource.bias, -0.05, 0.05),
-                normal_bias: clamp(shadowSource.normal_bias, 0, 1),
+                normal_bias: clamp(normalBias, 0, 1),
             },
             lights,
         };
@@ -5343,6 +5673,89 @@ class Factory3DWidget {
         }
     }
 
+    _selectLight(lightId) {
+        const light = this.lighting?.lights?.find(item => item.light_id === lightId);
+        if (!light) return;
+        this.selectedLightId = light.light_id;
+        this.selectedObjectId = "";
+        this.selectedObjectIds.clear();
+        this.selectedGroupId = "";
+        this.selectedSkydome = false;
+        this.selectedArchitecture = null;
+        this.selectedArchitectureItems.clear();
+        this.selectedCameraId = "";
+        this.selectedCameraIds.clear();
+        this.selectedCameraKeyframeId = "";
+        this.viewer?.select?.("");
+        this.viewer?.setArchitectureSelection?.(null);
+        this.viewer?.selectLightMarker?.(light.light_id);
+        this._renderObjects();
+        this._renderCameras();
+        this._renderInspector();
+        this._syncToolbar();
+        this._setWorkspaceTab("right", "inspector");
+        this._scheduleStateSave(0);
+    }
+
+    _duplicateLight(lightId) {
+        const source = this.lighting?.lights?.find(item => item.light_id === lightId);
+        if (!source || this.lighting.lights.length >= 32) return;
+        const before = this._captureEditorSnapshot();
+        const light = JSON.parse(JSON.stringify(source));
+        light.light_id = factoryId();
+        light.name = `${source.name || "Point light"} copy`;
+        light.position[0] = (Number(light.position[0]) || 0) + 0.5;
+        light.position[2] = (Number(light.position[2]) || 0) + 0.5;
+        light.target[0] = (Number(light.target[0]) || 0) + 0.5;
+        light.target[2] = (Number(light.target[2]) || 0) + 0.5;
+        this.lighting.lights.push(light);
+        this.history.push("Duplicate light", before, this._captureEditorSnapshot());
+        this._commitLighting({ final: true });
+        this._renderObjects();
+        this._updateSceneSummary();
+        this._selectLight(light.light_id);
+    }
+
+    _deleteLight(lightId) {
+        const light = this.lighting?.lights?.find(item => item.light_id === lightId);
+        if (!light) return;
+        const before = this._captureEditorSnapshot();
+        this.lighting.lights = this.lighting.lights.filter(item => item.light_id !== lightId);
+        if (this.selectedLightId === lightId) this.selectedLightId = "";
+        this.viewer?.selectLightMarker?.("");
+        this.history.push("Delete light", before, this._captureEditorSnapshot());
+        this._commitLighting({ final: true });
+        this._renderObjects();
+        this._renderInspector();
+        this._updateSceneSummary();
+        this._syncToolbar();
+        this._scheduleStateSave(0);
+    }
+
+    _onViewerLightTransform(lightId, position, { final = false } = {}) {
+        const light = this.lighting?.lights?.find(item => item.light_id === lightId);
+        if (!light || !Array.isArray(position) || position.length !== 3) return;
+        this._lightTransformHistoryBefore ||= this._captureEditorSnapshot();
+        light.position = position.map(value => Number(value) || 0);
+        this.viewer?.previewLightPosition?.(lightId, light.position);
+        if (!final) {
+            this._scheduleStateSave(100);
+            return;
+        }
+        this._commitLighting({ final: true });
+        if (this._lightTransformHistoryBefore) {
+            this.history.push(
+                "Move light",
+                this._lightTransformHistoryBefore,
+                this._captureEditorSnapshot(),
+            );
+        }
+        this._lightTransformHistoryBefore = null;
+        this._renderObjects();
+        this._renderInspector();
+        this._syncToolbar();
+    }
+
     _syncLighting() {
         this.lighting = this._normalizeLighting(this.lighting);
         this.els.lightIntensity.value = String(this.lighting.intensity);
@@ -5371,118 +5784,7 @@ class Factory3DWidget {
         this.els.shadowQuality.value = this.lighting.shadows.quality === "off"
             ? "medium"
             : this.lighting.shadows.quality;
-        this._renderLocalLights();
         this._drawLightingRadar();
-    }
-
-    _renderLocalLights() {
-        if (!this.els?.localLights) return;
-        this.els.localLights.replaceChildren();
-        if (!this.lighting.lights.length) {
-            this.els.localLights.appendChild(element("div", "vnccs-i3s__local-light-empty", "No local lights."));
-            return;
-        }
-        for (const light of this.lighting.lights) {
-            const card = element("details", "vnccs-i3s__local-light");
-            card.open = light.light_id === this._expandedLightId;
-            card.innerHTML = `
-                <summary><span>${escapeHTML(light.name)}</span><small>${escapeHTML(light.kind)} · ${Number(light.intensity).toFixed(2)}</small></summary>
-                <div class="vnccs-i3s__local-light-body">
-                <div class="vnccs-i3s__local-light-title">
-                    <input class="vnccs-i3s__input" data-light-path="name" value="${escapeHTML(light.name)}" maxlength="80" aria-label="Light name" />
-                    <button type="button" data-light-delete title="Delete light">${ICONS.trash}</button>
-                </div>
-                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Floor level</span><select class="vnccs-i3s__select" data-light-path="level_id">
-                    ${(this.scene?.levels || []).map(level => `<option value="${level.level_id}"${light.level_id === level.level_id ? " selected" : ""}>${escapeHTML(level.name)}</option>`).join("")}
-                </select></label>
-                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Building</span><select class="vnccs-i3s__select" data-light-path="building_id">
-                    ${this._buildingOptions(light.building_id)}
-                </select></label>
-                <div class="vnccs-i3s__local-light-grid">
-                    <select class="vnccs-i3s__select" data-light-path="kind"><option value="point"${light.kind === "point" ? " selected" : ""}>Point</option><option value="spot"${light.kind === "spot" ? " selected" : ""}>Spot</option><option value="directional"${light.kind === "directional" ? " selected" : ""}>Directional</option></select>
-                    <input type="color" data-light-path="color" value="${light.color}" aria-label="Light color" />
-                    <input class="vnccs-i3s__input" type="number" min="0" max="100000" step="0.01" data-light-path="intensity" value="${light.intensity}" aria-label="Light intensity" />
-                    <input class="vnccs-i3s__input" type="number" min="0" max="1000000" step="0.01" data-light-path="distance" value="${light.distance}" aria-label="Light range" />
-                </div>
-                <div class="vnccs-i3s__local-light-position">
-                    ${["X", "Y", "Z"].map((axis, index) => `<label>${axis}<input class="vnccs-i3s__input" type="number" step="0.01" data-light-path="position.${index}" value="${light.position[index]}" /></label>`).join("")}
-                </div>
-                ${light.kind !== "point" ? `
-                    <div class="vnccs-i3s__local-light-position">
-                        ${["TX", "TY", "TZ"].map((axis, index) => `<label>${axis}<input class="vnccs-i3s__input" type="number" step="0.01" data-light-path="target.${index}" value="${light.target[index]}" /></label>`).join("")}
-                    </div>` : ""}
-                ${light.kind === "spot" ? `
-                    <div class="vnccs-i3s__local-light-grid">
-                        <label><span>Angle</span><input class="vnccs-i3s__input" type="number" min="1" max="179" step="0.01" data-light-path="angle" value="${light.angle}" /></label>
-                        <label><span>Penumbra</span><input class="vnccs-i3s__input" type="number" min="0" max="1" step="0.01" data-light-path="penumbra" value="${light.penumbra}" /></label>
-                    </div>` : ""}
-                <div class="vnccs-i3s__local-light-flags">
-                    <label><input type="checkbox" data-light-path="visible"${light.visible !== false ? " checked" : ""} /> Visible</label>
-                    <label><input type="checkbox" data-light-path="cast_shadow"${light.cast_shadow !== false ? " checked" : ""} /> Cast shadow</label>
-                </div></div>`;
-            card.addEventListener("toggle", () => {
-                if (card.open) this._expandedLightId = light.light_id;
-                else if (this._expandedLightId === light.light_id) this._expandedLightId = "";
-            });
-            let before = null;
-            const begin = () => { before ||= this._captureEditorSnapshot(); };
-            for (const control of card.querySelectorAll("[data-light-path]")) {
-                control.addEventListener("pointerdown", begin);
-                control.addEventListener("focus", begin);
-                const apply = () => {
-                    const targetLight = this.lighting.lights.find(
-                        value => value.light_id === light.light_id,
-                    );
-                    if (!targetLight) return;
-                    const [key, rawIndex] = control.dataset.lightPath.split(".");
-                    const value = control.type === "checkbox"
-                        ? control.checked
-                        : control.type === "number"
-                            ? Number(control.value)
-                            : control.value;
-                    if (rawIndex !== undefined) targetLight[key][Number(rawIndex)] = value;
-                    else if (key === "level_id") {
-                        const previousLevel = this.scene?.levels?.find(
-                            level => level.level_id === targetLight.level_id,
-                        );
-                        const nextLevel = this.scene?.levels?.find(
-                            level => level.level_id === value,
-                        );
-                        const delta = (Number(nextLevel?.elevation) || 0)
-                            - (Number(previousLevel?.elevation) || 0);
-                        targetLight.position[1] += delta;
-                        targetLight.target[1] += delta;
-                        targetLight.level_id = value;
-                    } else if (key === "building_id") {
-                        targetLight.building_id = this._validBuildingId(value);
-                        this.editorView.active_building_id = targetLight.building_id;
-                    } else targetLight[key] = value;
-                    if (["name", "kind", "intensity"].includes(key)) {
-                        card.querySelector("summary span").textContent = targetLight.name;
-                        card.querySelector("summary small").textContent = `${targetLight.kind} · ${Number(targetLight.intensity).toFixed(2)}`;
-                    }
-                    this._commitLighting();
-                };
-                control.addEventListener("input", apply);
-                control.addEventListener("change", () => {
-                    apply();
-                    if (before) this.history.push("Edit light", before, this._captureEditorSnapshot());
-                    before = null;
-                    this._commitLighting({ final: true });
-                    this._syncToolbar();
-                    if (["kind", "level_id", "building_id"].includes(control.dataset.lightPath)) this._renderLocalLights();
-                });
-            }
-            card.querySelector("[data-light-delete]").addEventListener("click", () => {
-                const original = this._captureEditorSnapshot();
-                this.lighting.lights = this.lighting.lights.filter(value => value.light_id !== light.light_id);
-                if (original) this.history.push("Delete light", original, this._captureEditorSnapshot());
-                this._syncLighting();
-                this._commitLighting({ final: true });
-                this._syncToolbar();
-            });
-            this.els.localLights.appendChild(card);
-        }
     }
 
     _commitLighting({ final = false } = {}) {
@@ -5831,12 +6133,18 @@ class Factory3DWidget {
         const desiredObjectIds = new Set(this.selectedObjectIds);
         const desiredSkydome = reopeningCurrentScene && this.selectedSkydome;
         const desiredCameraId = this.selectedCameraId;
+        const desiredCameraIds = new Set(this.selectedCameraIds);
+        const desiredLightId = this.selectedLightId;
+        if (desiredCameraId) desiredCameraIds.add(desiredCameraId);
+        const desiredArchitectures = this._selectedArchitectureRefs().map(item => ({ ...item }));
         const desiredArchitecture = this.selectedArchitecture?.id
             ? { ...this.selectedArchitecture }
             : null;
         const desiredKeyframeId = this.selectedCameraKeyframeId;
         this.selectedGroupId = "";
         this.selectedCameraId = "";
+        this.selectedCameraIds.clear();
+        this.selectedLightId = "";
         this.selectedCameraKeyframeId = "";
         this.previewCameraId = "";
         this._cameraReturnState = null;
@@ -5868,6 +6176,7 @@ class Factory3DWidget {
             this.editorView.active_level_id = this.scene.levels[0]?.level_id || "";
         }
         this.selectedArchitecture = null;
+        this.selectedArchitectureItems.clear();
         this.scene.cameras = this._normalizeSceneCameras(scene.cameras);
         for (const camera of this.scene.cameras) {
             if (!this.scene.levels.some(level => level.level_id === camera.level_id)) {
@@ -5935,21 +6244,33 @@ class Factory3DWidget {
         );
         const desiredGroup = this._groupById(desiredGroupId);
         const normalizedDesiredArchitecture = this._normalizeArchitectureSelection(desiredArchitecture);
-        const desiredArchitectureValid = Boolean(normalizedDesiredArchitecture && (
-            (normalizedDesiredArchitecture.type === "building" && this.scene.architecture.buildings.some(item => item.building_id === normalizedDesiredArchitecture.id))
-            || (normalizedDesiredArchitecture.type === "level" && this.scene.levels.some(item => item.level_id === normalizedDesiredArchitecture.id))
-            || (normalizedDesiredArchitecture.type === "wall" && this.scene.architecture.walls.some(item => item.wall_id === normalizedDesiredArchitecture.id))
-            || (normalizedDesiredArchitecture.type === "room" && this.scene.architecture.rooms.some(item => item.room_id === normalizedDesiredArchitecture.id))
-            || (normalizedDesiredArchitecture.type === "opening" && this.scene.architecture.openings.some(item => item.opening_id === normalizedDesiredArchitecture.id))
+        const architectureSelectionValid = selection => Boolean(selection && (
+            (selection.type === "building" && this.scene.architecture.buildings.some(item => item.building_id === selection.id))
+            || (selection.type === "level" && this.scene.levels.some(item => item.level_id === selection.id))
+            || (selection.type === "wall" && this.scene.architecture.walls.some(item => item.wall_id === selection.id))
+            || (selection.type === "room" && this.scene.architecture.rooms.some(item => item.room_id === selection.id))
+            || (selection.type === "opening" && this.scene.architecture.openings.some(item => item.opening_id === selection.id))
         ));
+        const desiredArchitectureValid = architectureSelectionValid(normalizedDesiredArchitecture);
+        const normalizedDesiredArchitectures = desiredArchitectures
+            .map(selection => this._normalizeArchitectureSelection(selection))
+            .filter(architectureSelectionValid);
         const desiredCameraValid = this.scene.cameras.some(
             camera => camera.camera_id === desiredCameraId,
         );
+        const desiredLightValid = this.lighting.lights.some(
+            light => light.light_id === desiredLightId,
+        );
+        const normalizedDesiredCameraIds = new Set(Array.from(desiredCameraIds).filter(
+            cameraId => this.scene.cameras.some(camera => camera.camera_id === cameraId),
+        ));
         const desiredKeyframeTrack = this.scene.camera_tracks.find(
             track => track.keyframes?.some(frame => frame.keyframe_id === desiredKeyframeId),
         );
         if (desiredSkydome && scene.skydome) {
             this._selectSkydome();
+        } else if (desiredLightValid) {
+            this._selectLight(desiredLightId);
         } else if (desiredGroup) {
             this.selectedSkydome = false;
             this.selectedGroupId = desiredGroup.group_id;
@@ -5959,12 +6280,23 @@ class Factory3DWidget {
         } else if (desiredArchitectureValid) {
             this.selectedSkydome = false;
             this.selectedGroupId = "";
-            this.selectedObjectIds.clear();
-            this.selectedObjectId = "";
+            this.selectedObjectIds = new Set(Array.from(desiredObjectIds).filter(
+                objectId => scene.objects?.some(item => item.object_id === objectId),
+            ));
+            this.selectedObjectId = Array.from(this.selectedObjectIds).at(-1) || "";
             this.selectedArchitecture = normalizedDesiredArchitecture;
-            this.viewer.select("");
-            this.viewer.setArchitectureSelection(normalizedDesiredArchitecture);
-        } else if (desiredCameraValid) {
+            this.selectedArchitectureItems = new Map(normalizedDesiredArchitectures.map(selection => [
+                this._architectureSelectionKey(selection),
+                selection,
+            ]));
+            this.selectedCameraIds = normalizedDesiredCameraIds;
+            this.selectedCameraId = Array.from(this.selectedCameraIds).at(-1) || "";
+            this.viewer.select(this.selectedObjectId, { additive: true, emit: false });
+            this.viewer.setArchitectureSelection(
+                normalizedDesiredArchitecture,
+                normalizedDesiredArchitectures,
+            );
+        } else if (desiredCameraValid && !desiredObjectIds.size && !normalizedDesiredArchitectures.length) {
             this._selectCamera(desiredCameraId);
         } else if (desiredKeyframeTrack) {
             this.selectedSkydome = false;
@@ -5991,6 +6323,8 @@ class Factory3DWidget {
                     ? this.selectedObjectId
                     : Array.from(this.selectedObjectIds).at(-1) || ""
             );
+            this.selectedCameraIds = normalizedDesiredCameraIds;
+            this.selectedCameraId = Array.from(this.selectedCameraIds).at(-1) || "";
             this.viewer.select(this.selectedObjectId, {
                 additive: this.selectedObjectIds.size > 1,
             });
@@ -6199,8 +6533,11 @@ class Factory3DWidget {
         const roomCount = rooms.length;
         const skydome = this.scene?.skydome || null;
         const cameraCount = this.scene?.cameras?.length || 0;
+        const lightCount = this.lighting?.lights?.length || 0;
         const visibleIds = this._effectiveVisibleObjectIds();
-        this.els.objectCount.textContent = String(objects.length + (skydome ? 1 : 0) + wallCount + roomCount);
+        this.els.objectCount.textContent = String(
+            objects.length + lightCount + (skydome ? 1 : 0) + wallCount + roomCount,
+        );
         const gaussianSummary = objects.length
             ? `${visibleIds.size}/${objects.length} models visible · ${objects.reduce(
                 (sum, item) => sum + (visibleIds.has(item.object_id) ? Number(item.gaussians) || 0 : 0),
@@ -6215,9 +6552,11 @@ class Factory3DWidget {
         const architectureSummary = wallCount || roomCount
             ? `${contentSummary} · ${wallCount} standalone walls · ${roomCount} rooms`
             : contentSummary;
-        this.els.sceneSummary.textContent = cameraCount
-            ? `${architectureSummary} · ${cameraCount} camera${cameraCount === 1 ? "" : "s"}`
-            : architectureSummary;
+        this.els.sceneSummary.textContent = [
+            architectureSummary,
+            cameraCount ? `${cameraCount} camera${cameraCount === 1 ? "" : "s"}` : "",
+            lightCount ? `${lightCount} light${lightCount === 1 ? "" : "s"}` : "",
+        ].filter(Boolean).join(" · ");
     }
 
     _hasRenderableScene() {
@@ -6238,8 +6577,12 @@ class Factory3DWidget {
         this.selectedObjectIds.clear();
         this.selectedObjectId = "";
         this.selectedArchitecture = null;
+        this.selectedArchitectureItems.clear();
         this.selectedCameraKeyframeId = "";
         this.selectedCameraId = "";
+        this.selectedCameraIds.clear();
+        this.selectedLightId = "";
+        this.viewer.selectLightMarker("");
         this.viewer.setArchitectureSelection(null);
         this.viewer.select("");
         this.selectedSkydome = true;
@@ -6255,10 +6598,14 @@ class Factory3DWidget {
         this.selectedGroupId = "";
         this.selectedSkydome = false;
         this.selectedArchitecture = null;
+        this.selectedArchitectureItems.clear();
         this.selectedCameraId = "";
+        this.selectedCameraIds.clear();
+        this.selectedLightId = "";
         this.selectedCameraKeyframeId = "";
         this.viewer.setArchitectureSelection(null);
         this.viewer.select("");
+        this.viewer.selectLightMarker("");
         this._syncSelectionPresentation();
         this._renderCameras();
         this._renderCameraTracks();
@@ -6273,15 +6620,20 @@ class Factory3DWidget {
             : "";
         if (fromViewer && !valid && !additive) return;
         this.selectedSkydome = false;
+        this.selectedLightId = "";
+        this.viewer.selectLightMarker("");
         const selectedItem = this.scene?.objects?.find(item => item.object_id === valid);
         const selectedBuildingId = this._validBuildingId(selectedItem?.building_id);
         if (selectedBuildingId) this.editorView.active_building_id = selectedBuildingId;
         this.selectedGroupId = "";
-        this.selectedArchitecture = null;
         this.selectedCameraKeyframeId = "";
-        this.selectedCameraId = "";
-        this.viewer.setArchitectureSelection(null);
         if (!additive) {
+            this.selectedCameraId = "";
+            this.selectedCameraIds.clear();
+        }
+        if (!additive) {
+            this.selectedArchitectureItems.clear();
+            this.selectedArchitecture = null;
             this.selectedObjectIds = new Set(valid ? [valid] : []);
         } else if (valid) {
             if (!fromViewer && this.selectedObjectIds.has(valid)) this.selectedObjectIds.delete(valid);
@@ -6291,6 +6643,10 @@ class Factory3DWidget {
             ? valid
             : Array.from(this.selectedObjectIds).at(-1) || "";
         if (!fromViewer) this.viewer.select(this.selectedObjectId, { additive });
+        this.viewer.setArchitectureSelection(
+            this.selectedArchitecture,
+            this._selectedArchitectureRefs(),
+        );
         this._syncSelectionPresentation();
         this._renderInspector();
         this._syncToolbar();
@@ -6302,8 +6658,12 @@ class Factory3DWidget {
         const group = this._groupById(groupId);
         this.selectedSkydome = false;
         this.selectedArchitecture = null;
+        this.selectedArchitectureItems.clear();
         this.selectedCameraKeyframeId = "";
         this.selectedCameraId = "";
+        this.selectedCameraIds.clear();
+        this.selectedLightId = "";
+        this.viewer.selectLightMarker("");
         this.viewer.setArchitectureSelection(null);
         this.selectedGroupId = group?.group_id || "";
         const firstObject = group?.children?.length
@@ -6322,18 +6682,28 @@ class Factory3DWidget {
     }
 
     _syncSelectionControls() {
-        const count = this.selectedObjectIds.size;
-        this.els.groupSelected.disabled = count < 2;
+        const modelCount = this.selectedObjectIds.size;
+        const count = modelCount
+            + this._selectedArchitectureRefs().length
+            + this.selectedCameraIds.size
+            + (this.selectedLightId ? 1 : 0);
+        this.els.groupSelected.disabled = modelCount < 2 || count !== modelCount;
         this.els.selectionCount.textContent = count
             ? `${count} selected`
             : this.selectedSkydome
                 ? "Skydome selected"
             : this.selectedGroupId
                 ? "Group selected"
-                : "Shift-click to select multiple";
+                : this.selectedLightId
+                    ? "Light selected"
+                    : "Shift-click to select multiple";
     }
 
     _syncSelectionPresentation() {
+        this.viewer?.setObjectSelectionHighlights?.(
+            Array.from(this.selectedObjectIds),
+            this.selectedObjectId,
+        );
         for (const card of this.els.objectList.querySelectorAll(".vnccs-i3s__object")) {
             const objectId = card.dataset.objectId || "";
             card.classList.toggle(
@@ -6354,14 +6724,24 @@ class Factory3DWidget {
         const skydomeCard = this.els.objectList.querySelector(".vnccs-i3s__skydome-object");
         skydomeCard?.classList.toggle("is-selected", this.selectedSkydome);
         skydomeCard?.classList.toggle("is-primary", this.selectedSkydome);
+        for (const card of this.els.objectList.querySelectorAll("[data-light-id]")) {
+            const selected = card.dataset.lightId === this.selectedLightId;
+            card.classList.toggle("is-selected", selected);
+            card.classList.toggle("is-primary", selected);
+        }
         this._syncSelectionControls();
     }
 
     _renderObjects() {
+        this.viewer?.setObjectSelectionHighlights?.(
+            Array.from(this.selectedObjectIds),
+            this.selectedObjectId,
+        );
         const previousScrollTop = this.els.objectList.scrollTop;
         const previousScrollLeft = this.els.objectList.scrollLeft;
         const query = this.els.objectSearch.value.trim().toLowerCase();
         const objects = new Map((this.scene?.objects || []).map(item => [item.object_id, item]));
+        const lights = this.lighting?.lights || [];
         const skydome = this.scene?.skydome || null;
         const layers = this._normalizeSceneLayers();
         this.els.objectList.replaceChildren();
@@ -6372,11 +6752,17 @@ class Factory3DWidget {
             fragment.appendChild(entry);
             rendered += 1;
         }
+        for (const light of lights) {
+            const searchable = `${light.name || "Point light"} point light ${light.color || ""}`.toLowerCase();
+            if (query && !searchable.includes(query)) continue;
+            fragment.appendChild(this._createLightCard(light));
+            rendered += 1;
+        }
         if (skydome && (!query || skydome.name.toLowerCase().includes(query) || "skydome background environment".includes(query))) {
             fragment.appendChild(this._createSkydomeCard(skydome));
             rendered += 1;
         }
-        if (!objects.size && !skydome && !rendered) {
+        if (!objects.size && !lights.length && !skydome && !rendered) {
             fragment.appendChild(element("div", "vnccs-i3s__tree-empty", query ? "No matching objects." : "Generated objects will appear here."));
             this.els.objectList.appendChild(fragment);
             return;
@@ -6436,7 +6822,7 @@ class Factory3DWidget {
             const row = element(
                 "button",
                 `vnccs-i3s__architecture-row${
-                    this.selectedArchitecture?.type === type && this.selectedArchitecture?.id === id
+                    this._isArchitectureSelected(type, id)
                         ? " is-selected"
                         : ""
                 }`,
@@ -6447,7 +6833,10 @@ class Factory3DWidget {
             row.innerHTML = `<span class="vnccs-i3s__architecture-kind">${escapeHTML(type.slice(0, 1).toUpperCase())}</span><span class="vnccs-i3s__architecture-copy"><b></b><small></small></span>`;
             row.querySelector("b").textContent = name;
             row.querySelector("small").textContent = meta;
-            row.addEventListener("click", () => this._selectArchitecture({ type, id }));
+            row.addEventListener("click", event => this._selectArchitecture(
+                { type, id },
+                { additive: event.shiftKey },
+            ));
             return row;
         };
         const rootWalls = (architecture.walls || []).filter(
@@ -6538,6 +6927,85 @@ class Factory3DWidget {
             output.push(wrapper);
         }
         return output;
+    }
+
+    _createLightCard(light) {
+        const selected = light.light_id === this.selectedLightId;
+        const card = element(
+            "div",
+            `vnccs-i3s__object vnccs-i3s__light-object`
+                + `${selected ? " is-selected is-primary" : ""}`
+                + `${light.visible === false ? " is-hidden" : ""}`,
+        );
+        card.tabIndex = 0;
+        card.dataset.lightId = light.light_id;
+        const thumbnail = element("span", "vnccs-i3s__object-thumb vnccs-i3s__light-thumb");
+        thumbnail.innerHTML = ICONS.sun;
+        thumbnail.style.color = light.color || "#ffffff";
+        const copy = element("div", "vnccs-i3s__object-copy");
+        copy.append(
+            element("div", "vnccs-i3s__object-name", light.name || "Point light"),
+            element(
+                "div",
+                "vnccs-i3s__object-meta",
+                `Point light · ${Number(light.intensity).toFixed(2)} strength`
+                    + `${light.visible === false ? " · Hidden" : ""}`,
+            ),
+        );
+        const actions = element("div", "vnccs-i3s__object-actions");
+        const visibility = button(
+            "vnccs-i3s__button vnccs-i3s__button--quiet vnccs-i3s__icon-button",
+            "",
+            light.visible === false ? "eyeOff" : "eye",
+        );
+        visibility.title = light.visible === false ? "Show light" : "Hide light";
+        visibility.addEventListener("click", event => {
+            event.stopPropagation();
+            const before = this._captureEditorSnapshot();
+            light.visible = light.visible === false;
+            this.history.push("Toggle light visibility", before, this._captureEditorSnapshot());
+            this._commitLighting({ final: true });
+            this._renderObjects();
+            this._renderInspector();
+            this._updateSceneSummary();
+        });
+        const duplicate = button(
+            "vnccs-i3s__button vnccs-i3s__button--quiet vnccs-i3s__icon-button",
+            "",
+            "duplicate",
+        );
+        duplicate.title = "Duplicate light";
+        duplicate.addEventListener("click", event => {
+            event.stopPropagation();
+            this._duplicateLight(light.light_id);
+        });
+        const remove = button(
+            "vnccs-i3s__button vnccs-i3s__button--quiet vnccs-i3s__button--danger vnccs-i3s__icon-button",
+            "",
+            "trash",
+        );
+        remove.title = "Delete light";
+        remove.addEventListener("click", event => {
+            event.stopPropagation();
+            this._deleteLight(light.light_id);
+        });
+        for (const control of [visibility, duplicate, remove]) {
+            control.setAttribute("aria-label", control.title);
+            control.addEventListener("dblclick", event => event.stopPropagation());
+        }
+        actions.append(visibility, duplicate, remove);
+        card.append(thumbnail, copy, actions);
+        const select = () => this._selectLight(light.light_id);
+        card.addEventListener("click", event => {
+            if (!event.target.closest("button,input")) select();
+        });
+        card.addEventListener("keydown", event => {
+            if (event.target === card && (event.key === "Enter" || event.key === " ")) {
+                event.preventDefault();
+                select();
+            }
+        });
+        return card;
     }
 
     _createSkydomeCard(skydome) {
@@ -7757,6 +8225,332 @@ class Factory3DWidget {
             this._showError("Object export failed", error);
         } finally {
             if (control) control.disabled = false;
+        }
+    }
+
+    _copySelection() {
+        if (!this.scene) return;
+        const clone = value => JSON.parse(JSON.stringify(value));
+        const objectIds = new Set(this.selectedObjectIds);
+        const selectedGroup = this._groupById(this.selectedGroupId);
+        for (const objectId of selectedGroup?.children || []) objectIds.add(objectId);
+        const architecture = this.scene.architecture || {};
+        const buildings = new Map();
+        const rooms = new Map();
+        const walls = new Map();
+        const openings = new Map();
+        const addWall = wall => {
+            if (!wall || walls.has(wall.wall_id)) return;
+            walls.set(wall.wall_id, clone(wall));
+            for (const opening of architecture.openings || []) {
+                if (opening.wall_id === wall.wall_id) openings.set(opening.opening_id, clone(opening));
+            }
+        };
+        const addRoom = room => {
+            if (!room || rooms.has(room.room_id)) return;
+            rooms.set(room.room_id, clone(room));
+            for (const wallId of room.wall_ids || []) {
+                addWall(architecture.walls?.find(wall => wall.wall_id === wallId));
+            }
+        };
+        const architectureSelection = this._selectedArchitectureRefs();
+        for (const selection of architectureSelection) {
+            if (selection.type === "building") {
+                const building = architecture.buildings?.find(item => item.building_id === selection.id);
+                if (!building) continue;
+                buildings.set(building.building_id, clone(building));
+                for (const room of architecture.rooms || []) {
+                    if (room.building_id === building.building_id) addRoom(room);
+                }
+                for (const wall of architecture.walls || []) {
+                    if (wall.building_id === building.building_id) addWall(wall);
+                }
+            } else if (selection.type === "room") {
+                addRoom(architecture.rooms?.find(item => item.room_id === selection.id));
+            } else if (selection.type === "wall") {
+                addWall(architecture.walls?.find(item => item.wall_id === selection.id));
+            } else if (selection.type === "opening") {
+                const opening = architecture.openings?.find(item => item.opening_id === selection.id);
+                if (opening) openings.set(opening.opening_id, clone(opening));
+            }
+        }
+        const objects = (this.scene.objects || [])
+            .filter(item => objectIds.has(item.object_id))
+            .map(item => ({
+                object_id: item.object_id,
+                name: item.name,
+                level_id: item.level_id,
+                building_id: item.building_id,
+                transform: clone(item.transform || {
+                    position: [0, 0, 0],
+                    rotation: [0, 0, 0],
+                    scale: 1,
+                }),
+            }));
+        const cameraIds = this.selectedCameraIds.size
+            ? this.selectedCameraIds
+            : new Set(this.selectedCameraId ? [this.selectedCameraId] : []);
+        const cameras = (this.scene.cameras || [])
+            .filter(item => cameraIds.has(item.camera_id))
+            .map(clone);
+        const lights = (this.lighting?.lights || [])
+            .filter(item => item.light_id === this.selectedLightId)
+            .map(clone);
+        const total = objects.length + architectureSelection.length + cameras.length + lights.length;
+        if (!total) {
+            this.toast("Select at least one scene object to copy.", "info");
+            return;
+        }
+        this.selectionClipboard = {
+            scene_id: this.sceneId,
+            paste_count: 0,
+            objects,
+            buildings: Array.from(buildings.values()),
+            rooms: Array.from(rooms.values()),
+            walls: Array.from(walls.values()),
+            openings: Array.from(openings.values()),
+            cameras,
+            lights,
+            architecture_selection: clone(architectureSelection),
+        };
+        this._syncToolbar();
+        this.toast(`${total} scene object${total === 1 ? "" : "s"} copied.`, "success");
+    }
+
+    async _pasteSelection() {
+        const clipboard = this.selectionClipboard;
+        if (!this.scene || !clipboard) return;
+        if (clipboard.scene_id !== this.sceneId) {
+            this.toast("The Factory clipboard currently belongs to another scene.", "error");
+            return;
+        }
+        const plannedWalls = clipboard.walls?.length || 0;
+        const plannedRooms = clipboard.rooms?.length || 0;
+        const plannedOpenings = clipboard.openings?.length || 0;
+        const plannedCameras = clipboard.cameras?.length || 0;
+        const plannedLights = clipboard.lights?.length || 0;
+        if ((this.scene.architecture?.walls?.length || 0) + plannedWalls > 4096) {
+            this.toast("There is not enough room in the scene wall limit for this paste.", "error");
+            return;
+        }
+        if ((this.scene.architecture?.rooms?.length || 0) + plannedRooms > 1024) {
+            this.toast("There is not enough room in the scene room limit for this paste.", "error");
+            return;
+        }
+        if ((this.scene.architecture?.openings?.length || 0) + plannedOpenings > 4096) {
+            this.toast("There is not enough room in the scene opening limit for this paste.", "error");
+            return;
+        }
+        if ((this.scene.cameras?.length || 0) + plannedCameras > 32) {
+            this.toast("There is not enough room in the 32-camera limit for this paste.", "error");
+            return;
+        }
+        if ((this.lighting?.lights?.length || 0) + plannedLights > 32) {
+            this.toast("There is not enough room in the 32-light limit for this paste.", "error");
+            return;
+        }
+        const pasteIndex = Math.max(1, Number(clipboard.paste_count) + 1);
+        clipboard.paste_count = pasteIndex;
+        const step = Math.max(0.5, Number(this.editorView.plan_grid?.step) || 0.1);
+        const offset = step * pasteIndex;
+        const pastedObjectIds = [];
+        const pastedObjectSources = [];
+        this.els.selectionPaste.disabled = true;
+        this._setStatus("Pasting selection", "working");
+        try {
+            for (const source of clipboard.objects || []) {
+                const result = await this._fetchJSON(
+                    `${ENDPOINTS.scene(this.sceneId)}/objects/${encodeURIComponent(source.object_id)}/duplicate`,
+                    { method: "POST" },
+                );
+                await this._applyScene(result.scene, { preserveSource: true });
+                const pasted = this.scene.objects?.find(item => item.object_id === result.object_id);
+                if (!pasted) continue;
+                pastedObjectIds.push(pasted.object_id);
+                pastedObjectSources.push({ object_id: pasted.object_id, source });
+            }
+            for (const entry of pastedObjectSources) {
+                const pasted = this.scene.objects?.find(item => item.object_id === entry.object_id);
+                if (!pasted) continue;
+                pasted.transform = JSON.parse(JSON.stringify(entry.source.transform));
+                pasted.transform.position = Array.isArray(pasted.transform?.position)
+                    ? [...pasted.transform.position]
+                    : [0, 0, 0];
+                pasted.transform.position[0] += offset;
+                pasted.transform.position[2] += offset;
+                pasted.level_id = entry.source.level_id;
+                pasted.building_id = this._validBuildingId(entry.source.building_id);
+                this.viewer.updateObject(pasted.object_id, pasted);
+            }
+
+            const beforeArchitecture = this._captureEditorSnapshot();
+            const buildingIds = new Map();
+            const wallIds = new Map();
+            const roomIds = new Map();
+            const openingIds = new Map();
+            for (const source of clipboard.buildings || []) buildingIds.set(source.building_id, factoryId());
+            for (const source of clipboard.walls || []) wallIds.set(source.wall_id, factoryId());
+            for (const source of clipboard.rooms || []) roomIds.set(source.room_id, factoryId());
+            for (const source of clipboard.openings || []) openingIds.set(source.opening_id, factoryId());
+            for (const source of clipboard.buildings || []) {
+                this.scene.architecture.buildings.push({
+                    ...JSON.parse(JSON.stringify(source)),
+                    building_id: buildingIds.get(source.building_id),
+                    name: `${source.name || "Building"} copy`,
+                    position: [
+                        (Number(source.position?.[0]) || 0) + offset,
+                        Number(source.position?.[1]) || 0,
+                        (Number(source.position?.[2]) || 0) + offset,
+                    ],
+                });
+            }
+            for (const source of clipboard.walls || []) {
+                const buildingCopied = buildingIds.has(source.building_id);
+                const shift = buildingCopied ? 0 : offset;
+                this.scene.architecture.walls.push({
+                    ...JSON.parse(JSON.stringify(source)),
+                    wall_id: wallIds.get(source.wall_id),
+                    building_id: buildingIds.get(source.building_id) || source.building_id || "",
+                    name: `${source.name || "Wall"} copy`,
+                    start: [source.start[0] + shift, source.start[1] + shift],
+                    end: [source.end[0] + shift, source.end[1] + shift],
+                });
+            }
+            for (const source of clipboard.rooms || []) {
+                const buildingCopied = buildingIds.has(source.building_id);
+                const shift = buildingCopied ? 0 : offset;
+                this.scene.architecture.rooms.push({
+                    ...JSON.parse(JSON.stringify(source)),
+                    room_id: roomIds.get(source.room_id),
+                    building_id: buildingIds.get(source.building_id) || source.building_id || "",
+                    name: `${source.name || "Room"} copy`,
+                    wall_ids: (source.wall_ids || []).map(id => wallIds.get(id) || id),
+                    polygon: (source.polygon || []).map(point => [point[0] + shift, point[1] + shift]),
+                });
+            }
+            for (const source of clipboard.openings || []) {
+                const pastedWallId = wallIds.get(source.wall_id);
+                const opening = {
+                    ...JSON.parse(JSON.stringify(source)),
+                    opening_id: openingIds.get(source.opening_id),
+                    wall_id: pastedWallId || source.wall_id,
+                    name: `${source.name || "Opening"} copy`,
+                };
+                if (!pastedWallId) {
+                    const wall = this.scene.architecture.walls?.find(item => item.wall_id === source.wall_id);
+                    const length = wall ? Math.hypot(wall.end[0] - wall.start[0], wall.end[1] - wall.start[1]) : 0;
+                    const fitted = length > 0.001
+                        ? this._fitOpeningOnWall(
+                            wall,
+                            Math.min(0.99, Number(opening.offset) + offset / length),
+                            opening.width,
+                            opening.opening_id,
+                        )
+                        : null;
+                    if (!fitted) {
+                        openingIds.delete(source.opening_id);
+                        continue;
+                    }
+                    opening.offset = fitted.offset;
+                    opening.width = fitted.width;
+                }
+                this.scene.architecture.openings.push(opening);
+            }
+            const pastedCameraIds = [];
+            for (const source of clipboard.cameras || []) {
+                const camera = {
+                    ...JSON.parse(JSON.stringify(source)),
+                    camera_id: factoryId(),
+                    name: `${source.name || "Camera"} copy`,
+                    created_at: Date.now() / 1000,
+                    building_id: buildingIds.get(source.building_id) || source.building_id || "",
+                    position: [source.position[0] + offset, source.position[1], source.position[2] + offset],
+                    target: [source.target[0] + offset, source.target[1], source.target[2] + offset],
+                };
+                this.scene.cameras.push(camera);
+                pastedCameraIds.push(camera.camera_id);
+            }
+            const pastedLightIds = [];
+            for (const source of clipboard.lights || []) {
+                const light = {
+                    ...JSON.parse(JSON.stringify(source)),
+                    light_id: factoryId(),
+                    name: `${source.name || "Point light"} copy`,
+                    building_id: buildingIds.get(source.building_id) || source.building_id || "",
+                    position: [source.position[0] + offset, source.position[1], source.position[2] + offset],
+                    target: [source.target[0] + offset, source.target[1], source.target[2] + offset],
+                };
+                this.lighting.lights.push(light);
+                pastedLightIds.push(light.light_id);
+            }
+
+            const pastedArchitecture = [];
+            for (const selection of clipboard.architecture_selection || []) {
+                const id = selection.type === "building"
+                    ? buildingIds.get(selection.id)
+                    : selection.type === "room"
+                        ? roomIds.get(selection.id)
+                        : selection.type === "wall"
+                            ? wallIds.get(selection.id)
+                            : selection.type === "opening"
+                                ? openingIds.get(selection.id)
+                                : null;
+                if (id) pastedArchitecture.push({ type: selection.type, id });
+            }
+            const architectureAdded = buildingIds.size
+                + roomIds.size
+                + wallIds.size
+                + openingIds.size;
+            if (!architectureAdded && !pastedCameraIds.length && !pastedLightIds.length && !pastedObjectIds.length) {
+                this._setStatus("Nothing pasted", "idle");
+                this.toast("The copied selection could not be placed in the current scene.", "info");
+                return;
+            }
+            if (pastedLightIds.length) this._commitLighting({ final: true });
+            if (architectureAdded) {
+                this.history.push("Paste architecture", beforeArchitecture, this._captureEditorSnapshot());
+                await this._commitArchitecture();
+            } else if (pastedCameraIds.length || pastedLightIds.length || pastedObjectIds.length) {
+                this.history.push("Paste selection", beforeArchitecture, this._captureEditorSnapshot());
+                this.viewer.setCameraMarkers(this.scene.cameras || []);
+                await this._saveSceneNow({ showError: false });
+            }
+            this.selectedObjectIds = new Set(pastedObjectIds);
+            this.selectedObjectId = pastedObjectIds.at(-1) || "";
+            this.selectedArchitectureItems = new Map(pastedArchitecture.map(item => [
+                this._architectureSelectionKey(item),
+                item,
+            ]));
+            this.selectedArchitecture = pastedArchitecture.at(-1) || null;
+            this.selectedCameraId = !pastedObjectIds.length && !pastedArchitecture.length
+                ? pastedCameraIds.at(-1) || ""
+                : "";
+            this.selectedCameraIds = new Set(pastedCameraIds);
+            this.selectedLightId = !pastedObjectIds.length && !pastedArchitecture.length && !pastedCameraIds.length
+                ? pastedLightIds.at(-1) || ""
+                : "";
+            this.selectedGroupId = "";
+            this.selectedSkydome = false;
+            this.viewer.select(this.selectedObjectId, { additive: true, emit: false });
+            this.viewer.setArchitectureSelection(
+                this.selectedArchitecture,
+                this._selectedArchitectureRefs(),
+            );
+            this.viewer.selectLightMarker(this.selectedLightId);
+            this._renderObjects();
+            this._renderCameras();
+            this._renderInspector();
+            this._syncToolbar();
+            this._scheduleSceneSave(0);
+            this._scheduleStateSave(0);
+            const pastedCount = pastedObjectIds.length + pastedArchitecture.length + pastedCameraIds.length + pastedLightIds.length;
+            this._setStatus("Selection pasted", "success");
+            this.toast(`${pastedCount} object${pastedCount === 1 ? "" : "s"} pasted.`, "success");
+        } catch (error) {
+            this._setStatus("Paste failed", "error");
+            this._showError("Selection paste failed", error);
+        } finally {
+            this._syncToolbar();
         }
     }
 
@@ -9493,11 +10287,18 @@ class Factory3DWidget {
         this._syncViewportCameraHUD();
         this.els.view3d.setAttribute("aria-pressed", String(!plan));
         this.els.viewPlan.setAttribute("aria-pressed", String(plan));
+        const cutawayKey = plan ? "plan" : "three_d";
+        const cutawayEnabled = Boolean(this.editorView.interior_cutaway?.[cutawayKey]);
+        this.els.cutaway.setAttribute("aria-pressed", String(cutawayEnabled));
+        this.els.cutaway.title = cutawayEnabled
+            ? "Disable cutaway and show complete architecture in this viewport mode"
+            : "Interior cutaway (viewport only): hide ceilings and the nearest blocking wall";
+        this.viewer?.setInteriorCutaway?.(cutawayEnabled);
         this.els.planTools.hidden = !plan;
         this.els.openingKindShortcut.hidden = !plan || this.editorView.plan_tool !== "opening";
         this.els.modeMove.disabled = plan && this.editorView.plan_tool !== "select";
-        this.els.modeRotate.disabled = plan;
-        this.els.modeScale.disabled = plan;
+        this.els.modeRotate.disabled = plan || Boolean(this.selectedLightId);
+        this.els.modeScale.disabled = plan || Boolean(this.selectedLightId);
         const planToolTitles = {
             select: "Select and edit architecture",
             wall: "Press and drag to draw a wall",
@@ -9514,7 +10315,7 @@ class Factory3DWidget {
             );
         }
         const planHints = {
-            select: "Click to select · Drag wall points",
+            select: "Click an object · Drag empty space for box selection",
             wall: "Press and drag to draw a wall",
             room: "Press and drag diagonally to draw a room",
             opening: "Press on a wall and drag to set width",
@@ -9600,6 +10401,17 @@ class Factory3DWidget {
         this.els.levelAdd.disabled = !this.scene || levels.length >= 64;
         if (this.els.undo) this.els.undo.disabled = !this.history.canUndo;
         if (this.els.redo) this.els.redo.disabled = !this.history.canRedo;
+        if (this.els.selectionCopy) {
+            const copyableCount = this.selectedObjectIds.size
+                + this._selectedArchitectureRefs().length
+                + (this.selectedGroupId ? 1 : 0)
+                + this.selectedCameraIds.size
+                + (this.selectedLightId ? 1 : 0);
+            this.els.selectionCopy.disabled = !this.scene || copyableCount === 0;
+        }
+        if (this.els.selectionPaste) {
+            this.els.selectionPaste.disabled = !this.scene || !this.selectionClipboard;
+        }
     }
 
     serializeState() {
@@ -9611,7 +10423,10 @@ class Factory3DWidget {
             selected_group_id: this.selectedGroupId,
             selected_skydome: this.selectedSkydome,
             selected_architecture: this.selectedArchitecture,
+            selected_architectures: this._selectedArchitectureRefs(),
             selected_camera_id: this.selectedCameraId,
+            selected_camera_ids: Array.from(this.selectedCameraIds),
+            selected_light_id: this.selectedLightId,
             collapsed_group_ids: Array.from(this.collapsedGroupIds),
             settings: { ...this.settings },
             render_settings: { ...this.exportSettings },
@@ -9672,7 +10487,30 @@ class Factory3DWidget {
             if (!this.selectedArchitecture.type || !this.selectedArchitecture.id) {
                 this.selectedArchitecture = null;
             }
+            const savedArchitectureSelections = Array.isArray(state.selected_architectures)
+                ? state.selected_architectures
+                : this.selectedArchitecture
+                    ? [this.selectedArchitecture]
+                    : [];
+            this.selectedArchitectureItems = new Map(savedArchitectureSelections
+                .map(selection => this._normalizeArchitectureSelection(selection))
+                .filter(selection => selection?.id)
+                .map(selection => [this._architectureSelectionKey(selection), selection]));
+            this.selectedArchitecture = this.selectedArchitectureItems.has(
+                this._architectureSelectionKey(this.selectedArchitecture),
+            )
+                ? this.selectedArchitecture
+                : Array.from(this.selectedArchitectureItems.values()).at(-1) || null;
             this.selectedCameraId = String(state.selected_camera_id || "");
+            this.selectedCameraIds = new Set(
+                Array.isArray(state.selected_camera_ids)
+                    ? state.selected_camera_ids.map(String)
+                    : this.selectedCameraId
+                        ? [this.selectedCameraId]
+                        : [],
+            );
+            if (this.selectedCameraId) this.selectedCameraIds.add(this.selectedCameraId);
+            this.selectedLightId = String(state.selected_light_id || "");
             this.collapsedGroupIds = new Set(
                 Array.isArray(state.collapsed_group_ids)
                     ? state.collapsed_group_ids.map(String)

--- a/web/vnccs_3d_factory.js
+++ b/web/vnccs_3d_factory.js
@@ -3069,7 +3069,7 @@ class Factory3DWidget {
         }
     }
 
-    _previewSelectedArchitecture() {
+    _previewSelectedArchitecture({ persist = true } = {}) {
         if (!this.selectedArchitecture?.id || !this.scene) return;
         const type = ["floor", "ceiling"].includes(this.selectedArchitecture.type)
             ? "room"
@@ -3095,23 +3095,25 @@ class Factory3DWidget {
             }
         }
         this.viewer.setCameraMarkers(this.scene.cameras || []);
-        this._scheduleSceneSave(220);
-        this._scheduleStateSave(220);
+        if (persist) {
+            this._scheduleSceneSave(220);
+            this._scheduleStateSave(220);
+        }
     }
 
-    _queueSelectedArchitecturePreview({ flush = false } = {}) {
+    _queueSelectedArchitecturePreview({ flush = false, persist = true } = {}) {
         if (flush && this._architectureGeometryFrame) {
             cancelAnimationFrame(this._architectureGeometryFrame);
             this._architectureGeometryFrame = 0;
         }
         if (flush) {
-            this._previewSelectedArchitecture();
+            this._previewSelectedArchitecture({ persist });
             return;
         }
         if (this._architectureGeometryFrame) return;
         this._architectureGeometryFrame = requestAnimationFrame(() => {
             this._architectureGeometryFrame = 0;
-            this._previewSelectedArchitecture();
+            this._previewSelectedArchitecture({ persist });
         });
     }
 
@@ -3181,6 +3183,26 @@ class Factory3DWidget {
         if (change.type === "room") {
             const room = this.scene?.architecture?.rooms?.find(item => item.room_id === change.id);
             const linkedWalls = new Set(room?.wall_ids || []);
+            const phase = ["start", "move", "end", "cancel"].includes(change.phase)
+                ? change.phase
+                : "end";
+            const activeDrag = this._roomPlanDrag?.id === change.id
+                ? this._roomPlanDrag
+                : null;
+            if (phase === "cancel") {
+                if (room && activeDrag) {
+                    room.polygon = activeDrag.polygon.map(point => [...point]);
+                    for (const original of activeDrag.walls) {
+                        const wall = this.scene.architecture.walls?.find(item => item.wall_id === original.wall_id);
+                        if (!wall) continue;
+                        wall.start = [...original.start];
+                        wall.end = [...original.end];
+                    }
+                    this._roomPlanDrag = null;
+                    this._queueSelectedArchitecturePreview({ flush: true, persist: false });
+                }
+                return;
+            }
             if (
                 !room?.polygon?.length
                 || room.locked
@@ -3188,6 +3210,26 @@ class Factory3DWidget {
             ) return this.viewer.setArchitectureSelection(this.selectedArchitecture);
             const building = this._buildingForItem(room);
             if (building?.locked) return this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            if (phase === "start") {
+                if (this._architectureGeometryFrame) {
+                    cancelAnimationFrame(this._architectureGeometryFrame);
+                    this._architectureGeometryFrame = 0;
+                }
+                this._roomPlanDrag = {
+                    id: room.room_id,
+                    before: this._captureEditorSnapshot(),
+                    polygon: room.polygon.map(point => [...point]),
+                    walls: (this.scene.architecture.walls || [])
+                        .filter(wall => linkedWalls.has(wall.wall_id))
+                        .map(wall => ({
+                            wall_id: wall.wall_id,
+                            start: [...wall.start],
+                            end: [...wall.end],
+                        })),
+                };
+                return;
+            }
+            if (!Array.isArray(change.point)) return;
             const localPoint = this._worldToLocalPlan(
                 this._snapPlanPoint(change.point, change.event || {}),
                 building,
@@ -3197,7 +3239,7 @@ class Factory3DWidget {
                 [0, 0],
             ).map(value => value / room.polygon.length);
             const delta = [localPoint[0] - center[0], localPoint[1] - center[1]];
-            const before = this._captureEditorSnapshot();
+            const before = activeDrag?.before || this._captureEditorSnapshot();
             room.polygon = room.polygon.map(point => [point[0] + delta[0], point[1] + delta[1]]);
             const linked = new Set(room.wall_ids || []);
             for (const wall of this.scene.architecture.walls || []) {
@@ -3205,6 +3247,12 @@ class Factory3DWidget {
                 wall.start = [wall.start[0] + delta[0], wall.start[1] + delta[1]];
                 wall.end = [wall.end[0] + delta[0], wall.end[1] + delta[1]];
             }
+            if (phase === "move") {
+                this._queueSelectedArchitecturePreview({ persist: false });
+                return;
+            }
+            this._roomPlanDrag = null;
+            this._queueSelectedArchitecturePreview({ flush: true, persist: false });
             this.history.push("Move room", before, this._captureEditorSnapshot());
             void this._commitArchitecture();
             return;

--- a/web/vnccs_3d_factory.js
+++ b/web/vnccs_3d_factory.js
@@ -7501,6 +7501,17 @@ class Factory3DWidget {
     _onViewerTransform(objectId, transform, options = {}) {
         const item = this.scene?.objects?.find(value => value.object_id === objectId);
         if (!item) return;
+        if (options.cancelled) {
+            item.transform = transform;
+            if (options.command_last !== false) {
+                this._viewerTransformHistoryBefore = null;
+                this._renderInspector();
+            }
+            this._scheduleSceneSave(0);
+            this._scheduleStateSave(0);
+            this._scheduleScenePreview(120);
+            return;
+        }
         if (!this._suppressViewerTransformHistory && !this._viewerTransformHistoryBefore) {
             this._viewerTransformHistoryBefore = this._captureEditorSnapshot();
             for (const [previousId, previousTransform] of Object.entries(options.previous_transforms || {})) {

--- a/web/vnccs_3d_factory.js
+++ b/web/vnccs_3d_factory.js
@@ -447,7 +447,7 @@ class Factory3DWidget {
         this.settings = { ...DEFAULT_SETTINGS };
         this.exportSettings = { ...DEFAULT_EXPORT_SETTINGS };
         this.lighting = { ...DEFAULT_LIGHTING };
-        this.viewerState = { mode: "translate", grid: false };
+        this.viewerState = { mode: "translate", grid: false, zoom_sensitivity: 0.1 };
         this.capabilities = null;
         this.currentJobId = "";
         this.currentJobToken = 0;
@@ -535,6 +535,8 @@ class Factory3DWidget {
                     previousState.camera || {},
                     state.camera || {},
                 );
+                const zoomSensitivityChanged = previousState.zoom_sensitivity
+                    !== state.zoom_sensitivity;
                 const toolbarChanged = previousState.mode !== state.mode
                     || previousState.grid !== state.grid
                     || previousState.view_mode !== state.view_mode
@@ -542,7 +544,7 @@ class Factory3DWidget {
                     || previousState.active_level_id !== state.active_level_id;
                 this.viewerState = { ...this.viewerState, ...state };
                 if (toolbarChanged) this._syncToolbar();
-                if (cameraChanged) this._syncViewportCameraHUD(state.camera);
+                if (zoomSensitivityChanged) this._syncCameraPanelControls();
                 this._scheduleStateSave();
                 if (
                     cameraChanged
@@ -716,6 +718,19 @@ class Factory3DWidget {
                             <span class="vnccs-i3s__camera-look-reticle" aria-hidden="true"></span>
                         </div>
                         <div class="vnccs-i3s__camera-help">Drag to look</div>
+                        <label class="vnccs-i3s__field vnccs-i3s__camera-zoom-speed">
+                            <span class="vnccs-i3s__label"><span>Wheel zoom speed</span><output class="vnccs-i3s__camera-zoom-speed-value">0.10×</output></span>
+                            <input class="vnccs-i3s__range vnccs-i3s__camera-zoom-speed-range" type="range" min="-2" max="0.30103" step="0.01" value="-1" aria-label="Mouse wheel zoom speed" aria-valuetext="0.10×" />
+                        </label>
+                        <div class="vnccs-i3s__camera-view-presets">
+                            <span class="vnccs-i3s__label">View projection</span>
+                            <div class="vnccs-i3s__camera-view-preset-grid" role="group" aria-label="Camera view projections">
+                                <button class="vnccs-i3s__button" type="button" data-camera-preset="perspective">Perspective</button>
+                                <button class="vnccs-i3s__button" type="button" data-camera-preset="front">Front</button>
+                                <button class="vnccs-i3s__button" type="button" data-camera-preset="right">Right</button>
+                                <button class="vnccs-i3s__button" type="button" data-camera-preset="top">Top</button>
+                            </div>
+                        </div>
                         <button class="vnccs-i3s__button vnccs-i3s__button--primary vnccs-i3s__button--block vnccs-i3s__camera-add" type="button">
                             ${ICONS.cameraAdd}<span>Add camera</span>
                         </button>
@@ -824,73 +839,6 @@ class Factory3DWidget {
                         </details>
                         <span class="vnccs-i3s__plan-hint">Choose a tool, then press and drag in the plan.</span>
                     </div>
-                    <details class="vnccs-i3s__viewport-camera" open>
-                        <summary>
-                            <span>${ICONS.camera}<b>View camera</b></span>
-                            <output class="vnccs-i3s__viewport-camera-summary">Perspective</output>
-                        </summary>
-                        <div class="vnccs-i3s__viewport-camera-body">
-                            <div class="vnccs-i3s__viewport-camera-actions">
-                                <button type="button" data-camera-action="home" title="Restore a stable perspective and frame the complete scene">Reset view</button>
-                                <button type="button" data-camera-action="scene" title="Center and frame the complete scene">Frame scene</button>
-                                <button type="button" data-camera-action="selection" title="Center and frame the current selection">Selection</button>
-                            </div>
-                            <div class="vnccs-i3s__viewport-camera-presets" role="group" aria-label="Camera view presets">
-                                <button type="button" data-camera-preset="perspective">Perspective</button>
-                                <button type="button" data-camera-preset="front">Front</button>
-                                <button type="button" data-camera-preset="right">Right</button>
-                                <button type="button" data-camera-preset="top">Top</button>
-                            </div>
-                            <div class="vnccs-i3s__viewport-camera-navigation">
-                                <div>
-                                    <span class="vnccs-i3s__viewport-camera-label">Look</span>
-                                    <div class="vnccs-i3s__camera-orbit-pad" role="group" aria-label="Turn view camera in place">
-                                        <button type="button" data-camera-orbit="up" aria-label="Look upward" title="Look upward">↑</button>
-                                        <button type="button" data-camera-orbit="left" aria-label="Look left" title="Look left">←</button>
-                                        <span aria-hidden="true">●</span>
-                                        <button type="button" data-camera-orbit="right" aria-label="Look right" title="Look right">→</button>
-                                        <button type="button" data-camera-orbit="down" aria-label="Look downward" title="Look downward">↓</button>
-                                    </div>
-                                </div>
-                                <div>
-                                    <span class="vnccs-i3s__viewport-camera-label">Move</span>
-                                    <div class="vnccs-i3s__camera-pan-pad" role="group" aria-label="Move view camera and target">
-                                        <button type="button" data-camera-pan="forward" aria-label="Move forward" title="Move forward">↑</button>
-                                        <button type="button" data-camera-pan="left" aria-label="Move left" title="Move left">←</button>
-                                        <span aria-hidden="true">●</span>
-                                        <button type="button" data-camera-pan="right" aria-label="Move right" title="Move right">→</button>
-                                        <button type="button" data-camera-pan="back" aria-label="Move backward" title="Move backward">↓</button>
-                                    </div>
-                                </div>
-                                <div class="vnccs-i3s__viewport-camera-sliders">
-                                    <label>
-                                        <span>Distance</span>
-                                        <div><input class="vnccs-i3s__camera-distance-range" type="range" min="-4" max="6" step="0.002" aria-label="Camera distance" /><input class="vnccs-i3s__camera-distance-input" type="number" min="0.0001" max="1000000" step="0.01" inputmode="decimal" aria-label="Camera distance in meters" /><small>m</small></div>
-                                    </label>
-                                    <label>
-                                        <span>Height</span>
-                                        <div><input class="vnccs-i3s__camera-height-range" type="range" min="-50" max="100" step="0.01" aria-label="Camera height" /><input class="vnccs-i3s__camera-height-input" type="number" min="-1000000" max="1000000" step="0.01" inputmode="decimal" aria-label="Camera height in meters" /><small>m</small></div>
-                                    </label>
-                                </div>
-                            </div>
-                            <details class="vnccs-i3s__viewport-camera-exact">
-                                <summary>Exact coordinates</summary>
-                                <div class="vnccs-i3s__viewport-camera-vector">
-                                    <span>Position</span>
-                                    <label>X<input type="number" step="0.01" data-camera-vector="position" data-camera-axis="0" /></label>
-                                    <label>Y<input type="number" step="0.01" data-camera-vector="position" data-camera-axis="1" /></label>
-                                    <label>Z<input type="number" step="0.01" data-camera-vector="position" data-camera-axis="2" /></label>
-                                </div>
-                                <div class="vnccs-i3s__viewport-camera-vector">
-                                    <span>Target</span>
-                                    <label>X<input type="number" step="0.01" data-camera-vector="target" data-camera-axis="0" /></label>
-                                    <label>Y<input type="number" step="0.01" data-camera-vector="target" data-camera-axis="1" /></label>
-                                    <label>Z<input type="number" step="0.01" data-camera-vector="target" data-camera-axis="2" /></label>
-                                </div>
-                                <label class="vnccs-i3s__viewport-camera-fov"><span>View angle</span><input type="number" min="5" max="120" step="0.1" data-camera-fov /><small>°</small></label>
-                            </details>
-                        </div>
-                    </details>
                     <section class="vnccs-i3s__skydome-panel" aria-label="Skydome controls" hidden>
                         <div class="vnccs-i3s__lighting-head">
                             <div>
@@ -1207,18 +1155,9 @@ class Factory3DWidget {
             planSettings: Array.from(this.container.querySelectorAll("[data-plan-setting]")),
             planSettingsPanel: $(".vnccs-i3s__plan-settings"),
             planHint: $(".vnccs-i3s__plan-hint"),
-            viewportCamera: $(".vnccs-i3s__viewport-camera"),
-            viewportCameraSummary: $(".vnccs-i3s__viewport-camera-summary"),
-            cameraActions: Array.from(this.container.querySelectorAll("[data-camera-action]")),
             cameraPresets: Array.from(this.container.querySelectorAll("[data-camera-preset]")),
-            cameraOrbit: Array.from(this.container.querySelectorAll("[data-camera-orbit]")),
-            cameraPan: Array.from(this.container.querySelectorAll("[data-camera-pan]")),
-            cameraDistanceRange: $(".vnccs-i3s__camera-distance-range"),
-            cameraDistanceInput: $(".vnccs-i3s__camera-distance-input"),
-            cameraHeightRange: $(".vnccs-i3s__camera-height-range"),
-            cameraHeightInput: $(".vnccs-i3s__camera-height-input"),
-            cameraVectors: Array.from(this.container.querySelectorAll("[data-camera-vector]")),
-            cameraFov: $("[data-camera-fov]"),
+            cameraZoomSpeedRange: $(".vnccs-i3s__camera-zoom-speed-range"),
+            cameraZoomSpeedValue: $(".vnccs-i3s__camera-zoom-speed-value"),
             fit: $(".vnccs-i3s__fit"),
             cutaway: $(".vnccs-i3s__cutaway"),
             modeMove: $(".vnccs-i3s__mode-move"),
@@ -1490,8 +1429,6 @@ class Factory3DWidget {
             void this._saveSceneNow();
         });
         this._listen(this.els.fit, "click", () => this.viewer.frameScene());
-        this._listen(this.els.viewportCamera, "pointerdown", event => event.stopPropagation());
-        this._listen(this.els.viewportCamera, "click", event => event.stopPropagation());
         // LiteGraph and ComfyUI listen to both Pointer Events and legacy mouse
         // events. Blocking only pointerdown/click lets the rest of a range
         // drag escape to the graph, which can clear selection or end the drag.
@@ -1513,62 +1450,21 @@ class Factory3DWidget {
         this._listen(this.els.inspector, "keydown", event => event.stopPropagation());
         this._listen(this.els.inspector, "keyup", event => event.stopPropagation());
         this._listen(this.els.inspector, "wheel", event => event.stopPropagation(), { passive: true });
-        for (const control of this.els.cameraActions) {
-            this._listen(control, "click", () => {
-                if (this.cameraPlayback) return;
-                const action = control.dataset.cameraAction;
-                if (action === "home") this.viewer.resetView();
-                else if (action === "selection") this.viewer.frameSelection();
-                else this.viewer.frameScene();
-            });
-        }
         for (const control of this.els.cameraPresets) {
             this._listen(control, "click", () => {
                 if (!this.cameraPlayback) this.viewer.setViewPreset(control.dataset.cameraPreset);
             });
         }
-        const orbitSteps = {
-            up: { pitch: 7.5 },
-            down: { pitch: -7.5 },
-            left: { yaw: 7.5 },
-            right: { yaw: -7.5 },
-        };
-        for (const control of this.els.cameraOrbit) {
-            this._listen(control, "click", () => {
-                if (!this.cameraPlayback) this.viewer.rotateCameraFPV(orbitSteps[control.dataset.cameraOrbit]);
-            });
-        }
-        const panSteps = {
-            forward: { forward: 1 },
-            back: { forward: -1 },
-            left: { right: -1 },
-            right: { right: 1 },
-        };
-        for (const control of this.els.cameraPan) {
-            this._listen(control, "click", () => {
-                if (!this.cameraPlayback) this.viewer.panCamera(panSteps[control.dataset.cameraPan]);
-            });
-        }
-        this._listen(this.els.cameraDistanceRange, "input", () => {
-            if (!this.cameraPlayback) this.viewer.setCameraDistance(10 ** Number(this.els.cameraDistanceRange.value));
-        });
-        this._listen(this.els.cameraDistanceInput, "input", () => {
-            if (!this.cameraPlayback && Number.isFinite(this.els.cameraDistanceInput.valueAsNumber)) {
-                this.viewer.setCameraDistance(this.els.cameraDistanceInput.valueAsNumber);
+        this._listen(this.els.cameraZoomSpeedRange, "input", () => {
+            if (!this.cameraPlayback) {
+                this.viewer.setZoomSensitivity(10 ** this.els.cameraZoomSpeedRange.valueAsNumber);
+                this.els.cameraZoomSpeedValue.textContent = `${this.viewer.zoomSensitivity.toFixed(2)}×`;
+                this.els.cameraZoomSpeedRange.setAttribute(
+                    "aria-valuetext",
+                    `${this.viewer.zoomSensitivity.toFixed(2)}×`,
+                );
             }
         });
-        this._listen(this.els.cameraHeightRange, "input", () => {
-            if (!this.cameraPlayback) this.viewer.setCameraHeight(this.els.cameraHeightRange.value);
-        });
-        this._listen(this.els.cameraHeightInput, "input", () => {
-            if (!this.cameraPlayback && Number.isFinite(this.els.cameraHeightInput.valueAsNumber)) {
-                this.viewer.setCameraHeight(this.els.cameraHeightInput.valueAsNumber);
-            }
-        });
-        for (const control of this.els.cameraVectors) {
-            this._listen(control, "input", () => this._applyViewportCameraExact());
-        }
-        this._listen(this.els.cameraFov, "input", () => this._applyViewportCameraExact());
         this._listen(this.els.view3d, "click", () => this._setViewMode("3d"));
         this._listen(this.els.viewPlan, "click", () => this._setViewMode("plan"));
         this._listen(this.els.cutaway, "click", () => {
@@ -2184,81 +2080,18 @@ class Factory3DWidget {
         this._scheduleStateSave(0);
     }
 
-    _syncViewportCameraHUD(camera = this.viewerState.camera || {}) {
-        if (!this.els?.viewportCamera) return;
-        const position = Array.isArray(camera.position) ? camera.position : [2.8, 2.1, 4.2];
-        const target = Array.isArray(camera.target) ? camera.target : [0, 0, 0];
-        const distance = Math.max(
-            Math.hypot(
-                (Number(position[0]) || 0) - (Number(target[0]) || 0),
-                (Number(position[1]) || 0) - (Number(target[1]) || 0),
-                (Number(position[2]) || 0) - (Number(target[2]) || 0),
-            ),
-            0.0001,
-        );
-        const height = Number(position[1]) || 0;
-        const write = (control, value) => {
-            if (control && document.activeElement !== control) control.value = String(value);
-        };
-        write(this.els.cameraDistanceRange, Math.log10(distance));
-        write(this.els.cameraDistanceInput, Number(distance.toPrecision(7)));
-        write(this.els.cameraHeightRange, clamp(height, -50, 100));
-        write(this.els.cameraHeightInput, Number(height.toFixed(6)));
-        for (const control of this.els.cameraVectors) {
-            const vector = control.dataset.cameraVector === "target" ? target : position;
-            const axis = Number(control.dataset.cameraAxis) || 0;
-            write(control, Number((Number(vector[axis]) || 0).toFixed(6)));
+    _syncCameraPanelControls() {
+        if (!this.els?.cameraZoomSpeedRange) return;
+        const zoomSensitivity = clamp(Number(this.viewerState.zoom_sensitivity) || 0.1, 0.01, 2);
+        if (document.activeElement !== this.els.cameraZoomSpeedRange) {
+            this.els.cameraZoomSpeedRange.value = String(Math.log10(zoomSensitivity));
         }
-        write(this.els.cameraFov, Number((Number(camera.fov) || 42).toFixed(3)));
-        this.els.viewportCameraSummary.textContent = `${distance.toFixed(distance < 10 ? 2 : 1)} m · Y ${height.toFixed(2)}`;
-        const selectionAction = this.els.cameraActions.find(
-            control => control.dataset.cameraAction === "selection",
-        );
-        if (selectionAction) {
-            selectionAction.disabled = !(
-                this.selectedObjectId
-                || this.selectedGroupId
-                || this.selectedArchitecture?.id
-            );
-        }
-        const disabled = Boolean(this.cameraPlayback);
-        for (const control of [
-            ...this.els.cameraActions,
-            ...this.els.cameraPresets,
-            ...this.els.cameraOrbit,
-            ...this.els.cameraPan,
-            this.els.cameraDistanceRange,
-            this.els.cameraDistanceInput,
-            this.els.cameraHeightRange,
-            this.els.cameraHeightInput,
-            ...this.els.cameraVectors,
-            this.els.cameraFov,
-        ]) {
-            if (!control) continue;
-            if (control === selectionAction && !disabled) continue;
-            control.disabled = disabled;
-        }
-        this.els.viewportCamera.classList.toggle("is-playback", disabled);
-    }
-
-    _applyViewportCameraExact() {
-        if (this.cameraPlayback) return;
-        const current = this.viewer.getCameraState();
-        const next = {
-            ...current,
-            position: [...current.position],
-            target: [...current.target],
-            fov: Number.isFinite(this.els.cameraFov.valueAsNumber)
-                ? clamp(this.els.cameraFov.valueAsNumber, 5, 120)
-                : current.fov,
-        };
-        for (const control of this.els.cameraVectors) {
-            const key = control.dataset.cameraVector === "target" ? "target" : "position";
-            const axis = Number(control.dataset.cameraAxis) || 0;
-            const value = control.valueAsNumber;
-            if (Number.isFinite(value)) next[key][axis] = value;
-        }
-        this.viewer.setCameraState(next, { emit: true });
+        const label = `${zoomSensitivity.toFixed(2)}×`;
+        this.els.cameraZoomSpeedValue.textContent = label;
+        this.els.cameraZoomSpeedRange.setAttribute("aria-valuetext", label);
+        const disabled = Boolean(this.cameraPlayback) || this.editorView.view_mode === "plan";
+        this.els.cameraZoomSpeedRange.disabled = disabled;
+        for (const control of this.els.cameraPresets) control.disabled = disabled;
     }
 
     _setPlanTool(tool) {
@@ -5083,7 +4916,6 @@ class Factory3DWidget {
         if (!track || track.keyframes.length < 1) return;
         const pose = (evaluator || new FactoryCameraPath(track)).evaluate(time);
         this.viewer.setCameraState(legacyCameraFromPose(pose), { emit: false });
-        this._syncViewportCameraHUD(this.viewer.getCameraState());
         this.els.cameraTrackTime.value = String(time);
         this.els.cameraTrackMeta.textContent = `${Number(time).toFixed(2)}s · ${track.keyframes.length} points`;
     }
@@ -5094,7 +4926,7 @@ class Factory3DWidget {
             this.cameraPlayback = null;
             this.viewer.setCameraPlayback(false);
             this.els.cameraTrackPlay.textContent = "Play";
-            this._syncViewportCameraHUD(this.viewer.getCameraState());
+            this._syncCameraPanelControls();
             return;
         }
         const track = this._activeCameraTrack();
@@ -5107,7 +4939,7 @@ class Factory3DWidget {
         this.els.cameraTrackPlay.textContent = "Pause";
         this.viewer.setCameraPlayback(true);
         this.cameraPlayback = { frame: 0, started };
-        this._syncViewportCameraHUD(this.viewer.getCameraState());
+        this._syncCameraPanelControls();
         const step = now => {
             if (!this.cameraPlayback) return;
             let time = (now - started) / 1000;
@@ -10281,10 +10113,9 @@ class Factory3DWidget {
         this.els.modeScale.setAttribute("aria-pressed", String(mode === "scale"));
         this.els.grid.setAttribute("aria-pressed", String(Boolean(this.viewerState.grid)));
         const plan = this.editorView.view_mode === "plan";
-        this.els.viewportCamera.hidden = plan;
         this.els.fit.disabled = plan;
         this.els.fit.title = plan ? "Available in 3D view" : "Frame complete 3D scene";
-        this._syncViewportCameraHUD();
+        this._syncCameraPanelControls();
         this.els.view3d.setAttribute("aria-pressed", String(!plan));
         this.els.viewPlan.setAttribute("aria-pressed", String(plan));
         const cutawayKey = plan ? "plan" : "three_d";

--- a/web/vnccs_3d_factory.js
+++ b/web/vnccs_3d_factory.js
@@ -1,7 +1,29 @@
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
 import { installCustomSelects } from "./vnccs_custom_select.mjs";
-import { Factory3DViewer } from "./vnccs_3d_factory_viewer.js?v=20260726.18";
+import { Factory3DViewer } from "./vnccs_3d_factory_viewer.js?v=20260825.16";
+import {
+    FACTORY_EDITOR_SCHEMA_VERSION,
+    DEFAULT_BUILDING,
+    DEFAULT_LEVEL,
+    DEFAULT_ROOM,
+    DEFAULT_WALL,
+    factoryId,
+    normalizedArchitecture,
+    normalizedEditorView,
+    normalizedLevels,
+    normalizedObjectEditorProperties,
+} from "./factory3d/editor_schema.mjs?v=20260825.9";
+import {
+    FactoryCommandHistory,
+    preserveScrollState,
+} from "./factory3d/editor_commands.mjs?v=20260824.4";
+import {
+    FactoryCameraPath,
+    cameraPoseFromLegacy,
+    legacyCameraFromPose,
+    normalizedCameraPose,
+} from "./factory3d/camera_path.mjs?v=20260824.4";
 
 
 const VNCCS_DONATE_BANNER_URL = new URL("./assets/VNCCS_Donate_Button.png", import.meta.url).href;
@@ -18,6 +40,8 @@ const ENDPOINTS = Object.freeze({
     scene: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}`,
     reference: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/reference`,
     skydome: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/skydome`,
+    textures: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/textures`,
+    texture: (sceneId, textureId) => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/textures/${encodeURIComponent(textureId)}`,
     preview: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/preview`,
     captureSet: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/capture-set`,
     previewError: sceneId => `${API_BASE}/scenes/${encodeURIComponent(sceneId)}/preview/error`,
@@ -39,11 +63,12 @@ const ENDPOINTS = Object.freeze({
     libraryRepositoryProgress: taskId => `${LIBRARY_BASE}/repositories/progress/${encodeURIComponent(taskId)}`,
 });
 const DEFAULT_NODE_SIZE = Object.freeze([1100, 760]);
-const STATE_VERSION = 10;
-const FRONTEND_BUILD = "20260726.4";
+const STATE_VERSION = FACTORY_EDITOR_SCHEMA_VERSION;
+const FRONTEND_BUILD = "20260825.26";
 const MAX_IMAGE_BYTES = 32 * 1024 * 1024;
 const MAX_PLY_BYTES = 2 * 1024 * 1024 * 1024;
 const MAX_SKYDOME_BYTES = 64 * 1024 * 1024;
+const MAX_TEXTURE_BYTES = 32 * 1024 * 1024;
 const TERMINAL = new Set(["completed", "failed", "cancelled"]);
 const DEFAULT_SETTINGS = Object.freeze({
     name: "",
@@ -71,6 +96,13 @@ const DEFAULT_LIGHTING = Object.freeze({
     elevation: 42,
     ambient: 0.5,
     background: "#171b25",
+    shadows: Object.freeze({
+        enabled: true,
+        quality: "medium",
+        bias: -0.0004,
+        normal_bias: 0.015,
+    }),
+    lights: Object.freeze([]),
 });
 const DEFAULT_SKYDOME = Object.freeze({
     visible: true,
@@ -171,11 +203,16 @@ const ICONS = Object.freeze({
 
 
 function installStyles() {
-    if (document.getElementById("vnccs-3d-factory-styles")) return;
+    const href = new URL("./vnccs_3d_factory.css?v=20260825.9", import.meta.url).href;
+    const existing = document.getElementById("vnccs-3d-factory-styles");
+    if (existing) {
+        if (existing.href !== href) existing.href = href;
+        return;
+    }
     const link = document.createElement("link");
     link.id = "vnccs-3d-factory-styles";
     link.rel = "stylesheet";
-    link.href = new URL("./vnccs_3d_factory.css?v=20260726.2", import.meta.url).href;
+    link.href = href;
     document.head.appendChild(link);
 }
 
@@ -214,6 +251,21 @@ function apiUrl(path) {
 function clamp(value, minimum, maximum) {
     const number = Number(value);
     return Math.min(maximum, Math.max(minimum, Number.isFinite(number) ? number : minimum));
+}
+
+function reconcileIdentifiedObjects(currentValue, normalizedValue, idKey) {
+    const current = Array.isArray(currentValue) ? currentValue : [];
+    const normalized = Array.isArray(normalizedValue) ? normalizedValue : [];
+    const byId = new Map(current.map(item => [String(item?.[idKey] || ""), item]));
+    return normalized.map(next => {
+        const existing = byId.get(String(next?.[idKey] || ""));
+        if (!existing || typeof existing !== "object") return next;
+        for (const key of Object.keys(existing)) {
+            if (!(key in next)) delete existing[key];
+        }
+        Object.assign(existing, next);
+        return existing;
+    });
 }
 
 function formatBytes(value) {
@@ -314,6 +366,44 @@ function blobToDataURL(blob) {
     });
 }
 
+function quaternionFromEulerDegrees(rotation = [0, 0, 0]) {
+    const [x, y, z] = rotation.map(value => Number(value || 0) * Math.PI / 180 / 2);
+    const [sx, sy, sz] = [Math.sin(x), Math.sin(y), Math.sin(z)];
+    const [cx, cy, cz] = [Math.cos(x), Math.cos(y), Math.cos(z)];
+    return normalizedCameraPose({
+        quaternion: [
+            sx * cy * cz + cx * sy * sz,
+            cx * sy * cz - sx * cy * sz,
+            cx * cy * sz + sx * sy * cz,
+            cx * cy * cz - sx * sy * sz,
+        ],
+    }).quaternion;
+}
+
+function multiplyQuaternions(left = [0, 0, 0, 1], right = [0, 0, 0, 1]) {
+    const [ax, ay, az, aw] = left.map(Number);
+    const [bx, by, bz, bw] = right.map(Number);
+    return normalizedCameraPose({
+        quaternion: [
+            aw * bx + ax * bw + ay * bz - az * by,
+            aw * by - ax * bz + ay * bw + az * bx,
+            aw * bz + ax * by - ay * bx + az * bw,
+            aw * bw - ax * bx - ay * by - az * bz,
+        ],
+    }).quaternion;
+}
+
+function eulerDegreesFromQuaternion(quaternion = [0, 0, 0, 1]) {
+    const [x, y, z, w] = normalizedCameraPose({ quaternion }).quaternion;
+    // Inverse of quaternionFromEulerDegrees' intrinsic XYZ order. Mixing this
+    // with the common ZYX yaw/pitch/roll equations makes exact camera fields
+    // drift as soon as more than one axis is rotated.
+    const rotationX = Math.atan2(2 * (w * x - y * z), 1 - 2 * (x * x + y * y));
+    const rotationY = Math.asin(Math.max(-1, Math.min(1, 2 * (x * z + w * y))));
+    const rotationZ = Math.atan2(2 * (w * z - x * y), 1 - 2 * (y * y + z * z));
+    return [rotationX, rotationY, rotationZ].map(value => value * 180 / Math.PI);
+}
+
 
 class Factory3DWidget {
     constructor(node) {
@@ -323,6 +413,7 @@ class Factory3DWidget {
             console.info(`[VNCCS 3D Factory] Frontend build ${FRONTEND_BUILD}`);
         }
         this.node = node;
+        this._workspaceId = `vnccs-factory-${randomLayerId()}`;
         this.destroyed = false;
         this.sceneId = "";
         this.scene = null;
@@ -334,6 +425,16 @@ class Factory3DWidget {
         this.selectedGroupId = "";
         this.selectedSkydome = false;
         this.selectedCameraId = "";
+        this.previewCameraId = "";
+        this.selectedArchitecture = null;
+        this.editorView = normalizedEditorView();
+        this.planDraft = null;
+        this.planHover = null;
+        this._planHoverFrame = 0;
+        this._pendingPlanHover = null;
+        this.activeCameraTrackId = "";
+        this.selectedCameraKeyframeId = "";
+        this.cameraPlayback = null;
         this._cameraReturnState = null;
         this._cameraSelectionTransition = false;
         this._cameraPadPointer = null;
@@ -355,10 +456,16 @@ class Factory3DWidget {
         this._previewSaveTimer = 0;
         this._previewIdleHandle = 0;
         this._lightingApplyTimer = 0;
+        this._lightingHistoryBefore = null;
+        this._expandedLightId = "";
         this._searchRenderFrame = 0;
         this._sceneSaveSerial = Promise.resolve();
+        this._architectureCommitSerial = Promise.resolve();
+        this._architecturePreviewTimer = 0;
+        this._architectureGeometryFrame = 0;
         this._previewSaveSerial = Promise.resolve();
         this._restoreSerial = Promise.resolve();
+        this._historyRestoreSerial = Promise.resolve();
         this._resizeFrame = 0;
         this._uiScaleValue = "";
         this._modalCleanup = null;
@@ -378,18 +485,38 @@ class Factory3DWidget {
         this.libraryResizeObserver = null;
         this._libraryAutoRefreshStarted = false;
         this._suppressViewerStatePersistence = false;
+        this.history = new FactoryCommandHistory({
+            limit: 100,
+            onRestore: snapshot => {
+                const operation = this._historyRestoreSerial.then(
+                    () => this._restoreEditorSnapshot(snapshot),
+                );
+                this._historyRestoreSerial = operation.catch(() => null);
+                return operation;
+            },
+        });
         // Keep callbacks read-only until the serialized ComfyUI widget state has
         // been applied. Viewer setup emits state changes during construction.
         this._isRestoring = true;
         this._createLayout();
         this._cache();
         this._bind();
+        this._syncWorkspace();
         this.viewer = new Factory3DViewer(this.els.viewerHost, {
             onSelectionChange: (id, options) => this._selectObject(id, {
                 fromViewer: true,
                 additive: Boolean(options?.additive),
             }),
             onTransformChange: (id, transform, options) => this._onViewerTransform(id, transform, options),
+            onArchitectureSelection: selection => this._selectArchitecture(selection),
+            onArchitectureEdit: change => this._onArchitectureEdit(change),
+            snapPlanPoint: (point, event, context) => this._snapPlanPoint(
+                point,
+                event,
+                context?.origin || null,
+            ),
+            onPlanGesture: gesture => this._onPlanGesture(gesture),
+            onPlanHover: (tool, point, event) => this._queuePlanHover(tool, point, event),
             onStateChange: state => {
                 const previousState = this.viewerState;
                 const cameraChanged = !cameraStatesEqual(
@@ -397,15 +524,37 @@ class Factory3DWidget {
                     state.camera || {},
                 );
                 const toolbarChanged = previousState.mode !== state.mode
-                    || previousState.grid !== state.grid;
+                    || previousState.grid !== state.grid
+                    || previousState.view_mode !== state.view_mode
+                    || previousState.plan_tool !== state.plan_tool
+                    || previousState.active_level_id !== state.active_level_id;
                 this.viewerState = { ...this.viewerState, ...state };
                 if (toolbarChanged) this._syncToolbar();
+                if (cameraChanged) this._syncViewportCameraHUD(state.camera);
                 this._scheduleStateSave();
                 if (
                     cameraChanged
                     && !this._isRestoring
                     && !this._suppressViewerStatePersistence
-                    && !this.selectedCameraId
+                    && !this._cameraSelectionTransition
+                    && this.previewCameraId
+                    && this.scene
+                ) {
+                    const savedCamera = this.scene.cameras?.find(
+                        camera => camera.camera_id === this.previewCameraId,
+                    );
+                    if (savedCamera) {
+                        Object.assign(savedCamera, this._normalizeCameraState(state.camera));
+                        this.viewer.setCameraMarkers(this.scene.cameras);
+                        this._renderInspector();
+                        this._scheduleSceneSave(180);
+                    }
+                }
+                if (
+                    cameraChanged
+                    && !this._isRestoring
+                    && !this._suppressViewerStatePersistence
+                    && !this.previewCameraId
                     && this.scene
                 ) {
                     this.scene.camera = { ...state.camera };
@@ -423,6 +572,8 @@ class Factory3DWidget {
         this._navigationCleanup = enableCanvasNavigationForwarding(this.container);
         this._renderObjects();
         this._renderCameras();
+        this._renderInspector();
+        this._renderCameraTracks();
         this._syncSettings();
         this._syncExportSettings();
         this._syncLighting();
@@ -435,7 +586,29 @@ class Factory3DWidget {
         root.style.containerType = "inline-size";
         root.setAttribute("aria-label", "VNCCS 3D Factory");
         root.innerHTML = `
-            <aside class="vnccs-i3s__side vnccs-i3s__side--left" aria-label="Reference and generation settings">
+            <aside class="vnccs-i3s__side vnccs-i3s__side--left" aria-label="Creation and camera tools">
+                <div class="vnccs-i3s__workspace-tabs" role="tablist" aria-label="Creation workspace">
+                    <button class="vnccs-i3s__workspace-tab" type="button" role="tab"
+                        data-workspace-side="left" data-workspace-tab="generate"
+                        id="${this._workspaceId}-left-generate-tab"
+                        title="Generation tools"
+                        aria-controls="${this._workspaceId}-left-generate" aria-selected="true">
+                        <span aria-hidden="true">${ICONS.upload}</span><span>Generate</span>
+                    </button>
+                    <button class="vnccs-i3s__workspace-tab" type="button" role="tab"
+                        data-workspace-side="left" data-workspace-tab="cameras"
+                        id="${this._workspaceId}-left-cameras-tab"
+                        title="Camera tools"
+                        aria-controls="${this._workspaceId}-left-cameras" aria-selected="false" tabindex="-1">
+                        <span aria-hidden="true">${ICONS.camera}</span><span>Cameras</span>
+                    </button>
+                </div>
+                <div class="vnccs-i3s__workspace-panels">
+                    <div class="vnccs-i3s__workspace-panel vnccs-i3s__workspace-panel--left"
+                        id="${this._workspaceId}-left-generate" role="tabpanel"
+                        aria-labelledby="${this._workspaceId}-left-generate-tab"
+                        data-workspace-side="left" data-workspace-panel="generate"
+                        data-preserve-scroll="workspace-left-generate">
                 <section class="vnccs-i3s__section">
                     <div class="vnccs-i3s__section-head"><span>Reference</span></div>
                     <div class="vnccs-i3s__section-body">
@@ -507,6 +680,12 @@ class Factory3DWidget {
                         <button class="vnccs-i3s__button vnccs-i3s__button--primary vnccs-i3s__button--block vnccs-i3s__generate" type="button">${ICONS.play}<span>Generate object</span></button>
                     </div>
                 </section>
+                    </div>
+                    <div class="vnccs-i3s__workspace-panel vnccs-i3s__workspace-panel--left"
+                        id="${this._workspaceId}-left-cameras" role="tabpanel"
+                        aria-labelledby="${this._workspaceId}-left-cameras-tab"
+                        data-workspace-side="left" data-workspace-panel="cameras"
+                        data-preserve-scroll="workspace-left-cameras" hidden>
                 <section class="vnccs-i3s__section vnccs-i3s__camera-section">
                     <div class="vnccs-i3s__section-head">
                         <span>Camera</span>
@@ -536,8 +715,30 @@ class Factory3DWidget {
                             </div>
                             <div class="vnccs-i3s__camera-list"></div>
                         </div>
+                        <div class="vnccs-i3s__camera-track-editor">
+                            <div class="vnccs-i3s__camera-group-head">
+                                <span>${ICONS.play}</span>
+                                <strong>Camera path</strong>
+                            </div>
+                            <div class="vnccs-i3s__camera-track-row">
+                                <select class="vnccs-i3s__select vnccs-i3s__camera-track-select" aria-label="Camera path"></select>
+                                <button class="vnccs-i3s__button vnccs-i3s__camera-track-add" type="button" title="Add camera path">+</button>
+                                <button class="vnccs-i3s__button vnccs-i3s__camera-track-delete" type="button" title="Delete active camera path" aria-label="Delete active camera path">${ICONS.trash}</button>
+                            </div>
+                            <input class="vnccs-i3s__input vnccs-i3s__camera-track-name" maxlength="80" placeholder="Camera path name" aria-label="Camera path name" />
+                            <select class="vnccs-i3s__select vnccs-i3s__camera-track-building" aria-label="Camera path building"></select>
+                            <div class="vnccs-i3s__camera-track-actions">
+                                <button class="vnccs-i3s__button vnccs-i3s__camera-keyframe-add" type="button">Add point</button>
+                                <button class="vnccs-i3s__button vnccs-i3s__camera-track-play" type="button">Play</button>
+                            </div>
+                            <input class="vnccs-i3s__range vnccs-i3s__camera-track-time" type="range" min="0" max="5" step="0.001" value="0" aria-label="Camera path time" />
+                            <div class="vnccs-i3s__camera-track-meta">No camera path</div>
+                            <div class="vnccs-i3s__camera-keyframes" data-preserve-scroll="camera-keyframes"></div>
+                        </div>
                     </div>
                 </section>
+                    </div>
+                </div>
                 <a class="vnccs-i3s__donate-link" href="https://www.buymeacoffee.com/MIUProject" target="_blank" rel="noopener noreferrer" title="Support MIUProject">
                     <img src="${VNCCS_DONATE_BANNER_URL}" alt="Support MIUProject" width="1859" height="525" decoding="async" />
                 </a>
@@ -556,22 +757,125 @@ class Factory3DWidget {
                 </header>
                 <div class="vnccs-i3s__viewport">
                     <div class="vnccs-i3s__viewer-host" aria-label="Gaussian scene viewport"></div>
-                    <div class="vnccs-i3s__empty-view">
-                        <div class="vnccs-i3s__empty-view-icon">${ICONS.cube}</div>
-                        <div class="vnccs-i3s__empty-view-title">Your scene will appear here</div>
-                        <div>Load a reference and generate the first Gaussian object.</div>
-                    </div>
                     <div class="vnccs-i3s__toolbar" role="toolbar">
-                        <button class="vnccs-i3s__tool vnccs-i3s__fit" type="button" title="Fit scene">${ICONS.fit}</button>
+                        <div class="vnccs-i3s__view-switch" role="group" aria-label="Viewport mode">
+                            <button class="vnccs-i3s__tool-label vnccs-i3s__view-3d" type="button" aria-pressed="true">3D</button>
+                            <button class="vnccs-i3s__tool-label vnccs-i3s__view-plan" type="button" aria-pressed="false">Plan</button>
+                        </div>
+                        <select class="vnccs-i3s__context-select vnccs-i3s__building-select" aria-label="Active building" title="New walls, rooms, models, cameras, camera paths, and lights are assigned to this building"></select>
+                        <select class="vnccs-i3s__context-select vnccs-i3s__level-select" aria-label="Active floor level"></select>
+                        <button class="vnccs-i3s__tool-label vnccs-i3s__level-add" type="button" title="Add floor level">+ Floor</button>
+                        <button class="vnccs-i3s__tool-label vnccs-i3s__building-add" type="button" title="Add a movable building container">+ Building</button>
+                        <button class="vnccs-i3s__tool-label vnccs-i3s__undo" type="button" title="Undo (Ctrl/Cmd+Z)" disabled>Undo</button>
+                        <button class="vnccs-i3s__tool-label vnccs-i3s__redo" type="button" title="Redo (Ctrl/Cmd+Shift+Z)" disabled>Redo</button>
                         <span class="vnccs-i3s__tool-separator"></span>
-                        <button class="vnccs-i3s__tool vnccs-i3s__mode-move" type="button" title="Move" aria-pressed="true">${ICONS.move}</button>
-                        <button class="vnccs-i3s__tool vnccs-i3s__mode-rotate" type="button" title="Rotate" aria-pressed="false">${ICONS.rotate}</button>
-                        <button class="vnccs-i3s__tool vnccs-i3s__mode-scale" type="button" title="Scale uniformly" aria-pressed="false">${ICONS.scale}</button>
+                        <button class="vnccs-i3s__tool vnccs-i3s__fit" type="button" title="Fit scene" aria-label="Fit scene">${ICONS.fit}</button>
                         <span class="vnccs-i3s__tool-separator"></span>
-                        <button class="vnccs-i3s__tool vnccs-i3s__skydome-open" type="button" title="Skydome" aria-pressed="false">${ICONS.image}</button>
-                        <button class="vnccs-i3s__tool vnccs-i3s__lighting-open" type="button" title="Scene lighting" aria-pressed="false">${ICONS.sun}</button>
-                        <button class="vnccs-i3s__tool vnccs-i3s__grid" type="button" title="Grid" aria-pressed="false">${ICONS.grid}</button>
+                        <button class="vnccs-i3s__tool vnccs-i3s__mode-move" type="button" title="Move" aria-label="Move selected objects" aria-pressed="true">${ICONS.move}</button>
+                        <button class="vnccs-i3s__tool vnccs-i3s__mode-rotate" type="button" title="Rotate" aria-label="Rotate selected objects" aria-pressed="false">${ICONS.rotate}</button>
+                        <button class="vnccs-i3s__tool vnccs-i3s__mode-scale" type="button" title="Scale uniformly" aria-label="Scale selected objects uniformly" aria-pressed="false">${ICONS.scale}</button>
+                        <button class="vnccs-i3s__tool-label vnccs-i3s__drop-surface" type="button" title="Drop selection to the nearest surface (End)">Drop</button>
+                        <span class="vnccs-i3s__tool-separator"></span>
+                        <button class="vnccs-i3s__tool vnccs-i3s__skydome-open" type="button" title="Skydome" aria-label="Open skydome controls" aria-pressed="false">${ICONS.image}</button>
+                        <button class="vnccs-i3s__tool vnccs-i3s__lighting-open" type="button" title="Scene lighting" aria-label="Open scene lighting controls" aria-pressed="false">${ICONS.sun}</button>
+                        <button class="vnccs-i3s__tool vnccs-i3s__grid" type="button" title="Grid" aria-label="Toggle 3D grid" aria-pressed="false">${ICONS.grid}</button>
                     </div>
+                    <div class="vnccs-i3s__plan-tools" role="toolbar" aria-label="Floor plan tools" hidden>
+                        <button type="button" data-plan-tool="select" aria-pressed="true" title="Select and edit architecture"><span>Select</span></button>
+                        <button type="button" data-plan-tool="wall" aria-pressed="false" title="Press and drag to draw a wall"><span>Wall</span></button>
+                        <button type="button" data-plan-tool="room" aria-pressed="false" title="Press and drag diagonally to draw a rectangular room"><span>Room</span></button>
+                        <button type="button" data-plan-tool="opening" aria-pressed="false" title="Press on a wall and drag to set the opening width"><span>Opening</span></button>
+                        <label class="vnccs-i3s__opening-kind-shortcut" hidden>
+                            <span>Place</span>
+                            <select class="vnccs-i3s__select" data-plan-setting="opening_kind" aria-label="Opening type">
+                                <option value="window">Window</option><option value="door">Door</option><option value="empty">Empty</option>
+                            </select>
+                        </label>
+                        <button type="button" data-plan-tool="camera" aria-pressed="false" title="Press and drag to place and aim a saved camera"><span>Camera</span></button>
+                        <button class="vnccs-i3s__plan-grid-toggle" type="button" aria-pressed="true" title="Show plan grid">Grid</button>
+                        <button class="vnccs-i3s__snap-toggle" type="button" aria-pressed="true" title="Snap drawing and edits to the plan grid">Snap</button>
+                        <label class="vnccs-i3s__snap-grid">Step <input type="number" min="0.001" max="1000" step="0.01" value="0.1" inputmode="decimal" aria-label="Plan grid step in meters" /><span>m</span></label>
+                        <details class="vnccs-i3s__plan-settings">
+                            <summary>Options</summary>
+                            <div class="vnccs-i3s__plan-settings-popover">
+                                <label><span>Grid step · m</span><input class="vnccs-i3s__input" data-plan-setting="grid_step" type="number" min="0.001" max="1000" step="0.01" /></label>
+                                <label><span>Major line every</span><input class="vnccs-i3s__input" data-plan-setting="major_every" type="number" min="2" max="100" step="1" /></label>
+                                <label><span>Angle step</span><input class="vnccs-i3s__input" data-plan-setting="angle" type="number" min="0" max="180" step="1" /></label>
+                                <label><span>Opening type</span><select class="vnccs-i3s__select" data-plan-setting="opening_kind"><option value="window">Window</option><option value="door">Door</option><option value="empty">Empty</option></select></label>
+                                <label><input data-plan-setting="endpoints" type="checkbox" /> Snap to endpoints</label>
+                                <label><input data-plan-setting="midpoints" type="checkbox" /> Snap to midpoints</label>
+                                <label><input data-plan-setting="orthogonal" type="checkbox" /> Automatic orthogonal snap</label>
+                            </div>
+                        </details>
+                        <span class="vnccs-i3s__plan-hint">Choose a tool, then press and drag in the plan.</span>
+                    </div>
+                    <details class="vnccs-i3s__viewport-camera" open>
+                        <summary>
+                            <span>${ICONS.camera}<b>View camera</b></span>
+                            <output class="vnccs-i3s__viewport-camera-summary">Perspective</output>
+                        </summary>
+                        <div class="vnccs-i3s__viewport-camera-body">
+                            <div class="vnccs-i3s__viewport-camera-actions">
+                                <button type="button" data-camera-action="home" title="Restore a stable perspective and frame the complete scene">Reset view</button>
+                                <button type="button" data-camera-action="scene" title="Center and frame the complete scene">Frame scene</button>
+                                <button type="button" data-camera-action="selection" title="Center and frame the current selection">Selection</button>
+                            </div>
+                            <div class="vnccs-i3s__viewport-camera-presets" role="group" aria-label="Camera view presets">
+                                <button type="button" data-camera-preset="perspective">Perspective</button>
+                                <button type="button" data-camera-preset="front">Front</button>
+                                <button type="button" data-camera-preset="right">Right</button>
+                                <button type="button" data-camera-preset="top">Top</button>
+                            </div>
+                            <div class="vnccs-i3s__viewport-camera-navigation">
+                                <div>
+                                    <span class="vnccs-i3s__viewport-camera-label">Look</span>
+                                    <div class="vnccs-i3s__camera-orbit-pad" role="group" aria-label="Turn view camera in place">
+                                        <button type="button" data-camera-orbit="up" aria-label="Look upward" title="Look upward">↑</button>
+                                        <button type="button" data-camera-orbit="left" aria-label="Look left" title="Look left">←</button>
+                                        <span aria-hidden="true">●</span>
+                                        <button type="button" data-camera-orbit="right" aria-label="Look right" title="Look right">→</button>
+                                        <button type="button" data-camera-orbit="down" aria-label="Look downward" title="Look downward">↓</button>
+                                    </div>
+                                </div>
+                                <div>
+                                    <span class="vnccs-i3s__viewport-camera-label">Move</span>
+                                    <div class="vnccs-i3s__camera-pan-pad" role="group" aria-label="Move view camera and target">
+                                        <button type="button" data-camera-pan="forward" aria-label="Move forward" title="Move forward">↑</button>
+                                        <button type="button" data-camera-pan="left" aria-label="Move left" title="Move left">←</button>
+                                        <span aria-hidden="true">●</span>
+                                        <button type="button" data-camera-pan="right" aria-label="Move right" title="Move right">→</button>
+                                        <button type="button" data-camera-pan="back" aria-label="Move backward" title="Move backward">↓</button>
+                                    </div>
+                                </div>
+                                <div class="vnccs-i3s__viewport-camera-sliders">
+                                    <label>
+                                        <span>Distance</span>
+                                        <div><input class="vnccs-i3s__camera-distance-range" type="range" min="-4" max="6" step="0.002" aria-label="Camera distance" /><input class="vnccs-i3s__camera-distance-input" type="number" min="0.0001" max="1000000" step="0.01" inputmode="decimal" aria-label="Camera distance in meters" /><small>m</small></div>
+                                    </label>
+                                    <label>
+                                        <span>Height</span>
+                                        <div><input class="vnccs-i3s__camera-height-range" type="range" min="-50" max="100" step="0.01" aria-label="Camera height" /><input class="vnccs-i3s__camera-height-input" type="number" min="-1000000" max="1000000" step="0.01" inputmode="decimal" aria-label="Camera height in meters" /><small>m</small></div>
+                                    </label>
+                                </div>
+                            </div>
+                            <details class="vnccs-i3s__viewport-camera-exact">
+                                <summary>Exact coordinates</summary>
+                                <div class="vnccs-i3s__viewport-camera-vector">
+                                    <span>Position</span>
+                                    <label>X<input type="number" step="0.01" data-camera-vector="position" data-camera-axis="0" /></label>
+                                    <label>Y<input type="number" step="0.01" data-camera-vector="position" data-camera-axis="1" /></label>
+                                    <label>Z<input type="number" step="0.01" data-camera-vector="position" data-camera-axis="2" /></label>
+                                </div>
+                                <div class="vnccs-i3s__viewport-camera-vector">
+                                    <span>Target</span>
+                                    <label>X<input type="number" step="0.01" data-camera-vector="target" data-camera-axis="0" /></label>
+                                    <label>Y<input type="number" step="0.01" data-camera-vector="target" data-camera-axis="1" /></label>
+                                    <label>Z<input type="number" step="0.01" data-camera-vector="target" data-camera-axis="2" /></label>
+                                </div>
+                                <label class="vnccs-i3s__viewport-camera-fov"><span>View angle</span><input type="number" min="5" max="120" step="0.1" data-camera-fov /><small>°</small></label>
+                            </details>
+                        </div>
+                    </details>
                     <section class="vnccs-i3s__skydome-panel" aria-label="Skydome controls" hidden>
                         <div class="vnccs-i3s__lighting-head">
                             <div>
@@ -667,8 +971,22 @@ class Factory3DWidget {
                                 </label>
                             </div>
                         </div>
+                        <div class="vnccs-i3s__lighting-advanced">
+                            <div class="vnccs-i3s__switch-row">
+                                <div><div class="vnccs-i3s__scene-frame-title">Occlusion shadows</div><div class="vnccs-i3s__scene-frame-copy">Walls and opaque objects block direct light.</div></div>
+                                <button class="vnccs-i3s__switch vnccs-i3s__shadow-enabled" type="button" role="switch" aria-checked="true" aria-label="Enable shadows"></button>
+                            </div>
+                            <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Shadow quality</span>
+                                <select class="vnccs-i3s__select vnccs-i3s__shadow-quality">
+                                    <option value="low">Low · 512</option><option value="medium">Medium · 1024</option><option value="high">High · 2048</option><option value="ultra">Ultra · 4096</option>
+                                </select>
+                            </label>
+                            <div class="vnccs-i3s__hint">Local shadow-map budget: Low 2 · Medium 4 · High 6 · Ultra 8. Additional lights still illuminate without a shadow map.</div>
+                            <div class="vnccs-i3s__lighting-local-head"><b>Local lights</b><button class="vnccs-i3s__button vnccs-i3s__local-light-add" type="button">Add light</button></div>
+                            <div class="vnccs-i3s__local-lights"></div>
+                        </div>
                     </section>
-                    <div class="vnccs-i3s__viewport-help">Click: select · Shift-click: multi-select · Drag gizmo: transform · Drag empty space: orbit · W/E/R: move/rotate/scale · F: frame</div>
+                    <div class="vnccs-i3s__viewport-help">Click: select · Shift-click: multi-select · Drag gizmo: transform · W/E/R: move/rotate/scale · End: drop · F: frame</div>
                     <div class="vnccs-i3s__progress">
                         <div class="vnccs-i3s__progress-copy">
                             <div class="vnccs-i3s__progress-head">
@@ -682,29 +1000,73 @@ class Factory3DWidget {
                     </div>
                 </div>
             </main>
-            <aside class="vnccs-i3s__side vnccs-i3s__side--right" aria-label="Scene objects and export">
+            <aside class="vnccs-i3s__side vnccs-i3s__side--right" aria-label="Scene tools">
                 <div class="vnccs-i3s__library-launcher-wrap">
                     <button class="vnccs-ps-btn primary vnccs-i3s__library-open" type="button">
-                        <span class="vnccs-ps-btn-icon">📚</span> Model Library
+                        <span class="vnccs-ps-btn-icon" aria-hidden="true">${ICONS.library}</span> Model Library
                     </button>
                     <button class="vnccs-i3s__button vnccs-i3s__ply-import" type="button" title="Import a Gaussian PLY into the active scene">
                         ${ICONS.upload}<span>Import PLY</span>
                     </button>
                     <input class="vnccs-i3s__file-input vnccs-i3s__ply-input" type="file" accept=".ply,application/octet-stream" tabindex="-1" />
                 </div>
-                <section class="vnccs-i3s__section vnccs-i3s__object-section">
-                    <div class="vnccs-i3s__section-head"><span>Scene objects</span><span class="vnccs-i3s__object-count">0</span></div>
+                <div class="vnccs-i3s__workspace-tabs vnccs-i3s__workspace-tabs--three" role="tablist" aria-label="Scene workspace">
+                    <button class="vnccs-i3s__workspace-tab" type="button" role="tab"
+                        data-workspace-side="right" data-workspace-tab="objects"
+                        id="${this._workspaceId}-right-objects-tab"
+                        title="Scene objects"
+                        aria-controls="${this._workspaceId}-right-objects" aria-selected="true">
+                        <span aria-hidden="true">${ICONS.folder}</span><span>Objects</span>
+                        <span class="vnccs-i3s__workspace-tab-count vnccs-i3s__object-count">0</span>
+                    </button>
+                    <button class="vnccs-i3s__workspace-tab vnccs-i3s__workspace-tab--inspector" type="button" role="tab"
+                        data-workspace-side="right" data-workspace-tab="inspector"
+                        id="${this._workspaceId}-right-inspector-tab"
+                        title="Selection inspector"
+                        aria-controls="${this._workspaceId}-right-inspector" aria-selected="false" tabindex="-1">
+                        <span aria-hidden="true">${ICONS.settings}</span><span>Inspector</span>
+                        <span class="vnccs-i3s__workspace-tab-dot" aria-hidden="true"></span>
+                    </button>
+                    <button class="vnccs-i3s__workspace-tab" type="button" role="tab"
+                        data-workspace-side="right" data-workspace-tab="export"
+                        id="${this._workspaceId}-right-export-tab"
+                        title="Export settings"
+                        aria-controls="${this._workspaceId}-right-export" aria-selected="false" tabindex="-1">
+                        <span aria-hidden="true">${ICONS.download}</span><span>Export</span>
+                    </button>
+                </div>
+                <div class="vnccs-i3s__workspace-panels">
+                <section class="vnccs-i3s__section vnccs-i3s__workspace-panel vnccs-i3s__object-section"
+                    id="${this._workspaceId}-right-objects" role="tabpanel"
+                    aria-labelledby="${this._workspaceId}-right-objects-tab"
+                    data-workspace-side="right" data-workspace-panel="objects">
+                    <div class="vnccs-i3s__section-head"><span>Scene hierarchy</span></div>
                     <div class="vnccs-i3s__section-body">
                         <label class="vnccs-i3s__search">${ICONS.search}<input class="vnccs-i3s__input vnccs-i3s__object-search" type="search" placeholder="Filter objects" /></label>
                         <div class="vnccs-i3s__layer-tools">
                             <button class="vnccs-i3s__button vnccs-i3s__group-selected" type="button" disabled>${ICONS.folder}<span>Group</span></button>
                             <span class="vnccs-i3s__selection-count">Shift-click to select multiple</span>
                         </div>
-                        <div class="vnccs-i3s__object-list"></div>
+                        <div class="vnccs-i3s__object-list" data-preserve-scroll="scene-objects"></div>
                     </div>
                 </section>
-                <section class="vnccs-i3s__section">
-                    <div class="vnccs-i3s__section-head"><span>Scene export</span></div>
+                <section class="vnccs-i3s__section vnccs-i3s__workspace-panel vnccs-i3s__inspector-section"
+                    id="${this._workspaceId}-right-inspector" role="tabpanel"
+                    aria-labelledby="${this._workspaceId}-right-inspector-tab"
+                    data-workspace-side="right" data-workspace-panel="inspector" hidden>
+                    <div class="vnccs-i3s__section-head">
+                        <span>Selection</span>
+                        <span class="vnccs-i3s__inspector-kind">Nothing selected</span>
+                    </div>
+                    <div class="vnccs-i3s__section-body vnccs-i3s__inspector" data-preserve-scroll="inspector">
+                        <div class="vnccs-i3s__inspector-empty">Select an object, wall, room, opening, or camera.</div>
+                    </div>
+                </section>
+                <section class="vnccs-i3s__section vnccs-i3s__workspace-panel vnccs-i3s__export-section"
+                    id="${this._workspaceId}-right-export" role="tabpanel"
+                    aria-labelledby="${this._workspaceId}-right-export-tab"
+                    data-workspace-side="right" data-workspace-panel="export" hidden>
+                    <div class="vnccs-i3s__section-head"><span>Output settings</span></div>
                     <div class="vnccs-i3s__section-body">
                         <div class="vnccs-i3s__hint vnccs-i3s__scene-summary">No objects in this scene.</div>
                         <div class="vnccs-i3s__scene-render-settings">
@@ -742,10 +1104,11 @@ class Factory3DWidget {
                             <div class="vnccs-i3s__scene-render-summary">1024 × 1024 px · Camera follows the current 3D view</div>
                         </div>
                         <div class="vnccs-i3s__export-grid">
-                            <button class="vnccs-i3s__button vnccs-i3s__scene-export" type="button">${ICONS.download}<span>Scene PLY</span></button>
+                            <button class="vnccs-i3s__button vnccs-i3s__scene-export" type="button">${ICONS.download}<span>Gaussian PLY</span></button>
                         </div>
                     </div>
                 </section>
+                </div>
             </aside>
             <div class="vnccs-i3s__toasts" aria-live="polite"></div>
             <div class="vnccs-i3s__modal-layer"></div>
@@ -756,6 +1119,8 @@ class Factory3DWidget {
     _cache() {
         const $ = selector => this.container.querySelector(selector);
         this.els = {
+            workspaceTabs: Array.from(this.container.querySelectorAll("[data-workspace-tab]")),
+            workspacePanels: Array.from(this.container.querySelectorAll("[data-workspace-panel]")),
             sourceDrop: $(".vnccs-i3s__dropzone"),
             sourceInput: $(".vnccs-i3s__source-input"),
             sourcePreview: $(".vnccs-i3s__source-preview"),
@@ -780,6 +1145,16 @@ class Factory3DWidget {
             cameraCount: $(".vnccs-i3s__camera-count"),
             cameraGroupCount: $(".vnccs-i3s__camera-group-count"),
             cameraList: $(".vnccs-i3s__camera-list"),
+            cameraTrackSelect: $(".vnccs-i3s__camera-track-select"),
+            cameraTrackAdd: $(".vnccs-i3s__camera-track-add"),
+            cameraTrackDelete: $(".vnccs-i3s__camera-track-delete"),
+            cameraTrackName: $(".vnccs-i3s__camera-track-name"),
+            cameraTrackBuilding: $(".vnccs-i3s__camera-track-building"),
+            cameraKeyframeAdd: $(".vnccs-i3s__camera-keyframe-add"),
+            cameraTrackPlay: $(".vnccs-i3s__camera-track-play"),
+            cameraTrackTime: $(".vnccs-i3s__camera-track-time"),
+            cameraTrackMeta: $(".vnccs-i3s__camera-track-meta"),
+            cameraKeyframes: $(".vnccs-i3s__camera-keyframes"),
             donateLink: $(".vnccs-i3s__donate-link"),
             sceneName: $(".vnccs-i3s__scene-name-input"),
             sceneId: $(".vnccs-i3s__project-id"),
@@ -789,10 +1164,40 @@ class Factory3DWidget {
             plyInput: $(".vnccs-i3s__ply-input"),
             status: $(".vnccs-i3s__status-pill"),
             viewerHost: $(".vnccs-i3s__viewer-host"),
+            view3d: $(".vnccs-i3s__view-3d"),
+            viewPlan: $(".vnccs-i3s__view-plan"),
+            levelSelect: $(".vnccs-i3s__level-select"),
+            buildingSelect: $(".vnccs-i3s__building-select"),
+            levelAdd: $(".vnccs-i3s__level-add"),
+            buildingAdd: $(".vnccs-i3s__building-add"),
+            undo: $(".vnccs-i3s__undo"),
+            redo: $(".vnccs-i3s__redo"),
+            planTools: $(".vnccs-i3s__plan-tools"),
+            planToolButtons: Array.from(this.container.querySelectorAll("[data-plan-tool]")),
+            openingKindShortcut: $(".vnccs-i3s__opening-kind-shortcut"),
+            planGridToggle: $(".vnccs-i3s__plan-grid-toggle"),
+            snapToggle: $(".vnccs-i3s__snap-toggle"),
+            snapGrid: $(".vnccs-i3s__snap-grid input"),
+            planSettings: Array.from(this.container.querySelectorAll("[data-plan-setting]")),
+            planSettingsPanel: $(".vnccs-i3s__plan-settings"),
+            planHint: $(".vnccs-i3s__plan-hint"),
+            viewportCamera: $(".vnccs-i3s__viewport-camera"),
+            viewportCameraSummary: $(".vnccs-i3s__viewport-camera-summary"),
+            cameraActions: Array.from(this.container.querySelectorAll("[data-camera-action]")),
+            cameraPresets: Array.from(this.container.querySelectorAll("[data-camera-preset]")),
+            cameraOrbit: Array.from(this.container.querySelectorAll("[data-camera-orbit]")),
+            cameraPan: Array.from(this.container.querySelectorAll("[data-camera-pan]")),
+            cameraDistanceRange: $(".vnccs-i3s__camera-distance-range"),
+            cameraDistanceInput: $(".vnccs-i3s__camera-distance-input"),
+            cameraHeightRange: $(".vnccs-i3s__camera-height-range"),
+            cameraHeightInput: $(".vnccs-i3s__camera-height-input"),
+            cameraVectors: Array.from(this.container.querySelectorAll("[data-camera-vector]")),
+            cameraFov: $("[data-camera-fov]"),
             fit: $(".vnccs-i3s__fit"),
             modeMove: $(".vnccs-i3s__mode-move"),
             modeRotate: $(".vnccs-i3s__mode-rotate"),
             modeScale: $(".vnccs-i3s__mode-scale"),
+            dropSurface: $(".vnccs-i3s__drop-surface"),
             skydomeOpen: $(".vnccs-i3s__skydome-open"),
             skydomePanel: $(".vnccs-i3s__skydome-panel"),
             skydomeClose: $(".vnccs-i3s__skydome-close"),
@@ -826,6 +1231,10 @@ class Factory3DWidget {
             lightColorValue: $(".vnccs-i3s__light-color-value"),
             lightRadar: $(".vnccs-i3s__lighting-radar"),
             lightElevation: $(".vnccs-i3s__light-elevation"),
+            shadowEnabled: $(".vnccs-i3s__shadow-enabled"),
+            shadowQuality: $(".vnccs-i3s__shadow-quality"),
+            localLightAdd: $(".vnccs-i3s__local-light-add"),
+            localLights: $(".vnccs-i3s__local-lights"),
             lightAzimuthValue: $(".vnccs-i3s__light-azimuth-value"),
             lightElevationValue: $(".vnccs-i3s__light-elevation-value"),
             grid: $(".vnccs-i3s__grid"),
@@ -840,6 +1249,8 @@ class Factory3DWidget {
             selectionCount: $(".vnccs-i3s__selection-count"),
             objectList: $(".vnccs-i3s__object-list"),
             objectCount: $(".vnccs-i3s__object-count"),
+            inspector: $(".vnccs-i3s__inspector"),
+            inspectorKind: $(".vnccs-i3s__inspector-kind"),
             sceneSummary: $(".vnccs-i3s__scene-summary"),
             sceneAspect: $(".vnccs-i3s__scene-aspect"),
             sceneWidth: $(".vnccs-i3s__scene-width"),
@@ -857,7 +1268,66 @@ class Factory3DWidget {
         this._listeners.push(() => target?.removeEventListener(type, handler, options));
     }
 
+    _setWorkspaceTab(side, tab, { save = true, focus = false } = {}) {
+        const allowed = side === "left"
+            ? new Set(["generate", "cameras"])
+            : new Set(["objects", "inspector", "export"]);
+        if (!allowed.has(tab)) return;
+        this.editorView.workspace = {
+            left: this.editorView.workspace?.left || "generate",
+            right: this.editorView.workspace?.right || "objects",
+            [side]: tab,
+        };
+        let activeButton = null;
+        for (const button of this.els.workspaceTabs) {
+            if (button.dataset.workspaceSide !== side) continue;
+            const active = button.dataset.workspaceTab === tab;
+            button.setAttribute("aria-selected", String(active));
+            button.tabIndex = active ? 0 : -1;
+            if (active) activeButton = button;
+        }
+        for (const panel of this.els.workspacePanels) {
+            if (panel.dataset.workspaceSide !== side) continue;
+            panel.hidden = panel.dataset.workspacePanel !== tab;
+        }
+        this._customSelects?.refresh?.();
+        if (focus) activeButton?.focus({ preventScroll: true });
+        if (save) this._scheduleStateSave(0);
+    }
+
+    _syncWorkspace() {
+        this._setWorkspaceTab("left", this.editorView.workspace?.left || "generate", { save: false });
+        this._setWorkspaceTab("right", this.editorView.workspace?.right || "objects", { save: false });
+    }
+
+    _bindWorkspaceTabs() {
+        for (const button of this.els.workspaceTabs) {
+            this._listen(button, "click", () => {
+                this._setWorkspaceTab(button.dataset.workspaceSide, button.dataset.workspaceTab);
+            });
+            this._listen(button, "keydown", event => {
+                if (!["ArrowLeft", "ArrowRight", "Home", "End"].includes(event.key)) return;
+                const tabs = this.els.workspaceTabs.filter(
+                    item => item.dataset.workspaceSide === button.dataset.workspaceSide,
+                );
+                const current = Math.max(0, tabs.indexOf(button));
+                const next = event.key === "Home"
+                    ? 0
+                    : event.key === "End"
+                        ? tabs.length - 1
+                        : (current + (event.key === "ArrowRight" ? 1 : -1) + tabs.length) % tabs.length;
+                event.preventDefault();
+                this._setWorkspaceTab(
+                    button.dataset.workspaceSide,
+                    tabs[next].dataset.workspaceTab,
+                    { focus: true },
+                );
+            });
+        }
+    }
+
     _bind() {
+        this._bindWorkspaceTabs();
         this._listen(api, "vnccs_req_3d_factory_preview", event => {
             const detail = safeObject(event?.detail);
             if (String(detail.node_id ?? "") !== String(this.node?.id ?? "")) return;
@@ -929,6 +1399,50 @@ class Factory3DWidget {
         this._listen(this.els.generate, "click", () => void this.generate());
         this._bindCameraControls();
         this._listen(this.els.cameraAdd, "click", () => void this.addCamera());
+        this._listen(this.els.cameraTrackAdd, "click", () => this._addCameraTrack());
+        this._listen(this.els.cameraTrackDelete, "click", () => this._deleteCameraTrack());
+        this._listen(this.els.cameraKeyframeAdd, "click", () => this._addCameraKeyframe());
+        this._listen(this.els.cameraTrackPlay, "click", () => this._toggleCameraPlayback());
+        this._listen(this.els.cameraTrackSelect, "change", () => {
+            if (this.cameraPlayback) this._toggleCameraPlayback();
+            this.activeCameraTrackId = this.els.cameraTrackSelect.value;
+            const track = this._activeCameraTrack();
+            if (track) this.editorView.active_building_id = this._validBuildingId(track.building_id);
+            this.selectedCameraKeyframeId = "";
+            this._renderCameraTracks();
+            this._renderInspector();
+            this._syncToolbar();
+            this._scheduleSceneSave(0);
+            this._scheduleStateSave(0);
+        });
+        this._listen(this.els.cameraTrackName, "change", () => {
+            const track = this._activeCameraTrack();
+            if (!track) return;
+            const before = this._captureEditorSnapshot();
+            track.name = String(this.els.cameraTrackName.value || "Camera path").trim().slice(0, 80) || "Camera path";
+            this.history.push("Rename camera path", before, this._captureEditorSnapshot());
+            this._renderCameraTracks();
+            this._scheduleSceneSave(0);
+            this._syncToolbar();
+        });
+        this._listen(this.els.cameraTrackBuilding, "change", () => {
+            const track = this._activeCameraTrack();
+            if (!track) return;
+            const before = this._captureEditorSnapshot();
+            track.building_id = this._validBuildingId(this.els.cameraTrackBuilding.value);
+            if (track.building_id) this.editorView.active_building_id = track.building_id;
+            this.history.push("Assign camera path to building", before, this._captureEditorSnapshot());
+            this._renderCameraTracks();
+            this._scheduleSceneSave(0);
+            this._scheduleStateSave(0);
+            this._syncToolbar();
+        });
+        this._listen(this.els.cameraTrackTime, "input", () => {
+            this._setCameraTrackTime(Number(this.els.cameraTrackTime.value));
+        });
+        this._listen(this.els.cameraTrackTime, "pointerdown", () => {
+            if (this.cameraPlayback) this._toggleCameraPlayback();
+        });
         this._listen(this.els.libraryOpen, "click", () => void this.openLibrary());
         this._listen(this.els.plyImport, "click", () => {
             if (this.currentJobId || this.importingPly) {
@@ -949,10 +1463,177 @@ class Factory3DWidget {
             this._scheduleStateSave(0);
             void this._saveSceneNow();
         });
-        this._listen(this.els.fit, "click", () => this.viewer.fit());
+        this._listen(this.els.fit, "click", () => this.viewer.frameScene());
+        this._listen(this.els.viewportCamera, "pointerdown", event => event.stopPropagation());
+        this._listen(this.els.viewportCamera, "click", event => event.stopPropagation());
+        // LiteGraph and ComfyUI listen to both Pointer Events and legacy mouse
+        // events. Blocking only pointerdown/click lets the rest of a range
+        // drag escape to the graph, which can clear selection or end the drag.
+        for (const eventName of [
+            "pointerdown",
+            "pointermove",
+            "pointerup",
+            "pointercancel",
+            "mousedown",
+            "mousemove",
+            "mouseup",
+            "click",
+            "dblclick",
+        ]) {
+            this._listen(this.els.inspector, eventName, event => event.stopPropagation());
+        }
+        // Exact-value typing belongs to the Inspector and must not trigger
+        // ComfyUI graph shortcuts while an input is focused.
+        this._listen(this.els.inspector, "keydown", event => event.stopPropagation());
+        this._listen(this.els.inspector, "keyup", event => event.stopPropagation());
+        this._listen(this.els.inspector, "wheel", event => event.stopPropagation(), { passive: true });
+        for (const control of this.els.cameraActions) {
+            this._listen(control, "click", () => {
+                if (this.cameraPlayback) return;
+                const action = control.dataset.cameraAction;
+                if (action === "home") this.viewer.resetView();
+                else if (action === "selection") this.viewer.frameSelection();
+                else this.viewer.frameScene();
+            });
+        }
+        for (const control of this.els.cameraPresets) {
+            this._listen(control, "click", () => {
+                if (!this.cameraPlayback) this.viewer.setViewPreset(control.dataset.cameraPreset);
+            });
+        }
+        const orbitSteps = {
+            up: { pitch: 7.5 },
+            down: { pitch: -7.5 },
+            left: { yaw: 7.5 },
+            right: { yaw: -7.5 },
+        };
+        for (const control of this.els.cameraOrbit) {
+            this._listen(control, "click", () => {
+                if (!this.cameraPlayback) this.viewer.rotateCameraFPV(orbitSteps[control.dataset.cameraOrbit]);
+            });
+        }
+        const panSteps = {
+            forward: { forward: 1 },
+            back: { forward: -1 },
+            left: { right: -1 },
+            right: { right: 1 },
+        };
+        for (const control of this.els.cameraPan) {
+            this._listen(control, "click", () => {
+                if (!this.cameraPlayback) this.viewer.panCamera(panSteps[control.dataset.cameraPan]);
+            });
+        }
+        this._listen(this.els.cameraDistanceRange, "input", () => {
+            if (!this.cameraPlayback) this.viewer.setCameraDistance(10 ** Number(this.els.cameraDistanceRange.value));
+        });
+        this._listen(this.els.cameraDistanceInput, "input", () => {
+            if (!this.cameraPlayback && Number.isFinite(this.els.cameraDistanceInput.valueAsNumber)) {
+                this.viewer.setCameraDistance(this.els.cameraDistanceInput.valueAsNumber);
+            }
+        });
+        this._listen(this.els.cameraHeightRange, "input", () => {
+            if (!this.cameraPlayback) this.viewer.setCameraHeight(this.els.cameraHeightRange.value);
+        });
+        this._listen(this.els.cameraHeightInput, "input", () => {
+            if (!this.cameraPlayback && Number.isFinite(this.els.cameraHeightInput.valueAsNumber)) {
+                this.viewer.setCameraHeight(this.els.cameraHeightInput.valueAsNumber);
+            }
+        });
+        for (const control of this.els.cameraVectors) {
+            this._listen(control, "input", () => this._applyViewportCameraExact());
+        }
+        this._listen(this.els.cameraFov, "input", () => this._applyViewportCameraExact());
+        this._listen(this.els.view3d, "click", () => this._setViewMode("3d"));
+        this._listen(this.els.viewPlan, "click", () => this._setViewMode("plan"));
+        this._listen(this.els.levelSelect, "change", () => {
+            this.editorView.active_level_id = this.els.levelSelect.value;
+            this.viewer.setActiveLevel(this.editorView.active_level_id);
+            this._selectArchitecture({ type: "level", id: this.editorView.active_level_id });
+            this._syncToolbar();
+            this._scheduleStateSave(0);
+        });
+        this._listen(this.els.buildingSelect, "change", () => {
+            this.editorView.active_building_id = this._validBuildingId(this.els.buildingSelect.value);
+            this._selectArchitecture({ type: "building", id: this.editorView.active_building_id });
+            this._syncToolbar();
+            this._scheduleStateSave(0);
+        });
+        this._listen(this.els.levelAdd, "click", () => {
+            if (!this.scene) return;
+            if (this.scene.levels.length >= 64) {
+                this.toast("A scene can contain up to 64 floor levels.", "error");
+                return;
+            }
+            this._recordEditorCommand("Add floor level", () => {
+                const highest = normalizedLevels(this.scene.levels).at(-1);
+                const level = {
+                    ...DEFAULT_LEVEL,
+                    level_id: factoryId(),
+                    name: `Level ${this.scene.levels.length + 1}`,
+                    elevation: Number(highest.elevation) + Number(highest.height),
+                };
+                this.scene.levels.push(level);
+                this.editorView.active_level_id = level.level_id;
+                this.selectedArchitecture = { type: "level", id: level.level_id };
+                void this._commitArchitecture();
+                this.viewer.setActiveLevel(level.level_id);
+                this._syncToolbar();
+            });
+        });
+        this._listen(this.els.buildingAdd, "click", () => this._addBuilding());
+        this._listen(this.els.undo, "click", () => {
+            this.history.undo();
+            this._syncToolbar();
+        });
+        this._listen(this.els.redo, "click", () => {
+            this.history.redo();
+            this._syncToolbar();
+        });
+        for (const control of this.els.planToolButtons) {
+            this._listen(control, "click", () => this._setPlanTool(control.dataset.planTool));
+        }
+        this._listen(this.els.planGridToggle, "click", () => {
+            this.editorView.plan_grid.visible = !this.editorView.plan_grid.visible;
+            this._syncToolbar();
+            this._scheduleStateSave(0);
+        });
+        this._listen(this.els.snapToggle, "click", () => {
+            this.editorView.snap.enabled = !this.editorView.snap.enabled;
+            this._syncToolbar();
+            this._scheduleStateSave(0);
+        });
+        this._listen(this.els.snapGrid, "change", () => {
+            const step = clamp(this.els.snapGrid.value, 0.001, 1000);
+            this.editorView.plan_grid.step = step;
+            // Preserve the legacy serialized alias for older frontends.
+            this.editorView.snap.grid = step;
+            this._syncToolbar();
+            this._scheduleStateSave(0);
+        });
+        for (const control of this.els.planSettings) {
+            this._listen(control, "change", () => {
+                const key = control.dataset.planSetting;
+                if (key === "opening_kind") {
+                    this.editorView.opening_kind = control.value;
+                } else if (key === "grid_step") {
+                    const step = clamp(control.value, 0.001, 1000);
+                    this.editorView.plan_grid.step = step;
+                    this.editorView.snap.grid = step;
+                } else if (key === "major_every") {
+                    this.editorView.plan_grid.major_every = Math.round(clamp(control.value, 2, 100));
+                } else if (control.type === "checkbox") {
+                    this.editorView.snap[key] = control.checked;
+                } else {
+                    this.editorView.snap[key] = clamp(control.value, 0, 180);
+                }
+                this._syncToolbar();
+                this._scheduleStateSave(0);
+            });
+        }
         this._listen(this.els.modeMove, "click", () => this.viewer.setMode("translate"));
         this._listen(this.els.modeRotate, "click", () => this.viewer.setMode("rotate"));
         this._listen(this.els.modeScale, "click", () => this.viewer.setMode("scale"));
+        this._listen(this.els.dropSurface, "click", event => this._dropSelectionToSurface(event.shiftKey));
         this._listen(this.els.skydomeOpen, "click", event => {
             event.stopPropagation();
             this._setSkydomePanelOpen(this.els.skydomePanel.hidden);
@@ -966,11 +1647,14 @@ class Factory3DWidget {
         });
         this._listen(this.els.skydomeVisible, "click", () => {
             if (!this.scene?.skydome) return;
+            const before = this._captureEditorSnapshot();
             this.scene.skydome.visible = this.scene.skydome.visible === false;
             this._syncSkydome();
             this._commitSkydome({ final: true });
             this._updateSceneSummary();
             this._renderObjects();
+            this.history.push("Toggle skydome visibility", before, this._captureEditorSnapshot());
+            this._syncToolbar();
         });
         for (const [control, key] of [
             [this.els.skydomeYaw, "yaw"],
@@ -979,26 +1663,39 @@ class Factory3DWidget {
             [this.els.skydomeExposure, "exposure"],
             [this.els.skydomeBlur, "blur"],
         ]) {
+            let before = null;
             this._listen(control, "input", () => {
                 if (!this.scene?.skydome) return;
+                before ||= this._captureEditorSnapshot();
                 this.scene.skydome[key] = Number(control.value);
                 this._syncSkydome();
                 this._commitSkydome();
             });
-            this._listen(control, "change", () => this._commitSkydome({ final: true }));
+            this._listen(control, "change", () => {
+                this._commitSkydome({ final: true });
+                if (before) this.history.push("Edit skydome", before, this._captureEditorSnapshot());
+                before = null;
+                this._syncToolbar();
+            });
         }
         this._listen(this.els.skydomeLevel, "click", () => {
             if (!this.scene?.skydome) return;
+            const before = this._captureEditorSnapshot();
             this.scene.skydome.pitch = 0;
             this.scene.skydome.roll = 0;
             this._syncSkydome();
             this._commitSkydome({ final: true });
+            this.history.push("Level skydome horizon", before, this._captureEditorSnapshot());
+            this._syncToolbar();
         });
         this._listen(this.els.skydomeReset, "click", () => {
             if (!this.scene?.skydome) return;
+            const before = this._captureEditorSnapshot();
             Object.assign(this.scene.skydome, { yaw: 0, pitch: 0, roll: 0 });
             this._syncSkydome();
             this._commitSkydome({ final: true });
+            this.history.push("Reset skydome orientation", before, this._captureEditorSnapshot());
+            this._syncToolbar();
         });
         this._listen(this.els.skydomeRemove, "click", () => void this.removeSkydome());
         this._listen(this.els.lightingOpen, "click", event => {
@@ -1017,27 +1714,101 @@ class Factory3DWidget {
                 && !this.els.skydomePanel.contains(event.target)
                 && !this.els.skydomeOpen.contains(event.target)
             ) this._setSkydomePanelOpen(false);
+            if (this.els.planSettingsPanel.open && !this.els.planSettingsPanel.contains(event.target)) {
+                this.els.planSettingsPanel.open = false;
+            }
         });
         this._listen(document, "keydown", event => {
+            const activeWithin = this.container.contains(event.target)
+                || this.container.contains(document.activeElement);
+            const editing = event.target instanceof HTMLInputElement
+                || event.target instanceof HTMLTextAreaElement
+                || event.target instanceof HTMLSelectElement
+                || event.target?.isContentEditable;
+            const modifier = event.ctrlKey || event.metaKey;
+            if (activeWithin && !editing && modifier && event.key.toLowerCase() === "z") {
+                event.preventDefault();
+                if (event.shiftKey) this.history.redo();
+                else this.history.undo();
+                this._syncToolbar();
+                return;
+            }
+            if (activeWithin && !editing && modifier && event.key.toLowerCase() === "y") {
+                event.preventDefault();
+                this.history.redo();
+                this._syncToolbar();
+                return;
+            }
+            if (activeWithin && !editing && event.key === "Escape" && this.cameraPlayback) {
+                event.preventDefault();
+                this._toggleCameraPlayback();
+                return;
+            }
+            if (activeWithin && !editing && event.key === "Escape" && this.previewCameraId) {
+                event.preventDefault();
+                this._exitCameraView({ restore: true });
+                return;
+            }
+            if (
+                activeWithin
+                && !editing
+                && event.key === "Escape"
+                && this.editorView.view_mode === "plan"
+                && this.editorView.plan_tool !== "select"
+            ) {
+                event.preventDefault();
+                this._setPlanTool("select");
+                return;
+            }
+            if (activeWithin && !editing && event.key.toLowerCase() === "v") {
+                event.preventDefault();
+                if (this.editorView.view_mode === "plan") this._setPlanTool("select");
+                else this.viewer.setMode("translate");
+                return;
+            }
+            if (activeWithin && !editing && event.key === "End") {
+                event.preventDefault();
+                this._dropSelectionToSurface(event.shiftKey);
+                return;
+            }
             if (event.key === "Escape" && !this.els.lightingPanel.hidden) {
                 this._setLightingPanelOpen(false);
+                return;
             }
             if (event.key === "Escape" && !this.els.skydomePanel.hidden) {
                 this._setSkydomePanelOpen(false);
+                return;
+            }
+            if (event.key === "Escape" && this.els.planSettingsPanel.open) {
+                this.els.planSettingsPanel.open = false;
+                return;
+            }
+            if (activeWithin && !editing && event.key === "Escape") {
+                event.preventDefault();
+                this._clearSelection();
             }
         });
         for (const presetButton of this.els.lightingPresets) {
             this._listen(presetButton, "click", () => {
+                const before = this._captureEditorSnapshot();
                 const key = presetButton.dataset.preset;
                 const preset = LIGHTING_PRESETS[key];
                 if (!preset) return;
-                this.lighting = { preset: key, ...preset };
+                this.lighting = {
+                    ...this.lighting,
+                    preset: key,
+                    ...preset,
+                    shadows: { ...this.lighting.shadows },
+                    lights: [...(this.lighting.lights || [])],
+                };
                 delete this.lighting.label;
                 this._syncLighting();
                 this._commitLighting({ final: true });
+                this.history.push("Change lighting preset", before, this._captureEditorSnapshot());
             });
         }
         this._listen(this.els.lightIntensity, "input", () => {
+            this._beginLightingHistory();
             this.lighting.intensity = Number(this.els.lightIntensity.value);
             this.lighting.preset = "custom";
             this._syncLighting();
@@ -1045,8 +1816,10 @@ class Factory3DWidget {
         });
         this._listen(this.els.lightIntensity, "change", () => {
             this._commitLighting({ final: true });
+            this._finishLightingHistory("Edit light strength");
         });
         this._listen(this.els.lightColor, "input", () => {
+            this._beginLightingHistory();
             this.lighting.color = this.els.lightColor.value;
             this.lighting.preset = "custom";
             this._syncLighting();
@@ -1054,8 +1827,10 @@ class Factory3DWidget {
         });
         this._listen(this.els.lightColor, "change", () => {
             this._commitLighting({ final: true });
+            this._finishLightingHistory("Edit light color");
         });
         this._listen(this.els.lightElevation, "input", () => {
+            this._beginLightingHistory();
             this.lighting.elevation = Number(this.els.lightElevation.value);
             this.lighting.preset = "custom";
             this._syncLighting();
@@ -1063,6 +1838,59 @@ class Factory3DWidget {
         });
         this._listen(this.els.lightElevation, "change", () => {
             this._commitLighting({ final: true });
+            this._finishLightingHistory("Edit light direction");
+        });
+        this._listen(this.els.shadowEnabled, "click", () => {
+            const before = this._captureEditorSnapshot();
+            this.lighting.shadows.enabled = !this.lighting.shadows.enabled;
+            this._syncLighting();
+            this._commitLighting({ final: true });
+            this.history.push("Toggle shadows", before, this._captureEditorSnapshot());
+        });
+        this._listen(this.els.shadowQuality, "change", () => {
+            const before = this._captureEditorSnapshot();
+            this.lighting.shadows.quality = this.els.shadowQuality.value;
+            this.lighting.shadows.enabled = true;
+            this._syncLighting();
+            this._commitLighting({ final: true });
+            this.history.push("Change shadow quality", before, this._captureEditorSnapshot());
+        });
+        this._listen(this.els.localLightAdd, "click", () => {
+            if (this.lighting.lights.length >= 32) {
+                this.toast("A scene can contain up to 32 local lights.", "error");
+                return;
+            }
+            const before = this._captureEditorSnapshot();
+            const level = this.scene?.levels?.find(value => value.level_id === this.editorView.active_level_id);
+            const building = this._activeBuilding();
+            const buildingElevation = Number(building?.position?.[1]) || 0;
+            const planTarget = this.viewer?.getState?.().plan_camera?.target || [0, 0];
+            const cameraTarget = this.viewer?.getCameraState?.().target || [0, 0, 0];
+            const center = this.editorView.view_mode === "plan"
+                ? [Number(planTarget[0]) || 0, Number(planTarget[1]) || 0]
+                : [Number(cameraTarget[0]) || 0, Number(cameraTarget[2]) || 0];
+            const lightId = factoryId();
+            this.lighting.lights.push({
+                light_id: lightId,
+                name: `Light ${this.lighting.lights.length + 1}`,
+                level_id: this.editorView.active_level_id,
+                building_id: building?.building_id || "",
+                kind: "point",
+                position: [center[0], (Number(level?.elevation) || 0) + buildingElevation + 2.4, center[1]],
+                target: [center[0], (Number(level?.elevation) || 0) + buildingElevation, center[1]],
+                color: "#ffffff",
+                intensity: 10,
+                distance: 8,
+                angle: 45,
+                penumbra: 0.2,
+                cast_shadow: true,
+                visible: true,
+            });
+            this._expandedLightId = lightId;
+            if (before) this.history.push("Add light", before, this._captureEditorSnapshot());
+            this._syncLighting();
+            this._commitLighting({ final: true });
+            this._syncToolbar();
         });
         this._bindLightingRadar();
         this._listen(this.els.grid, "click", () => this.viewer.setGrid(!this.viewerState.grid));
@@ -1130,6 +1958,2842 @@ class Factory3DWidget {
         this._listen(this.els.sceneExport, "click", () => void this.exportScene());
     }
 
+    _captureEditorSnapshot() {
+        if (!this.scene) return null;
+        return JSON.parse(JSON.stringify({
+            levels: this.scene.levels || [],
+            architecture: this.scene.architecture || {},
+            objects: (this.scene.objects || []).map(item => ({
+                object_id: item.object_id,
+                name: item.name,
+                level_id: item.level_id,
+                building_id: item.building_id,
+                transform: item.transform,
+                visible: item.visible !== false,
+                ...normalizedObjectEditorProperties(item),
+            })),
+            layers: this.scene.layers || [],
+            cameras: this.scene.cameras || [],
+            camera_tracks: this.scene.camera_tracks || [],
+            lighting: this.lighting,
+            skydome: this.scene.skydome || null,
+            render: this.exportSettings,
+        }));
+    }
+
+    _dropSelectionToSurface(individual = false) {
+        if (!this.scene || !this.viewer) return;
+        const before = this._captureEditorSnapshot();
+        let results = null;
+        this._suppressViewerTransformHistory = true;
+        try { results = this.viewer.dropSelectionToSurface({ individual }); }
+        finally {
+            this._suppressViewerTransformHistory = false;
+            this._viewerTransformHistoryBefore = null;
+        }
+        if (!results?.length) {
+            this.toast("Select an unlocked object to drop.", "info");
+            return;
+        }
+        this.history.push("Drop to surface", before, this._captureEditorSnapshot());
+        const support = Math.max(...results.map(result => Number(result.supportY) || 0));
+        this.toast(`Placed on the nearest support at ${support.toFixed(2)} m.`, "success");
+        this._renderInspector();
+        this._scheduleSceneSave(0);
+        this._scheduleStateSave(0);
+        this._scheduleScenePreview(120);
+    }
+
+    _placeNewObjectOnActiveFloor(objectId) {
+        const item = this.scene?.objects?.find(value => value.object_id === objectId);
+        const targetLevel = this.scene?.levels?.find(
+            value => value.level_id === this.editorView.active_level_id,
+        );
+        if (!item || !targetLevel) return false;
+        const previousLevel = this.scene.levels.find(value => value.level_id === item.level_id);
+        const before = this._captureEditorSnapshot();
+        item.transform ||= { position: [0, 0, 0], rotation: [0, 0, 0], scale: 1 };
+        item.transform.position = Array.isArray(item.transform.position)
+            ? [...item.transform.position]
+            : [0, 0, 0];
+        const targetBuilding = this._activeBuilding()
+            || this.scene.architecture?.buildings?.[0]
+            || null;
+        item.transform.position[0] += Number(targetBuilding?.position?.[0]) || 0;
+        item.transform.position[1] += (Number(targetLevel.elevation) || 0)
+            - (Number(previousLevel?.elevation) || 0)
+            + (Number(targetBuilding?.position?.[1]) || 0);
+        item.transform.position[2] += Number(targetBuilding?.position?.[2]) || 0;
+        item.level_id = targetLevel.level_id;
+        item.building_id = targetBuilding?.building_id
+            || "";
+        this.viewer.updateObject(item.object_id, item);
+        this._selectObject(item.object_id);
+        this.history.push("Place new object on active floor", before, this._captureEditorSnapshot());
+        this._dropSelectionToSurface(false);
+        this._renderObjects();
+        this._scheduleSceneSave(0);
+        return true;
+    }
+
+    _recordEditorCommand(label, operation) {
+        if (!this.scene) return operation?.();
+        const before = this._captureEditorSnapshot();
+        const result = operation?.();
+        const finish = () => {
+            const after = this._captureEditorSnapshot();
+            this.history.push(label, before, after);
+            this._scheduleStateSave(0);
+            this._syncToolbar();
+        };
+        if (result?.then) return result.finally(finish);
+        finish();
+        return result;
+    }
+
+    async _restoreEditorSnapshot(snapshot) {
+        if (!this.scene || !snapshot) return;
+        this.scene.levels = normalizedLevels(snapshot.levels);
+        this.scene.architecture = normalizedArchitecture(snapshot.architecture, this.scene.levels);
+        const byId = new Map((snapshot.objects || []).map(item => [item.object_id, item]));
+        for (const item of this.scene.objects || []) {
+            const restored = byId.get(item.object_id);
+            if (restored) Object.assign(item, restored);
+        }
+        this.scene.cameras = this._normalizeSceneCameras(snapshot.cameras);
+        this.scene.camera_tracks = Array.isArray(snapshot.camera_tracks)
+            ? JSON.parse(JSON.stringify(snapshot.camera_tracks)).map(track => ({
+                ...track,
+                building_id: this._validBuildingId(track.building_id),
+            }))
+            : [];
+        this.scene.layers = Array.isArray(snapshot.layers)
+            ? JSON.parse(JSON.stringify(snapshot.layers))
+            : this.scene.layers;
+        this.scene.lighting = this._normalizeLighting(snapshot.lighting);
+        this.lighting = { ...this.scene.lighting };
+        this.scene.skydome = snapshot.skydome
+            ? JSON.parse(JSON.stringify(snapshot.skydome))
+            : null;
+        this.exportSettings = { ...this.exportSettings, ...safeObject(snapshot.render) };
+        await this.viewer.setScene(this.scene, { incremental: true });
+        this.viewer.setViewMode(this.editorView.view_mode);
+        this.viewer.setPlanTool(this.editorView.plan_tool);
+        this.viewer.setActiveLevel(this.editorView.active_level_id);
+        this.viewer.setArchitectureSelection(this.selectedArchitecture);
+        this.viewer.applySceneVisibility(this.scene);
+        this.viewer.setCameraMarkers(this.scene.cameras || []);
+        this.viewer.setLighting(this.lighting);
+        this._renderObjects();
+        this._renderCameras();
+        this._renderCameraTracks();
+        this._renderInspector();
+        this._syncLighting();
+        this._syncSkydome();
+        this._syncExportSettings();
+        this._syncToolbar();
+        this._scheduleSceneSave(0);
+        this._scheduleScenePreview(120);
+        this._scheduleStateSave(0);
+    }
+
+    _setViewMode(mode) {
+        this.editorView.view_mode = mode === "plan" ? "plan" : "3d";
+        if (this.editorView.view_mode !== "plan") this._cancelPlanDraft();
+        this.viewer.setViewMode(this.editorView.view_mode);
+        this._syncToolbar();
+        this._scheduleStateSave(0);
+    }
+
+    _syncViewportCameraHUD(camera = this.viewerState.camera || {}) {
+        if (!this.els?.viewportCamera) return;
+        const position = Array.isArray(camera.position) ? camera.position : [2.8, 2.1, 4.2];
+        const target = Array.isArray(camera.target) ? camera.target : [0, 0, 0];
+        const distance = Math.max(
+            Math.hypot(
+                (Number(position[0]) || 0) - (Number(target[0]) || 0),
+                (Number(position[1]) || 0) - (Number(target[1]) || 0),
+                (Number(position[2]) || 0) - (Number(target[2]) || 0),
+            ),
+            0.0001,
+        );
+        const height = Number(position[1]) || 0;
+        const write = (control, value) => {
+            if (control && document.activeElement !== control) control.value = String(value);
+        };
+        write(this.els.cameraDistanceRange, Math.log10(distance));
+        write(this.els.cameraDistanceInput, Number(distance.toPrecision(7)));
+        write(this.els.cameraHeightRange, clamp(height, -50, 100));
+        write(this.els.cameraHeightInput, Number(height.toFixed(6)));
+        for (const control of this.els.cameraVectors) {
+            const vector = control.dataset.cameraVector === "target" ? target : position;
+            const axis = Number(control.dataset.cameraAxis) || 0;
+            write(control, Number((Number(vector[axis]) || 0).toFixed(6)));
+        }
+        write(this.els.cameraFov, Number((Number(camera.fov) || 42).toFixed(3)));
+        this.els.viewportCameraSummary.textContent = `${distance.toFixed(distance < 10 ? 2 : 1)} m · Y ${height.toFixed(2)}`;
+        const selectionAction = this.els.cameraActions.find(
+            control => control.dataset.cameraAction === "selection",
+        );
+        if (selectionAction) {
+            selectionAction.disabled = !(
+                this.selectedObjectId
+                || this.selectedGroupId
+                || this.selectedArchitecture?.id
+            );
+        }
+        const disabled = Boolean(this.cameraPlayback);
+        for (const control of [
+            ...this.els.cameraActions,
+            ...this.els.cameraPresets,
+            ...this.els.cameraOrbit,
+            ...this.els.cameraPan,
+            this.els.cameraDistanceRange,
+            this.els.cameraDistanceInput,
+            this.els.cameraHeightRange,
+            this.els.cameraHeightInput,
+            ...this.els.cameraVectors,
+            this.els.cameraFov,
+        ]) {
+            if (!control) continue;
+            if (control === selectionAction && !disabled) continue;
+            control.disabled = disabled;
+        }
+        this.els.viewportCamera.classList.toggle("is-playback", disabled);
+    }
+
+    _applyViewportCameraExact() {
+        if (this.cameraPlayback) return;
+        const current = this.viewer.getCameraState();
+        const next = {
+            ...current,
+            position: [...current.position],
+            target: [...current.target],
+            fov: Number.isFinite(this.els.cameraFov.valueAsNumber)
+                ? clamp(this.els.cameraFov.valueAsNumber, 5, 120)
+                : current.fov,
+        };
+        for (const control of this.els.cameraVectors) {
+            const key = control.dataset.cameraVector === "target" ? "target" : "position";
+            const axis = Number(control.dataset.cameraAxis) || 0;
+            const value = control.valueAsNumber;
+            if (Number.isFinite(value)) next[key][axis] = value;
+        }
+        this.viewer.setCameraState(next, { emit: true });
+    }
+
+    _setPlanTool(tool) {
+        if (!["select", "wall", "room", "opening", "camera"].includes(tool)) return;
+        if (this.planDraft && this.planDraft.tool !== tool) this._cancelPlanDraft();
+        this._clearPlanHover();
+        this.editorView.plan_tool = tool;
+        this.viewer.setPlanTool(tool);
+        this._renderPlanPreview();
+        this._syncToolbar();
+        this._scheduleStateSave(0);
+    }
+
+    _addBuilding() {
+        if (!this.scene) return;
+        if ((this.scene.architecture?.buildings?.length || 0) >= 64) {
+            this.toast("A scene can contain up to 64 buildings.", "error");
+            return;
+        }
+        this._recordEditorCommand("Add building", () => {
+            const architecture = this.scene.architecture ||= normalizedArchitecture({}, this.scene.levels);
+            const building = {
+                ...DEFAULT_BUILDING,
+                building_id: factoryId(),
+                name: `Building ${(architecture.buildings?.length || 0) + 1}`,
+                position: [0, 0, 0],
+            };
+            architecture.buildings.push(building);
+            this.editorView.active_building_id = building.building_id;
+            this.selectedArchitecture = { type: "building", id: building.building_id };
+            void this._commitArchitecture();
+        });
+    }
+
+    _clearPlanHover() {
+        if (this._planHoverFrame) cancelAnimationFrame(this._planHoverFrame);
+        this._planHoverFrame = 0;
+        this._pendingPlanHover = null;
+        this.planHover = null;
+    }
+
+    _queuePlanHover(tool, rawPoint, event = {}) {
+        this._pendingPlanHover = {
+            tool,
+            point: Array.isArray(rawPoint) ? [...rawPoint] : null,
+            event: {
+                altKey: Boolean(event.altKey),
+                shiftKey: Boolean(event.shiftKey),
+            },
+        };
+        if (this._planHoverFrame) return;
+        this._planHoverFrame = requestAnimationFrame(() => {
+            this._planHoverFrame = 0;
+            const pending = this._pendingPlanHover;
+            this._pendingPlanHover = null;
+            if (!pending || this.editorView.view_mode !== "plan" || pending.tool !== this.editorView.plan_tool) {
+                return;
+            }
+            if (!pending.point) {
+                this.planHover = null;
+                this._renderPlanPreview();
+                return;
+            }
+            // Opening owns a stronger wall-projection snap. Rounding the
+            // cursor to the global grid first can move it away from a thin
+            // wall at high zoom and make an otherwise valid click look inert.
+            const point = pending.tool === "opening"
+                ? [...pending.point]
+                : this._snapPlanPoint(pending.point, pending.event);
+            if (pending.tool === "opening") this.planSnapHint = "Wall projection";
+            const nearest = pending.tool === "opening"
+                ? this._nearestWallProjection(point)
+                : null;
+            const openingKind = this.editorView.opening_kind || "window";
+            const openingPlacement = nearest
+                ? this._openingPlacement(nearest, openingKind === "door" ? 0.9 : 1.2)
+                : null;
+            if (openingPlacement) openingPlacement.kind = openingKind;
+            this.planHover = {
+                tool: pending.tool,
+                point,
+                opening: openingPlacement,
+            };
+            const previous = this.planDraft?.points?.at(-1);
+            const measurement = previous
+                ? ` · ${Math.hypot(point[0] - previous[0], point[1] - previous[1]).toFixed(2)} m · ${((Math.atan2(point[1] - previous[1], point[0] - previous[0]) * 180 / Math.PI + 360) % 360).toFixed(1)}°`
+                : "";
+            if (pending.tool === "opening") {
+                this.els.planHint.textContent = openingPlacement
+                    ? `Press and drag on the wall to set width · ${nearest.length.toFixed(2)} m wall`
+                    : nearest
+                        ? "This wall has no free span for another opening."
+                        : "Move over an editable wall, then press and drag.";
+            } else if (pending.tool === "camera" && previous) {
+                this.els.planHint.textContent = `Aim camera${measurement}`;
+            } else {
+                this.els.planHint.textContent = `${this.planSnapHint || "Free"}${measurement}`;
+            }
+            this._renderPlanPreview();
+        });
+    }
+
+    _roomRectangle(start, end) {
+        if (!Array.isArray(start) || !Array.isArray(end)) return null;
+        if (Math.abs(end[0] - start[0]) < 0.001 || Math.abs(end[1] - start[1]) < 0.001) return null;
+        return [
+            [start[0], start[1]],
+            [end[0], start[1]],
+            [end[0], end[1]],
+            [start[0], end[1]],
+        ];
+    }
+
+    _activeBuilding() {
+        const buildings = this.scene?.architecture?.buildings || [];
+        if (this.selectedArchitecture?.type === "building") {
+            const selected = buildings.find(item => item.building_id === this.selectedArchitecture.id);
+            if (selected) return selected;
+        }
+        const selectedItem = this._selectedArchitectureValue();
+        if (selectedItem?.building_id) {
+            const owner = buildings.find(item => item.building_id === selectedItem.building_id);
+            if (owner) return owner;
+        }
+        const selectedObject = this.scene?.objects?.find(item => item.object_id === this.selectedObjectId);
+        if (selectedObject?.building_id) {
+            const owner = buildings.find(item => item.building_id === selectedObject.building_id);
+            if (owner) return owner;
+        }
+        const selectedCamera = this.scene?.cameras?.find(item => item.camera_id === this.selectedCameraId);
+        if (selectedCamera?.building_id) {
+            const owner = buildings.find(item => item.building_id === selectedCamera.building_id);
+            if (owner) return owner;
+        }
+        const selectedGroup = this._groupById(this.selectedGroupId);
+        const groupedObject = selectedGroup?.children?.length
+            ? this.scene?.objects?.find(item => item.object_id === selectedGroup.children[0])
+            : null;
+        if (groupedObject?.building_id) {
+            const owner = buildings.find(item => item.building_id === groupedObject.building_id);
+            if (owner) return owner;
+        }
+        if (this.selectedCameraKeyframeId) {
+            const track = this._activeCameraTrack();
+            const owner = buildings.find(item => item.building_id === track?.building_id);
+            if (owner) return owner;
+        }
+        const active = buildings.find(item => item.building_id === this.editorView.active_building_id);
+        if (active) return active;
+        return buildings[0] || null;
+    }
+
+    _buildingForItem(item) {
+        const buildingId = String(item?.building_id || "");
+        if (!buildingId) return null;
+        return this.scene?.architecture?.buildings?.find(
+            building => building.building_id === buildingId,
+        ) || null;
+    }
+
+    _validBuildingId(value) {
+        const buildings = this.scene?.architecture?.buildings || [];
+        const requested = String(value || "");
+        return buildings.some(building => building.building_id === requested)
+            ? requested
+            : "";
+    }
+
+    _buildingOptions(selectedId = "") {
+        const valid = this._validBuildingId(selectedId);
+        return `<option value=""${valid ? "" : " selected"}>No building</option>`
+            + (this.scene?.architecture?.buildings || []).map(building => (
+            `<option value="${building.building_id}"${building.building_id === valid ? " selected" : ""}>${escapeHTML(building.name || "Building")}</option>`
+        )).join("");
+    }
+
+    _transformPointWithBuilding(point, previousPosition, nextPosition, deltaRotationDegrees) {
+        const source = Array.isArray(point) ? point : [0, 0, 0];
+        const angle = Number(deltaRotationDegrees || 0) * Math.PI / 180;
+        const cosine = Math.cos(angle);
+        const sine = Math.sin(angle);
+        const x = (Number(source[0]) || 0) - previousPosition[0];
+        const z = (Number(source[2]) || 0) - previousPosition[2];
+        return [
+            x * cosine + z * sine + nextPosition[0],
+            (Number(source[1]) || 0) + nextPosition[1] - previousPosition[1],
+            -x * sine + z * cosine + nextPosition[2],
+        ];
+    }
+
+    _applyBuildingTransform(building, nextPosition, nextRotationY) {
+        if (!building) return;
+        const previousPosition = [0, 1, 2].map(index => Number(building.position?.[index]) || 0);
+        const position = [0, 1, 2].map(index => Number(nextPosition?.[index]) || 0);
+        const previousRotation = Number(building.rotation_y) || 0;
+        const rotation = Number(nextRotationY) || 0;
+        const deltaRotation = rotation - previousRotation;
+        const hasPositionDelta = position.some((value, index) => Math.abs(value - previousPosition[index]) > 1e-12);
+        if (!hasPositionDelta && Math.abs(deltaRotation) <= 1e-12) return;
+        const transformPoint = point => this._transformPointWithBuilding(
+            point,
+            previousPosition,
+            position,
+            deltaRotation,
+        );
+        for (const object of this.scene?.objects || []) {
+            if (object.building_id !== building.building_id) continue;
+            object.transform ||= { position: [0, 0, 0], rotation: [0, 0, 0], scale: 1 };
+            object.transform.position = transformPoint(object.transform.position);
+            object.transform.rotation = Array.isArray(object.transform.rotation)
+                ? [...object.transform.rotation]
+                : [0, 0, 0];
+            object.transform.rotation[1] = (Number(object.transform.rotation[1]) || 0) + deltaRotation;
+            this.viewer?.updateObject(object.object_id, { transform: object.transform });
+        }
+        for (const camera of this.scene?.cameras || []) {
+            if (camera.building_id !== building.building_id) continue;
+            camera.position = transformPoint(camera.position);
+            camera.target = transformPoint(camera.target);
+            if (Array.isArray(camera.up) && Math.abs(deltaRotation) > 1e-12) {
+                const angle = deltaRotation * Math.PI / 180;
+                const cosine = Math.cos(angle);
+                const sine = Math.sin(angle);
+                const x = Number(camera.up[0]) || 0;
+                const z = Number(camera.up[2]) || 0;
+                camera.up = [x * cosine + z * sine, Number(camera.up[1]) || 0, -x * sine + z * cosine];
+            }
+        }
+        if (Math.abs(deltaRotation) > 1e-12 || hasPositionDelta) {
+            const halfYaw = deltaRotation * Math.PI / 360;
+            const yaw = [0, Math.sin(halfYaw), 0, Math.cos(halfYaw)];
+            for (const track of this.scene?.camera_tracks || []) {
+                if (track.building_id !== building.building_id) continue;
+                for (const frame of track.keyframes || []) {
+                    frame.position = transformPoint(frame.position);
+                    if (Math.abs(deltaRotation) > 1e-12) {
+                        frame.quaternion = multiplyQuaternions(yaw, frame.quaternion);
+                    }
+                }
+            }
+        }
+        for (const light of this.lighting?.lights || []) {
+            if (light.building_id !== building.building_id) continue;
+            light.position = transformPoint(light.position);
+            light.target = transformPoint(light.target);
+        }
+        building.position = position;
+        building.rotation_y = rotation;
+        if (this.previewCameraId) {
+            const preview = this.scene?.cameras?.find(camera => camera.camera_id === this.previewCameraId);
+            if (preview?.building_id === building.building_id) {
+                this.viewer?.setCameraState(preview, { emit: false });
+            }
+        }
+        this.viewer?.setCameraMarkers(this.scene?.cameras || []);
+        if (this.lighting) {
+            this.scene.lighting = { ...this.lighting };
+            this.viewer?.setLighting(this.lighting);
+        }
+    }
+
+    _localToWorldPlan(point, building) {
+        const angle = Number(building?.rotation_y || 0) * Math.PI / 180;
+        const cosine = Math.cos(angle);
+        const sine = Math.sin(angle);
+        const x = Number(point?.[0]) || 0;
+        const z = Number(point?.[1]) || 0;
+        return [
+            x * cosine + z * sine + (Number(building?.position?.[0]) || 0),
+            -x * sine + z * cosine + (Number(building?.position?.[2]) || 0),
+        ];
+    }
+
+    _worldToLocalPlan(point, building) {
+        const angle = -Number(building?.rotation_y || 0) * Math.PI / 180;
+        const cosine = Math.cos(angle);
+        const sine = Math.sin(angle);
+        const x = (Number(point?.[0]) || 0) - (Number(building?.position?.[0]) || 0);
+        const z = (Number(point?.[1]) || 0) - (Number(building?.position?.[2]) || 0);
+        return [
+            Number((x * cosine + z * sine).toFixed(6)),
+            Number((-x * sine + z * cosine).toFixed(6)),
+        ];
+    }
+
+    _renderPlanPreview() {
+        if (!this.viewer) return;
+        const hover = this.planHover?.tool === this.editorView.plan_tool
+            ? this.planHover
+            : null;
+        if (this.planDraft?.tool === "wall") {
+            this.viewer.setPlanDraft({
+                ...this.planDraft,
+                cursor: hover?.point || null,
+                thickness: DEFAULT_WALL.thickness,
+            });
+            return;
+        }
+        if (this.planDraft?.tool === "room") {
+            const start = this.planDraft.points?.[0];
+            this.viewer.setPlanDraft({
+                ...this.planDraft,
+                cursor: hover?.point || null,
+                rectangle: this._roomRectangle(start, hover?.point),
+                thickness: DEFAULT_WALL.thickness,
+            });
+            return;
+        }
+        if (hover?.tool === "opening") {
+            this.viewer.setPlanDraft({
+                tool: "opening",
+                cursor: hover.point,
+                opening: hover.opening,
+            });
+            return;
+        }
+        if (this.planDraft?.tool === "camera") {
+            this.viewer.setPlanDraft({
+                ...this.planDraft,
+                cursor: hover?.point || null,
+                fov: 42,
+            });
+            return;
+        }
+        if (hover && ["camera"].includes(hover.tool)) {
+            this.viewer.setPlanDraft({ tool: hover.tool, cursor: hover.point, fov: 42 });
+            return;
+        }
+        this.viewer.setPlanDraft(null);
+    }
+
+    _snapPlanPoint(point, event = {}, snapOrigin = null) {
+        const pointerPoint = [...point];
+        const result = [...point];
+        if (event.altKey || this.editorView.snap?.enabled === false) {
+            this.planSnapHint = event.altKey ? "Snap temporarily bypassed" : "Snap off";
+            return result;
+        }
+        const grid = Math.max(
+            0.001,
+            Number(this.editorView.plan_grid?.step ?? this.editorView.snap?.grid) || 0.1,
+        );
+        result[0] = Math.round(result[0] / grid) * grid;
+        result[1] = Math.round(result[1] / grid) * grid;
+        this.planSnapHint = `Grid ${grid.toLocaleString()} m`;
+        const previous = Array.isArray(snapOrigin)
+            ? snapOrigin
+            : ["wall", "camera"].includes(this.planDraft?.tool)
+                ? this.planDraft.points?.at(-1)
+                : null;
+        if (previous && (event.shiftKey || this.editorView.snap?.orthogonal)) {
+            const dx = Math.abs(result[0] - previous[0]);
+            const dz = Math.abs(result[1] - previous[1]);
+            if (event.shiftKey || Math.min(dx, dz) <= grid * 0.35) {
+                if (dx >= dz) result[1] = previous[1];
+                else result[0] = previous[0];
+                this.planSnapHint = "Orthogonal";
+            }
+        }
+        if (previous && !event.shiftKey && Number(this.editorView.snap?.angle) > 0) {
+            const dx = result[0] - previous[0];
+            const dz = result[1] - previous[1];
+            const radius = Math.hypot(dx, dz);
+            const increment = Number(this.editorView.snap.angle) * Math.PI / 180;
+            const angle = Math.atan2(dz, dx);
+            const snappedAngle = Math.round(angle / increment) * increment;
+            const delta = Math.abs(Math.atan2(Math.sin(angle - snappedAngle), Math.cos(angle - snappedAngle)));
+            if (radius > 0.001 && delta <= Math.min(increment * 0.3, 3 * Math.PI / 180)) {
+                result[0] = previous[0] + Math.cos(snappedAngle) * radius;
+                result[1] = previous[1] + Math.sin(snappedAngle) * radius;
+                this.planSnapHint = `Angle ${this.editorView.snap.angle}°`;
+            }
+        }
+        const threshold = 10 / Math.max(0.01, Number(this.viewerState.plan_camera?.zoom) || 24);
+        let nearest = null;
+        for (const wall of this.scene?.architecture?.walls || []) {
+            if (wall.level_id !== this.editorView.active_level_id) continue;
+            const building = this._buildingForItem(wall);
+            if (wall.visible === false || building?.visible === false) continue;
+            const wallStart = this._localToWorldPlan(wall.start, building);
+            const wallEnd = this._localToWorldPlan(wall.end, building);
+            const candidates = [];
+            if (this.editorView.snap?.endpoints !== false) {
+                candidates.push({ point: wallStart, kind: "Endpoint" }, { point: wallEnd, kind: "Endpoint" });
+            }
+            if (this.editorView.snap?.midpoints !== false) {
+                candidates.push({
+                    point: [
+                        (wallStart[0] + wallEnd[0]) * 0.5,
+                        (wallStart[1] + wallEnd[1]) * 0.5,
+                    ],
+                    kind: "Midpoint",
+                });
+            }
+            for (const candidate of candidates) {
+                const distance = Math.hypot(
+                    pointerPoint[0] - candidate.point[0],
+                    pointerPoint[1] - candidate.point[1],
+                );
+                if (distance <= threshold && (!nearest || distance < nearest.distance)) {
+                    nearest = { point: candidate.point, distance, kind: candidate.kind };
+                }
+            }
+        }
+        if (nearest) this.planSnapHint = nearest.kind;
+        return nearest ? [...nearest.point] : result.map(value => Number(value.toFixed(6)));
+    }
+
+    _wallProjection(point, wall) {
+        if (!Array.isArray(point) || !wall) return null;
+        const building = this._buildingForItem(wall);
+        const wallStart = this._localToWorldPlan(wall.start, building);
+        const wallEnd = this._localToWorldPlan(wall.end, building);
+        const dx = wallEnd[0] - wallStart[0];
+        const dz = wallEnd[1] - wallStart[1];
+        const lengthSquared = dx * dx + dz * dz;
+        if (lengthSquared < 1e-9) return null;
+        const offset = clamp(
+            ((point[0] - wallStart[0]) * dx + (point[1] - wallStart[1]) * dz) / lengthSquared,
+            0,
+            1,
+        );
+        const projected = [wallStart[0] + dx * offset, wallStart[1] + dz * offset];
+        return {
+            wall,
+            offset,
+            distance: Math.hypot(point[0] - projected[0], point[1] - projected[1]),
+            point: projected,
+            length: Math.sqrt(lengthSquared),
+        };
+    }
+
+    _openingDragPlacement(startProjection, point, kind) {
+        const endProjection = this._wallProjection(point, startProjection?.wall);
+        if (!startProjection || !endProjection) return null;
+        const width = Math.abs(endProjection.offset - startProjection.offset) * endProjection.length;
+        const centerOffset = (startProjection.offset + endProjection.offset) * 0.5;
+        const placement = this._openingPlacement({
+            ...endProjection,
+            offset: centerOffset,
+        }, width);
+        if (placement) placement.kind = kind;
+        return placement;
+    }
+
+    _createOpeningFromPlacement(placement, kind) {
+        if (!placement) return false;
+        if (this.scene.architecture.openings.length >= 4096) {
+            this.toast("The scene opening limit has been reached.", "error");
+            return false;
+        }
+        const openingId = factoryId();
+        this._recordEditorCommand("Create opening", () => {
+            this.scene.architecture.openings.push({
+                opening_id: openingId,
+                wall_id: placement.wall.wall_id,
+                name: kind === "door" ? "Door" : kind === "empty" ? "Opening" : "Window",
+                kind,
+                offset: placement.offset,
+                width: placement.width,
+                height: kind === "door" ? 2 : 1.2,
+                sill_height: kind === "door" ? 0 : 0.9,
+                material_id: "",
+                visible: true,
+                locked: false,
+            });
+            this.selectedArchitecture = { type: "opening", id: openingId };
+            this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            void this._commitArchitecture();
+        });
+        return true;
+    }
+
+    _onPlanGesture(gesture = {}) {
+        const phase = String(gesture.phase || "");
+        const tool = String(gesture.tool || "");
+        const event = gesture.event || {};
+        const rawPoint = Array.isArray(gesture.point) ? gesture.point : null;
+        if (!this.scene || !["wall", "room", "opening", "camera"].includes(tool)) return;
+
+        if (phase === "cancel") {
+            this._cancelPlanDraft();
+            this._syncToolbar();
+            return;
+        }
+        if (!rawPoint) return;
+
+        if (phase === "start") {
+            if (this._planHoverFrame) cancelAnimationFrame(this._planHoverFrame);
+            this._planHoverFrame = 0;
+            this._pendingPlanHover = null;
+            if (["wall", "room"].includes(tool) && this._activeBuilding()?.locked) {
+                this.toast("Unlock the active building before editing its plan.", "info");
+                this.planDraft = null;
+                return;
+            }
+            if (tool === "opening") {
+                const projection = this._nearestWallProjection(rawPoint);
+                this.planDraft = {
+                    tool,
+                    points: projection ? [projection.point] : [],
+                    openingStart: projection,
+                };
+                this.planHover = { tool, point: [...rawPoint], opening: null };
+                this.els.planHint.textContent = projection
+                    ? "Drag along the wall to set the opening width"
+                    : "Start the drag on an editable wall";
+            } else {
+                const point = this._snapPlanPoint(rawPoint, event);
+                this.planDraft = { tool, points: [point] };
+                this.planHover = { tool, point };
+                this.els.planHint.textContent = tool === "wall"
+                    ? "Drag to set wall length"
+                    : tool === "room"
+                        ? "Drag diagonally to size the room"
+                        : "Drag to aim the camera";
+            }
+            this._renderPlanPreview();
+            return;
+        }
+
+        const draft = this.planDraft;
+        if (!draft || draft.tool !== tool) return;
+        let point = rawPoint;
+        let placement = null;
+        if (tool === "opening") {
+            const kind = this.editorView.opening_kind || "window";
+            placement = this._openingDragPlacement(draft.openingStart, rawPoint, kind);
+            const projected = this._wallProjection(rawPoint, draft.openingStart?.wall);
+            point = projected?.point || rawPoint;
+            this.planHover = { tool, point, opening: placement };
+        } else {
+            const origin = ["wall", "camera"].includes(tool) ? draft.points[0] : null;
+            point = this._snapPlanPoint(rawPoint, event, origin);
+            this.planHover = { tool, point, opening: null };
+        }
+
+        const start = draft.points?.[0];
+        const length = start ? Math.hypot(point[0] - start[0], point[1] - start[1]) : 0;
+        if (phase === "move") {
+            if (tool === "opening") {
+                this.els.planHint.textContent = placement
+                    ? `Opening width ${placement.width.toFixed(2)} m`
+                    : "Drag along a free span of the wall";
+            } else if (tool === "room") {
+                this.els.planHint.textContent = `${Math.abs(point[0] - start[0]).toFixed(2)} × ${Math.abs(point[1] - start[1]).toFixed(2)} m`;
+            } else {
+                this.els.planHint.textContent = `${length.toFixed(2)} m`;
+            }
+            this._renderPlanPreview();
+            return;
+        }
+
+        if (phase !== "end") return;
+        if (!gesture.moved) {
+            this._cancelPlanDraft();
+            this._syncToolbar();
+            return;
+        }
+
+        if (tool === "wall" && length >= 0.001) {
+            this._createWallFromDrag(start, point);
+        } else if (tool === "room" && this._roomRectangle(start, point)) {
+            this._createRectangularRoom(start, point);
+        } else if (tool === "opening" && placement) {
+            this._createOpeningFromPlacement(placement, this.editorView.opening_kind || "window");
+        } else if (tool === "camera" && length >= 0.001) {
+            this._createCameraFromDrag(start, point);
+        }
+        this._cancelPlanDraft();
+        this._syncToolbar();
+    }
+
+    _createWallFromDrag(start, end) {
+        if (!this.scene || !Array.isArray(start) || !Array.isArray(end)) return false;
+        if (this.scene.architecture.walls.length >= 4096) {
+            this.toast("The scene wall limit has been reached.", "error");
+            return false;
+        }
+        this._recordEditorCommand("Create wall", () => {
+            const building = this._activeBuilding();
+            const level = this.scene.levels.find(value => value.level_id === this.editorView.active_level_id);
+            this.scene.architecture.walls.push({
+                ...DEFAULT_WALL,
+                wall_id: factoryId(),
+                level_id: this.editorView.active_level_id,
+                building_id: building?.building_id || "",
+                start: this._worldToLocalPlan(start, building),
+                end: this._worldToLocalPlan(end, building),
+                height: Number(level?.height) || DEFAULT_WALL.height,
+            });
+            void this._commitArchitecture();
+        });
+        return true;
+    }
+
+    _createCameraFromDrag(position, target) {
+        if (!this.scene || !Array.isArray(position) || !Array.isArray(target)) return false;
+        if ((this.scene.cameras?.length || 0) >= 32) {
+            this.toast("A scene can contain up to 32 cameras.", "error");
+            return false;
+        }
+        const cameraId = factoryId();
+        this._recordEditorCommand("Place camera", () => {
+            const level = this.scene.levels.find(value => value.level_id === this.editorView.active_level_id);
+            const building = this._activeBuilding();
+            const eyeHeight = (Number(level?.elevation) || 0)
+                + (Number(building?.position?.[1]) || 0)
+                + 1.6;
+            const camera = {
+                camera_id: cameraId,
+                name: `Camera ${(this.scene.cameras?.length || 0) + 1}`,
+                created_at: Date.now() / 1000,
+                level_id: this.editorView.active_level_id,
+                building_id: building?.building_id || "",
+                position: [position[0], eyeHeight, position[1]],
+                target: [target[0], eyeHeight, target[1]],
+                up: [0, 1, 0],
+                fov: 42,
+            };
+            this.scene.cameras = [...(this.scene.cameras || []), camera];
+            this._selectCamera(camera.camera_id);
+            this._scheduleSceneSave(0);
+        });
+        return true;
+    }
+
+    _nearestWallProjection(point) {
+        let nearest = null;
+        for (const wall of this.scene?.architecture?.walls || []) {
+            if (wall.level_id !== this.editorView.active_level_id) continue;
+            const building = this._buildingForItem(wall);
+            if (wall.visible === false || wall.locked || building?.visible === false || building?.locked) continue;
+            const wallStart = this._localToWorldPlan(wall.start, building);
+            const wallEnd = this._localToWorldPlan(wall.end, building);
+            const dx = wallEnd[0] - wallStart[0];
+            const dz = wallEnd[1] - wallStart[1];
+            const lengthSquared = dx * dx + dz * dz;
+            if (lengthSquared < 1e-9) continue;
+            const offset = clamp(
+                ((point[0] - wallStart[0]) * dx + (point[1] - wallStart[1]) * dz)
+                    / lengthSquared,
+                0,
+                1,
+            );
+            const projected = [wallStart[0] + dx * offset, wallStart[1] + dz * offset];
+            const distance = Math.hypot(point[0] - projected[0], point[1] - projected[1]);
+            if (!nearest || distance < nearest.distance) {
+                nearest = {
+                    wall,
+                    offset,
+                    distance,
+                    point: projected,
+                    length: Math.sqrt(lengthSquared),
+                };
+            }
+        }
+        const tolerance = 20 / Math.max(0.01, Number(this.viewerState.plan_camera?.zoom) || 24);
+        return nearest?.distance <= tolerance ? nearest : null;
+    }
+
+    _openingPlacement(nearest, requestedWidth = 1.2) {
+        const wall = nearest?.wall;
+        const length = Number(nearest?.length) || 0;
+        if (!wall || length < 0.05) return null;
+        const fitted = this._fitOpeningOnWall(wall, nearest.offset, requestedWidth);
+        if (!fitted) return null;
+        const { width, offset } = fitted;
+        const building = this._buildingForItem(wall);
+        const wallStart = this._localToWorldPlan(wall.start, building);
+        const wallEnd = this._localToWorldPlan(wall.end, building);
+        const dx = (wallEnd[0] - wallStart[0]) / length;
+        const dz = (wallEnd[1] - wallStart[1]) / length;
+        const center = [
+            wallStart[0] + (wallEnd[0] - wallStart[0]) * offset,
+            wallStart[1] + (wallEnd[1] - wallStart[1]) * offset,
+        ];
+        return {
+            wall,
+            offset,
+            width,
+            thickness: Number(wall.thickness) || DEFAULT_WALL.thickness,
+            center,
+            start: [center[0] - dx * width / 2, center[1] - dz * width / 2],
+            end: [center[0] + dx * width / 2, center[1] + dz * width / 2],
+        };
+    }
+
+    _fitOpeningOnWall(wall, requestedOffset, requestedWidth, ignoreOpeningId = "") {
+        const length = Math.hypot(
+            Number(wall?.end?.[0]) - Number(wall?.start?.[0]),
+            Number(wall?.end?.[1]) - Number(wall?.start?.[1]),
+        );
+        if (!(length >= 0.05)) return null;
+        const numericWidth = Number(requestedWidth);
+        const width = Math.min(
+            Math.max(0.05, Number.isFinite(numericWidth) ? numericWidth : 1.2),
+            length,
+        );
+        const half = width / 2;
+        const occupied = (this.scene?.architecture?.openings || [])
+            .filter(opening => opening.wall_id === wall.wall_id && opening.opening_id !== ignoreOpeningId)
+            .map(opening => {
+                const otherHalf = Math.min(length, Math.max(0.05, Number(opening.width) || 0.05)) / 2;
+                const center = clamp(Number(opening.offset) || 0, 0, 1) * length;
+                return [Math.max(0, center - otherHalf), Math.min(length, center + otherHalf)];
+            })
+            .sort((left, right) => left[0] - right[0]);
+        const free = [];
+        let cursor = 0;
+        for (const interval of occupied) {
+            if (interval[0] > cursor) free.push([cursor, interval[0]]);
+            cursor = Math.max(cursor, interval[1]);
+        }
+        if (cursor < length) free.push([cursor, length]);
+        const requestedCenter = clamp(Number(requestedOffset) || 0, 0, 1) * length;
+        let best = null;
+        for (const interval of free) {
+            const minimum = interval[0] + half;
+            const maximum = interval[1] - half;
+            if (minimum > maximum + 1e-6) continue;
+            const center = clamp(requestedCenter, minimum, maximum);
+            const distance = Math.abs(center - requestedCenter);
+            if (!best || distance < best.distance) best = { center, distance };
+        }
+        return best ? { offset: best.center / length, width } : null;
+    }
+
+    _openingControlLimits(opening, wall) {
+        const wallLength = Math.max(0.05, Math.hypot(
+            Number(wall?.end?.[0]) - Number(wall?.start?.[0]),
+            Number(wall?.end?.[1]) - Number(wall?.start?.[1]),
+        ) || 0.05);
+        const wallHeight = Math.max(0.05, Number(wall?.height) || DEFAULT_WALL.height);
+        const center = clamp(Number(opening?.offset) || 0, 0, 1) * wallLength;
+        const occupied = (this.scene?.architecture?.openings || [])
+            .filter(item => item.wall_id === wall?.wall_id && item.opening_id !== opening?.opening_id)
+            .map(item => {
+                const half = Math.min(wallLength, Math.max(0.05, Number(item.width) || 0.05)) / 2;
+                const otherCenter = clamp(Number(item.offset) || 0, 0, 1) * wallLength;
+                return [Math.max(0, otherCenter - half), Math.min(wallLength, otherCenter + half)];
+            })
+            .sort((left, right) => left[0] - right[0]);
+        const free = [];
+        let cursor = 0;
+        for (const interval of occupied) {
+            if (interval[0] > cursor) free.push([cursor, interval[0]]);
+            cursor = Math.max(cursor, interval[1]);
+        }
+        if (cursor < wallLength) free.push([cursor, wallLength]);
+        const span = free.find(interval => center >= interval[0] - 1e-6 && center <= interval[1] + 1e-6)
+            || free.reduce((nearest, interval) => {
+                const distance = center < interval[0]
+                    ? interval[0] - center
+                    : center > interval[1]
+                        ? center - interval[1]
+                        : 0;
+                return !nearest || distance < nearest.distance ? { interval, distance } : nearest;
+            }, null)?.interval
+            || [0, wallLength];
+        const currentWidth = Math.min(wallLength, Math.max(0.05, Number(opening?.width) || 0.05));
+        const symmetricWidth = Math.max(0.05, 2 * Math.min(
+            Math.max(0, center - span[0]),
+            Math.max(0, span[1] - center),
+        ));
+        const widthMaximum = Math.min(
+            span[1] - span[0],
+            Math.max(currentWidth, symmetricWidth),
+        );
+        const halfWidth = currentWidth / 2;
+        const centerMinimum = span[0] + halfWidth;
+        const centerMaximum = span[1] - halfWidth;
+        return {
+            wallLength,
+            wallHeight,
+            widthMaximum: Math.max(0.05, widthMaximum),
+            centerMinimum: centerMinimum <= centerMaximum ? centerMinimum : center,
+            centerMaximum: centerMinimum <= centerMaximum ? centerMaximum : center,
+            sillMaximum: Math.max(0, wallHeight - Math.max(0.05, Number(opening?.height) || 0.05)),
+        };
+    }
+
+    _createRectangularRoom(start, end) {
+        const rectangle = this._roomRectangle(start, end);
+        if (!rectangle) {
+            this.toast("Choose an opposite corner with both width and depth.", "error");
+            return false;
+        }
+        if (this.scene.architecture.rooms.length >= 1024) {
+            this.toast("The scene room limit has been reached.", "error");
+            return false;
+        }
+        if (this.scene.architecture.walls.length > 4092) {
+            this.toast("Four free wall slots are required to create a room.", "error");
+            return false;
+        }
+        const roomId = factoryId();
+        this.planDraft = null;
+        this.planHover = { tool: "room", point: [...end] };
+        this._renderPlanPreview();
+        this._recordEditorCommand("Create room", () => {
+            const building = this._activeBuilding();
+            const level = this.scene.levels.find(value => value.level_id === this.editorView.active_level_id);
+            const localRectangle = rectangle.map(point => this._worldToLocalPlan(point, building));
+            const wallIds = [];
+            for (let index = 0; index < rectangle.length; index += 1) {
+                const wallId = factoryId();
+                wallIds.push(wallId);
+                this.scene.architecture.walls.push({
+                    ...DEFAULT_WALL,
+                    wall_id: wallId,
+                    level_id: this.editorView.active_level_id,
+                    building_id: building?.building_id || "",
+                    start: [...localRectangle[index]],
+                    end: [...localRectangle[(index + 1) % localRectangle.length]],
+                    height: Number(level?.height) || DEFAULT_WALL.height,
+                });
+            }
+            this.scene.architecture.rooms.push({
+                ...DEFAULT_ROOM,
+                floor: {
+                    ...DEFAULT_ROOM.floor,
+                    thickness: Math.max(0, Number(level?.slab_thickness) || DEFAULT_ROOM.floor.thickness),
+                },
+                ceiling: {
+                    ...DEFAULT_ROOM.ceiling,
+                    height: Number(level?.height) || DEFAULT_ROOM.ceiling.height,
+                },
+                room_id: roomId,
+                level_id: this.editorView.active_level_id,
+                building_id: building?.building_id || "",
+                polygon: localRectangle.map(point => [...point]),
+                wall_ids: wallIds,
+            });
+            this.selectedArchitecture = { type: "room", id: roomId };
+            this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            void this._commitArchitecture();
+        });
+        return true;
+    }
+
+    _cancelPlanDraft() {
+        this._clearPlanHover();
+        this.planDraft = null;
+        this.viewer?.setPlanDraft(null);
+    }
+
+    _commitArchitecture({ save = true, targeted = false } = {}) {
+        const sceneId = this.sceneId;
+        const operation = this._architectureCommitSerial.then(
+            () => this._commitArchitectureNow(sceneId, { save, targeted }),
+        );
+        this._architectureCommitSerial = operation.catch(() => null);
+        return operation;
+    }
+
+    async _commitArchitectureNow(sceneId, { save = true, targeted = false } = {}) {
+        if (!this.scene || !sceneId || this.sceneId !== sceneId) return;
+        this.scene.levels = reconcileIdentifiedObjects(
+            this.scene.levels,
+            normalizedLevels(this.scene.levels),
+            "level_id",
+        );
+        const currentArchitecture = this.scene.architecture || {};
+        const nextArchitecture = normalizedArchitecture(currentArchitecture, this.scene.levels);
+        this.scene.architecture = {
+            ...nextArchitecture,
+            materials: reconcileIdentifiedObjects(
+                currentArchitecture.materials,
+                nextArchitecture.materials,
+                "material_id",
+            ),
+            buildings: reconcileIdentifiedObjects(
+                currentArchitecture.buildings,
+                nextArchitecture.buildings,
+                "building_id",
+            ),
+            walls: reconcileIdentifiedObjects(
+                currentArchitecture.walls,
+                nextArchitecture.walls,
+                "wall_id",
+            ),
+            rooms: reconcileIdentifiedObjects(
+                currentArchitecture.rooms,
+                nextArchitecture.rooms,
+                "room_id",
+            ),
+            openings: reconcileIdentifiedObjects(
+                currentArchitecture.openings,
+                nextArchitecture.openings,
+                "opening_id",
+            ),
+        };
+        if (!this.scene.levels.some(level => level.level_id === this.editorView.active_level_id)) {
+            this.editorView.active_level_id = this.scene.levels[0]?.level_id || "";
+        }
+        const selectedType = ["floor", "ceiling"].includes(this.selectedArchitecture?.type)
+            ? "room"
+            : this.selectedArchitecture?.type;
+        const updated = targeted && this.selectedArchitecture?.id
+            ? this.viewer.updateArchitectureItem(
+                selectedType,
+                this.selectedArchitecture.id,
+                this.scene,
+            )
+            : false;
+        if (!updated) await this.viewer.refreshArchitecture(this.scene);
+        if (!this.scene || this.sceneId !== sceneId) return;
+        // Rebuilding procedural geometry must not replay a stale editor camera.
+        // The viewer already owns the live camera; only architecture-specific
+        // mode and floor state need to be reaffirmed after a refresh.
+        this.viewer.setViewMode(this.editorView.view_mode);
+        this.viewer.setPlanTool(this.editorView.plan_tool);
+        this.viewer.setActiveLevel(this.editorView.active_level_id);
+        this.viewer.setArchitectureSelection(this.selectedArchitecture);
+        if (!targeted) this._renderInspector();
+        if (this.selectedArchitecture) this._setWorkspaceTab("right", "inspector");
+        this._updateSceneSummary();
+        this._syncToolbar();
+        if (save) {
+            this._scheduleSceneSave(80);
+            this._scheduleScenePreview(240);
+            this._scheduleStateSave(0);
+        }
+    }
+
+    _previewSelectedArchitecture() {
+        if (!this.selectedArchitecture?.id || !this.scene) return;
+        const type = ["floor", "ceiling"].includes(this.selectedArchitecture.type)
+            ? "room"
+            : this.selectedArchitecture.type;
+        if (type === "level") {
+            this._previewArchitectureMaterials();
+            this.viewer.setActiveLevel(this.editorView.active_level_id);
+            this.viewer.setCameraMarkers(this.scene.cameras || []);
+            return;
+        }
+        this.viewer.updateArchitectureItem(type, this.selectedArchitecture.id, this.scene);
+        if (type === "wall") {
+            for (const room of this.scene.architecture.rooms || []) {
+                if (room.wall_ids?.includes(this.selectedArchitecture.id)) {
+                    this.viewer.updateArchitectureItem("room", room.room_id, this.scene);
+                }
+            }
+        } else if (type === "room") {
+            const room = this.scene.architecture.rooms?.find(value => value.room_id === this.selectedArchitecture.id);
+            const linked = new Set(room?.wall_ids || []);
+            for (const wall of this.scene.architecture.walls || []) {
+                if (linked.has(wall.wall_id)) this.viewer.updateArchitectureItem("wall", wall.wall_id, this.scene);
+            }
+        }
+        this.viewer.setCameraMarkers(this.scene.cameras || []);
+        this._scheduleSceneSave(220);
+        this._scheduleStateSave(220);
+    }
+
+    _queueSelectedArchitecturePreview({ flush = false } = {}) {
+        if (flush && this._architectureGeometryFrame) {
+            cancelAnimationFrame(this._architectureGeometryFrame);
+            this._architectureGeometryFrame = 0;
+        }
+        if (flush) {
+            this._previewSelectedArchitecture();
+            return;
+        }
+        if (this._architectureGeometryFrame) return;
+        this._architectureGeometryFrame = requestAnimationFrame(() => {
+            this._architectureGeometryFrame = 0;
+            this._previewSelectedArchitecture();
+        });
+    }
+
+    _syncRoomsForWall(wall) {
+        if (!wall) return;
+        for (const room of this.scene?.architecture?.rooms || []) {
+            if (!Array.isArray(room.wall_ids) || room.wall_ids.length !== room.polygon?.length) continue;
+            const index = room.wall_ids.indexOf(wall.wall_id);
+            if (index < 0) continue;
+            room.polygon[index] = [...wall.start];
+            room.polygon[(index + 1) % room.polygon.length] = [...wall.end];
+        }
+    }
+
+    _previewArchitectureMaterials() {
+        clearTimeout(this._architecturePreviewTimer);
+        this._architecturePreviewTimer = setTimeout(() => {
+            this._architecturePreviewTimer = 0;
+            void this.viewer.refreshArchitecture(this.scene);
+        }, 50);
+        this._scheduleSceneSave(220);
+        this._scheduleStateSave(220);
+    }
+
+    _selectArchitecture(selection) {
+        if (selection?.type === "camera") {
+            this._selectCamera(selection.id);
+            return;
+        }
+        this.selectedArchitecture = this._normalizeArchitectureSelection(selection);
+        const selected = this._selectedArchitectureValue();
+        const owner = this.selectedArchitecture?.type === "building"
+            ? this.scene?.architecture?.buildings?.find(
+                item => item.building_id === this.selectedArchitecture.id,
+            )
+            : this._buildingForItem(selected);
+        if (owner) this.editorView.active_building_id = owner.building_id;
+        this.selectedCameraId = "";
+        this.selectedCameraKeyframeId = "";
+        this.selectedObjectId = "";
+        this.selectedObjectIds.clear();
+        this.selectedGroupId = "";
+        this.selectedSkydome = false;
+        this.viewer.setArchitectureSelection(this.selectedArchitecture);
+        this._renderObjects();
+        this._renderInspector();
+        this._syncToolbar();
+        if (this.selectedArchitecture) this._setWorkspaceTab("right", "inspector");
+    }
+
+    _onArchitectureEdit(change) {
+        if (!change?.type || !change.id) return;
+        if (change.type === "building") {
+            const building = this.scene?.architecture?.buildings?.find(item => item.building_id === change.id);
+            if (!building || building.locked) return this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            const point = this._snapPlanPoint(change.point, change.event || {});
+            const before = this._captureEditorSnapshot();
+            this._applyBuildingTransform(
+                building,
+                [point[0], Number(building.position?.[1]) || 0, point[1]],
+                building.rotation_y,
+            );
+            this.history.push("Move building", before, this._captureEditorSnapshot());
+            void this._commitArchitecture({ targeted: true });
+            return;
+        }
+        if (change.type === "room") {
+            const room = this.scene?.architecture?.rooms?.find(item => item.room_id === change.id);
+            const linkedWalls = new Set(room?.wall_ids || []);
+            if (
+                !room?.polygon?.length
+                || room.locked
+                || this.scene.architecture.walls?.some(wall => linkedWalls.has(wall.wall_id) && wall.locked)
+            ) return this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            const building = this._buildingForItem(room);
+            if (building?.locked) return this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            const localPoint = this._worldToLocalPlan(
+                this._snapPlanPoint(change.point, change.event || {}),
+                building,
+            );
+            const center = room.polygon.reduce(
+                (sum, point) => [sum[0] + point[0], sum[1] + point[1]],
+                [0, 0],
+            ).map(value => value / room.polygon.length);
+            const delta = [localPoint[0] - center[0], localPoint[1] - center[1]];
+            const before = this._captureEditorSnapshot();
+            room.polygon = room.polygon.map(point => [point[0] + delta[0], point[1] + delta[1]]);
+            const linked = new Set(room.wall_ids || []);
+            for (const wall of this.scene.architecture.walls || []) {
+                if (!linked.has(wall.wall_id)) continue;
+                wall.start = [wall.start[0] + delta[0], wall.start[1] + delta[1]];
+                wall.end = [wall.end[0] + delta[0], wall.end[1] + delta[1]];
+            }
+            this.history.push("Move room", before, this._captureEditorSnapshot());
+            void this._commitArchitecture();
+            return;
+        }
+        if (change.type === "opening") {
+            const opening = this.scene?.architecture?.openings?.find(item => item.opening_id === change.id);
+            const wall = this.scene?.architecture?.walls?.find(item => item.wall_id === opening?.wall_id);
+            const building = this._buildingForItem(wall);
+            if (!opening || !wall || opening.locked || wall.locked || building?.locked) {
+                return this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            }
+            const point = this._worldToLocalPlan(
+                this._snapPlanPoint(change.point, change.event || {}),
+                building,
+            );
+            const dx = wall.end[0] - wall.start[0];
+            const dz = wall.end[1] - wall.start[1];
+            const lengthSquared = dx * dx + dz * dz;
+            if (lengthSquared < 1e-9) return this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            const requestedOffset = ((point[0] - wall.start[0]) * dx + (point[1] - wall.start[1]) * dz) / lengthSquared;
+            const fitted = this._fitOpeningOnWall(wall, requestedOffset, opening.width, opening.opening_id);
+            if (!fitted) return this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            const before = this._captureEditorSnapshot();
+            opening.offset = fitted.offset;
+            opening.width = fitted.width;
+            this.history.push("Move opening", before, this._captureEditorSnapshot());
+            void this._commitArchitecture({ targeted: true });
+            return;
+        }
+        if (change.type !== "wall" || !["start", "end"].includes(change.endpoint)) return;
+        const linkedRoom = this._roomForWallId(change.id);
+        if (linkedRoom) {
+            this._selectArchitecture({ type: "room", id: linkedRoom.room_id });
+            return;
+        }
+        const wall = this.scene?.architecture?.walls?.find(item => item.wall_id === change.id);
+        if (!wall || wall.locked || this._buildingForItem(wall)?.locked) {
+            this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            return;
+        }
+        const worldPoint = this._snapPlanPoint(change.point, change.event || {});
+        const building = this._buildingForItem(wall);
+        const point = this._worldToLocalPlan(worldPoint, building);
+        if (Math.hypot(
+            point[0] - wall[change.endpoint === "start" ? "end" : "start"][0],
+            point[1] - wall[change.endpoint === "start" ? "end" : "start"][1],
+        ) < 0.001) {
+            this.viewer.setArchitectureSelection(this.selectedArchitecture);
+            return;
+        }
+        const before = this._captureEditorSnapshot();
+        wall[change.endpoint] = point;
+        for (const room of this.scene.architecture.rooms || []) {
+            const index = room.wall_ids?.indexOf(wall.wall_id) ?? -1;
+            if (index < 0 || room.wall_ids.length !== room.polygon.length) continue;
+            const endpointIndex = change.endpoint === "start"
+                ? index
+                : (index + 1) % room.polygon.length;
+            room.polygon[endpointIndex] = [...point];
+        }
+        this.history.push("Move wall endpoint", before, this._captureEditorSnapshot());
+        void this._commitArchitecture();
+        this._syncToolbar();
+    }
+
+    _selectedArchitectureValue() {
+        if (!this.selectedArchitecture || !this.scene?.architecture) return null;
+        const { type, id } = this.selectedArchitecture;
+        if (type === "building") return this.scene.architecture.buildings?.find(item => item.building_id === id);
+        if (type === "level") return this.scene.levels.find(item => item.level_id === id);
+        if (type === "wall") return this.scene.architecture.walls.find(item => item.wall_id === id);
+        if (type === "room" || type === "floor" || type === "ceiling") {
+            return this.scene.architecture.rooms.find(item => item.room_id === id);
+        }
+        if (type === "opening") return this.scene.architecture.openings.find(item => item.opening_id === id);
+        return null;
+    }
+
+    _roomForWallId(wallId) {
+        return this.scene?.architecture?.rooms?.find(
+            room => room.wall_ids?.includes(wallId),
+        ) || null;
+    }
+
+    _normalizeArchitectureSelection(selection) {
+        if (!selection?.id) return null;
+        if (["room", "floor", "ceiling"].includes(selection.type)) {
+            return { type: "room", id: selection.id };
+        }
+        if (selection.type === "wall") {
+            const room = this._roomForWallId(selection.id);
+            if (room) return { type: "room", id: room.room_id };
+        }
+        return { type: selection.type, id: selection.id };
+    }
+
+    _roomBounds(room) {
+        const polygon = Array.isArray(room?.polygon) ? room.polygon : [];
+        if (!polygon.length) return { center: [0, 0], size: [0, 0] };
+        const xs = polygon.map(point => Number(point?.[0]) || 0);
+        const zs = polygon.map(point => Number(point?.[1]) || 0);
+        const minimum = [Math.min(...xs), Math.min(...zs)];
+        const maximum = [Math.max(...xs), Math.max(...zs)];
+        return {
+            center: [(minimum[0] + maximum[0]) / 2, (minimum[1] + maximum[1]) / 2],
+            size: [maximum[0] - minimum[0], maximum[1] - minimum[1]],
+        };
+    }
+
+    _syncRoomPerimeter(room) {
+        if (!room?.polygon?.length || room.wall_ids?.length !== room.polygon.length) return;
+        const wallsById = new Map(
+            (this.scene?.architecture?.walls || []).map(wall => [wall.wall_id, wall]),
+        );
+        room.wall_ids.forEach((wallId, index) => {
+            const wall = wallsById.get(wallId);
+            if (!wall) return;
+            wall.start = [...room.polygon[index]];
+            wall.end = [...room.polygon[(index + 1) % room.polygon.length]];
+            wall.level_id = room.level_id;
+            wall.building_id = room.building_id;
+            wall.height = Math.max(0.05, Number(room.ceiling?.height) || wall.height || 2.8);
+            wall.visible = room.visible !== false;
+            wall.locked = room.locked === true;
+        });
+    }
+
+    _formatControlNumber(value, step = 0.01) {
+        const numericValue = Number(value);
+        if (!Number.isFinite(numericValue)) return "0";
+        const numericStep = Math.abs(Number(step));
+        if (!Number.isFinite(numericStep) || numericStep <= 0) {
+            return String(Number(numericValue.toFixed(6)));
+        }
+        const stepText = numericStep.toString().toLowerCase();
+        const exponent = stepText.includes("e-") ? Number(stepText.split("e-")[1]) : 0;
+        const decimals = exponent || (stepText.split(".")[1]?.length || 0);
+        return String(Number(numericValue.toFixed(Math.min(8, decimals))));
+    }
+
+    _numericControl(label, path, value, {
+        minimum,
+        maximum,
+        step,
+        range = true,
+        sliderMinimum,
+        sliderMaximum,
+        disabled = false,
+    } = {}) {
+        const numericValue = Number(value);
+        const safeValue = Number.isFinite(numericValue) ? numericValue : 0;
+        const disabledAttribute = disabled ? " disabled" : "";
+        let rangeMinimum = Number.isFinite(sliderMinimum) ? sliderMinimum : minimum;
+        let rangeMaximum = Number.isFinite(sliderMaximum) ? sliderMaximum : maximum;
+        if (range && Number.isFinite(minimum) && Number.isFinite(maximum)) {
+            const span = maximum - minimum;
+            if (!Number.isFinite(sliderMinimum) && !Number.isFinite(sliderMaximum) && span > 720) {
+                const windowSize = path.includes("rotation")
+                    ? 45
+                    : path.includes("focus")
+                        ? Math.max(1, Math.abs(safeValue))
+                        : path.includes("scale")
+                            ? Math.max(1, Math.abs(safeValue) * 2)
+                            : 5;
+                rangeMinimum = Math.max(minimum, safeValue - windowSize);
+                rangeMaximum = Math.min(maximum, safeValue + windowSize);
+            }
+        }
+        rangeMinimum = Math.min(rangeMinimum, safeValue);
+        rangeMaximum = Math.max(rangeMaximum, safeValue);
+        const controlValue = this._formatControlNumber(safeValue, step);
+        const controlMinimum = this._formatControlNumber(minimum, step);
+        const controlMaximum = this._formatControlNumber(maximum, step);
+        const rangeMinimumValue = this._formatControlNumber(rangeMinimum, step);
+        const rangeMaximumValue = this._formatControlNumber(rangeMaximum, step);
+        return `
+            <div class="vnccs-i3s__precision-row">
+                <span>${escapeHTML(label)}</span>
+                ${range ? `<input type="range" aria-label="${escapeHTML(label)} slider" data-editor-path="${path}" min="${rangeMinimumValue}" max="${rangeMaximumValue}" step="${step}" value="${controlValue}"${disabledAttribute} />` : ""}
+                <input class="vnccs-i3s__input" aria-label="${escapeHTML(label)} exact value" type="number" data-editor-path="${path}" min="${controlMinimum}" max="${controlMaximum}" step="${step}" value="${controlValue}"${disabledAttribute} />
+            </div>`;
+    }
+
+    _renderInspector() {
+        if (!this.els?.inspector) return;
+        preserveScrollState(this.container, () => {
+            const item = this.scene?.objects?.find(value => value.object_id === this.selectedObjectId);
+            const architecture = this._selectedArchitectureValue();
+            const camera = this.scene?.cameras?.find(value => value.camera_id === this.selectedCameraId);
+            const group = this._groupById(this.selectedGroupId);
+            const track = this._activeCameraTrack();
+            const keyframe = track?.keyframes?.find(value => value.keyframe_id === this.selectedCameraKeyframeId);
+            const hasSelection = Boolean(item || architecture || camera || keyframe || group);
+            this.container.classList.toggle("has-inspector-selection", hasSelection);
+            const inspectorTab = this.els.workspaceTabs.find(
+                button => button.dataset.workspaceSide === "right"
+                    && button.dataset.workspaceTab === "inspector",
+            );
+            inspectorTab?.setAttribute(
+                "aria-label",
+                hasSelection ? "Inspector, selection available" : "Inspector",
+            );
+            if (!item && !architecture && !camera && !keyframe && !group) {
+                this.els.inspectorKind.textContent = "Nothing selected";
+                this.els.inspector.innerHTML = '<div class="vnccs-i3s__inspector-empty">Select an object, wall, room, opening, or camera.</div>';
+                return;
+            }
+            if (item) this._renderObjectInspector(item);
+            else if (group) this._renderGroupInspector(group);
+            else if (camera) this._renderCameraInspector(camera);
+            else if (keyframe) this._renderKeyframeInspector(track, keyframe);
+            else this._renderArchitectureInspector(architecture);
+        });
+    }
+
+    _renderGroupInspector(group) {
+        const center = this.viewer?.getGroupPivotPosition?.() || [0, 0, 0];
+        this.els.inspectorKind.textContent = "Object group";
+        this.els.inspector.innerHTML = `
+            <div class="vnccs-i3s__inspector-title">${escapeHTML(group.name || "Group")}</div>
+            <div class="vnccs-i3s__hint">Position is absolute. Rotation and scale are applied as a precise delta around the group center.</div>
+            <div class="vnccs-i3s__inspector-group"><b>Position · m</b>
+                ${["X", "Y", "Z"].map((axis, index) => this._numericControl(axis, `group.position.${index}`, center[index], { minimum: -10000, maximum: 10000, step: 0.01 })).join("")}
+            </div>
+            <div class="vnccs-i3s__inspector-group"><b>Rotation delta · degrees</b>
+                ${["X", "Y", "Z"].map((axis, index) => this._numericControl(axis, `group.rotation.${index}`, 0, { minimum: -360, maximum: 360, step: 0.01 })).join("")}
+            </div>
+            <div class="vnccs-i3s__inspector-group"><b>Scale factor</b>
+                ${this._numericControl("Scale", "group.scale", 1, { minimum: 0.001, maximum: 100, step: 0.001 })}
+            </div>
+            <div class="vnccs-i3s__inspector-actions"><button class="vnccs-i3s__button vnccs-i3s__button--primary" type="button" data-group-apply>Apply to ${group.children.length} objects</button></div>`;
+        const staged = { position: [...center], rotation: [0, 0, 0], scale: 1 };
+        for (const control of this.els.inspector.querySelectorAll("[data-editor-path]")) {
+            control.addEventListener("input", () => {
+                const [, key, rawIndex] = control.dataset.editorPath.split(".");
+                const value = Number(control.value);
+                if (!Number.isFinite(value)) return;
+                if (rawIndex !== undefined) staged[key][Number(rawIndex)] = value;
+                else staged[key] = value;
+                for (const peer of this.els.inspector.querySelectorAll(`[data-editor-path="${control.dataset.editorPath}"]`)) {
+                    if (peer !== control) peer.value = String(value);
+                }
+            });
+        }
+        this.els.inspector.querySelector("[data-group-apply]")?.addEventListener("click", () => {
+            this._recordEditorCommand("Transform group", () => {
+                this._suppressViewerTransformHistory = true;
+                try { this.viewer.applyGroupDelta(staged); }
+                finally {
+                    this._suppressViewerTransformHistory = false;
+                    this._viewerTransformHistoryBefore = null;
+                }
+                this._renderInspector();
+                this._scheduleSceneSave(0);
+            });
+        });
+    }
+
+    _renderCameraInspector(camera) {
+        const pose = cameraPoseFromLegacy(camera);
+        const rotation = eulerDegreesFromQuaternion(pose.quaternion);
+        this.els.inspectorKind.textContent = "Saved camera";
+        this.els.inspector.innerHTML = `
+            <div class="vnccs-i3s__inspector-title">${escapeHTML(camera.name || "Camera")}</div>
+            <div class="vnccs-i3s__hint">${this.previewCameraId === camera.camera_id
+                ? "Camera View is live: exact fields update the viewport immediately."
+                : "Exact fields update the saved Plan marker. Enter Camera View to preview rotation and lens."}</div>
+            <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Name</span><input class="vnccs-i3s__input" data-camera-property="name" value="${escapeHTML(camera.name || "Camera")}" maxlength="80" /></label>
+            <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Floor level</span><select class="vnccs-i3s__select" data-camera-property="level_id">
+                ${(this.scene?.levels || []).map(level => `<option value="${level.level_id}"${camera.level_id === level.level_id ? " selected" : ""}>${escapeHTML(level.name)}</option>`).join("")}
+            </select></label>
+            <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Building</span><select class="vnccs-i3s__select" data-camera-property="building_id">
+                ${this._buildingOptions(camera.building_id)}
+            </select></label>
+            <div class="vnccs-i3s__inspector-group"><b>Position · m</b>
+                ${["X", "Y", "Z"].map((axis, index) => this._numericControl(axis, `camera.position.${index}`, pose.position[index], { minimum: -10000, maximum: 10000, step: 0.01 })).join("")}
+            </div>
+            <div class="vnccs-i3s__inspector-group"><b>Rotation · degrees</b>
+                ${["X", "Y", "Z"].map((axis, index) => this._numericControl(axis, `camera.rotation.${index}`, rotation[index], { minimum: -36000, maximum: 36000, step: 0.01 })).join("")}
+            </div>
+            <div class="vnccs-i3s__inspector-group"><b>Lens</b>
+                ${this._numericControl("FOV", "camera.fov", pose.fov, { minimum: 5, maximum: 120, step: 0.01 })}
+                ${this._numericControl("Focus distance", "camera.focus_distance", pose.focus_distance, { minimum: 0.001, maximum: 100000, step: 0.001 })}
+            </div>
+            <div class="vnccs-i3s__inspector-actions">
+                <button class="vnccs-i3s__button" type="button" data-inspector-action="preview-camera">${this.previewCameraId === camera.camera_id ? "Exit camera view" : "Enter camera view"}</button>
+                <button class="vnccs-i3s__button" type="button" data-inspector-action="update-camera">Update from current view</button>
+                <button class="vnccs-i3s__button" type="button" data-inspector-action="keyframe">Add camera as path point</button>
+            </div>`;
+        let before = null;
+        const edited = {
+            position: [...pose.position],
+            rotation: [...rotation],
+            fov: pose.fov,
+            focus_distance: pose.focus_distance,
+        };
+        const begin = () => { before ||= this._captureEditorSnapshot(); };
+        const apply = () => {
+            const legacy = legacyCameraFromPose({
+                position: edited.position,
+                quaternion: quaternionFromEulerDegrees(edited.rotation),
+                fov: edited.fov,
+                focus_distance: edited.focus_distance,
+            });
+            Object.assign(camera, legacy);
+            // Precise edits in 3D enter the saved camera non-destructively so
+            // every slider and exact value has an immediate viewport result.
+            // Plan mode keeps showing the saved marker and its FOV wedge.
+            if (this.editorView.view_mode === "3d" && this.previewCameraId !== camera.camera_id) {
+                if (!this.previewCameraId) {
+                    this._cameraReturnState = this._normalizeCameraState(
+                        this.viewer.getCameraState(),
+                        this.scene?.camera,
+                    );
+                }
+                this.previewCameraId = camera.camera_id;
+                if (this.scene.levels?.some(level => level.level_id === camera.level_id)) {
+                    this.editorView.active_level_id = camera.level_id;
+                    this.viewer.setActiveLevel(camera.level_id);
+                }
+                this._renderCameras();
+                const previewAction = this.els.inspector.querySelector(
+                    '[data-inspector-action="preview-camera"]',
+                );
+                if (previewAction) previewAction.textContent = "Exit camera view";
+                const hint = this.els.inspector.querySelector(".vnccs-i3s__hint");
+                if (hint) {
+                    hint.textContent = "Camera View is live: exact fields update the viewport immediately.";
+                }
+            }
+            if (this.previewCameraId === camera.camera_id) {
+                this.viewer.setCameraState(camera, { emit: false });
+            }
+            this.viewer.setCameraMarkers(this.scene.cameras);
+            this._scheduleSceneSave(180);
+            this._scheduleStateSave(180);
+        };
+        for (const control of this.els.inspector.querySelectorAll("[data-editor-path]")) {
+            control.addEventListener("pointerdown", begin);
+            control.addEventListener("focus", begin);
+            control.addEventListener("input", () => {
+                const [, key, rawIndex] = control.dataset.editorPath.split(".");
+                const value = Number(control.value);
+                if (!Number.isFinite(value)) return;
+                if (rawIndex !== undefined) edited[key][Number(rawIndex)] = value;
+                else edited[key] = value;
+                for (const peer of this.els.inspector.querySelectorAll(`[data-editor-path="${control.dataset.editorPath}"]`)) {
+                    if (peer !== control) peer.value = String(value);
+                }
+                apply();
+            });
+            control.addEventListener("change", () => {
+                if (before) this.history.push("Edit camera", before, this._captureEditorSnapshot());
+                before = null;
+                this._syncToolbar();
+                this._scheduleSceneSave(0);
+            });
+        }
+        this.els.inspector.querySelector('[data-camera-property="name"]')?.addEventListener("change", event => {
+            const original = this._captureEditorSnapshot();
+            camera.name = String(event.currentTarget.value || "Camera").trim().slice(0, 80) || "Camera";
+            this.history.push("Rename camera", original, this._captureEditorSnapshot());
+            this._renderCameras();
+            this._renderInspector();
+            this._scheduleSceneSave(0);
+        });
+        this.els.inspector.querySelector('[data-camera-property="level_id"]')?.addEventListener("change", event => {
+            const original = this._captureEditorSnapshot();
+            const previousLevel = this.scene.levels.find(level => level.level_id === camera.level_id);
+            const nextLevel = this.scene.levels.find(level => level.level_id === event.currentTarget.value);
+            const elevationDelta = (Number(nextLevel?.elevation) || 0)
+                - (Number(previousLevel?.elevation) || 0);
+            camera.position[1] += elevationDelta;
+            camera.target[1] += elevationDelta;
+            camera.level_id = event.currentTarget.value;
+            if (this.previewCameraId === camera.camera_id) {
+                this.editorView.active_level_id = camera.level_id;
+                this.viewer.setActiveLevel(camera.level_id);
+                this.viewer.setCameraState(camera, { emit: false });
+                this._syncToolbar();
+            }
+            this.history.push("Move camera to floor", original, this._captureEditorSnapshot());
+            this.viewer.setCameraMarkers(this.scene.cameras);
+            this._renderCameras();
+            this._scheduleSceneSave(0);
+        });
+        this.els.inspector.querySelector('[data-camera-property="building_id"]')?.addEventListener("change", event => {
+            const original = this._captureEditorSnapshot();
+            camera.building_id = this._validBuildingId(event.currentTarget.value);
+            if (camera.building_id) this.editorView.active_building_id = camera.building_id;
+            this.history.push("Assign camera to building", original, this._captureEditorSnapshot());
+            this.viewer.setCameraMarkers(this.scene.cameras);
+            this._renderCameras();
+            this._syncToolbar();
+            this._scheduleSceneSave(0);
+            this._scheduleStateSave(0);
+        });
+        this.els.inspector.querySelector('[data-inspector-action="preview-camera"]')?.addEventListener("click", () => {
+            if (this.previewCameraId === camera.camera_id) this._exitCameraView({ restore: true });
+            else this._enterCameraView(camera.camera_id);
+        });
+        this.els.inspector.querySelector('[data-inspector-action="update-camera"]')?.addEventListener("click", () => {
+            const original = this._captureEditorSnapshot();
+            Object.assign(camera, this._normalizeCameraState(this.viewer.getCameraState()));
+            this.history.push("Update camera from view", original, this._captureEditorSnapshot());
+            this.viewer.setCameraMarkers(this.scene.cameras);
+            this._renderInspector();
+            this._renderCameras();
+            this._scheduleSceneSave(0);
+            this._syncToolbar();
+        });
+        this.els.inspector.querySelector('[data-inspector-action="keyframe"]')?.addEventListener("click", () => {
+            this._addCameraKeyframe(camera);
+        });
+    }
+
+    _renderKeyframeInspector(track, frame) {
+        const pose = normalizedCameraPose(frame);
+        const rotation = eulerDegreesFromQuaternion(pose.quaternion);
+        this.els.inspectorKind.textContent = "Camera path point";
+        this.els.inspector.innerHTML = `
+            <div class="vnccs-i3s__inspector-title">${escapeHTML(track.name || "Camera path")}</div>
+            <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Building</span><select class="vnccs-i3s__select" data-track-property="building_id">${this._buildingOptions(track.building_id)}</select></label>
+            <div class="vnccs-i3s__inspector-group"><b>Timeline</b>
+                ${this._numericControl("Time", "keyframe.time", frame.time, { minimum: 0, maximum: track.duration, step: 0.001 })}
+                ${this._numericControl("Duration", "track.duration", track.duration, { minimum: 0.1, maximum: 86400, step: 0.01 })}
+                ${this._numericControl("FPS", "track.fps", track.fps, { minimum: 1, maximum: 120, step: 1 })}
+            </div>
+            <div class="vnccs-i3s__inspector-group"><b>Position · m</b>
+                ${["X", "Y", "Z"].map((axis, index) => this._numericControl(axis, `keyframe.position.${index}`, pose.position[index], { minimum: -10000, maximum: 10000, step: 0.01 })).join("")}
+            </div>
+            <div class="vnccs-i3s__inspector-group"><b>Rotation · degrees</b>
+                ${["X", "Y", "Z"].map((axis, index) => this._numericControl(axis, `keyframe.rotation.${index}`, rotation[index], { minimum: -36000, maximum: 36000, step: 0.01 })).join("")}
+            </div>
+            <div class="vnccs-i3s__inspector-group"><b>Lens</b>
+                ${this._numericControl("FOV", "keyframe.fov", pose.fov, { minimum: 5, maximum: 120, step: 0.01 })}
+                ${this._numericControl("Focus", "keyframe.focus_distance", pose.focus_distance, { minimum: 0.001, maximum: 1000000, step: 0.001 })}
+            </div>
+            <div class="vnccs-i3s__inspector-grid">
+                <label><span>Interpolation</span><select class="vnccs-i3s__select" data-track-property="interpolation"><option value="linear"${track.interpolation === "linear" ? " selected" : ""}>Linear</option><option value="catmullrom"${track.interpolation === "catmullrom" ? " selected" : ""}>Smooth path</option></select></label>
+                <label><span>Easing</span><select class="vnccs-i3s__select" data-keyframe-property="easing"><option value="linear"${frame.easing === "linear" ? " selected" : ""}>Linear</option><option value="smooth"${frame.easing === "smooth" ? " selected" : ""}>Smooth</option><option value="ease_in"${frame.easing === "ease_in" ? " selected" : ""}>Ease in</option><option value="ease_out"${frame.easing === "ease_out" ? " selected" : ""}>Ease out</option><option value="ease_in_out"${frame.easing === "ease_in_out" ? " selected" : ""}>Ease in/out</option></select></label>
+            </div>
+            <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-track-property="constant_speed"${track.constant_speed ? " checked" : ""} /> Constant position speed</label>
+            <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-track-property="loop"${track.loop ? " checked" : ""} /> Loop playback</label>
+            <div class="vnccs-i3s__inspector-actions"><button class="vnccs-i3s__button" type="button" data-keyframe-action="update">Update from view</button><button class="vnccs-i3s__button vnccs-i3s__button--danger" type="button" data-keyframe-action="delete">Delete point</button></div>`;
+        const edited = {
+            position: [...pose.position],
+            rotation: [...rotation],
+            fov: pose.fov,
+            focus_distance: pose.focus_distance,
+        };
+        let before = null;
+        const begin = () => { before ||= this._captureEditorSnapshot(); };
+        const applyPose = () => {
+            Object.assign(frame, normalizedCameraPose({
+                position: edited.position,
+                quaternion: quaternionFromEulerDegrees(edited.rotation),
+                fov: edited.fov,
+                focus_distance: edited.focus_distance,
+            }));
+            this.viewer.setCameraState(legacyCameraFromPose(frame), { emit: false });
+            this._scheduleSceneSave(180);
+        };
+        for (const control of this.els.inspector.querySelectorAll("[data-editor-path]")) {
+            control.addEventListener("pointerdown", begin);
+            control.addEventListener("focus", begin);
+            control.addEventListener("input", () => {
+                const [scope, key, rawIndex] = control.dataset.editorPath.split(".");
+                const value = Number(control.value);
+                if (!Number.isFinite(value)) return;
+                if (scope === "track") {
+                    if (key === "fps") track[key] = Math.round(value);
+                    else if (key === "duration") {
+                        const lastTime = Math.max(0, ...track.keyframes.map(item => Number(item.time) || 0));
+                        track.duration = Math.max(value, lastTime, 0.1);
+                    } else track[key] = value;
+                }
+                else if (key === "time") frame.time = Math.max(0, Math.min(track.duration, value));
+                else {
+                    if (rawIndex !== undefined) edited[key][Number(rawIndex)] = value;
+                    else edited[key] = value;
+                    applyPose();
+                }
+                const appliedValue = scope === "track"
+                    ? track[key]
+                    : key === "time"
+                        ? frame.time
+                        : rawIndex !== undefined
+                            ? edited[key][Number(rawIndex)]
+                            : edited[key];
+                control.value = String(appliedValue);
+                for (const peer of this.els.inspector.querySelectorAll(`[data-editor-path="${control.dataset.editorPath}"]`)) {
+                    if (peer !== control) peer.value = String(appliedValue);
+                }
+            });
+            control.addEventListener("change", () => {
+                track.keyframes.sort((left, right) => left.time - right.time);
+                if (before) this.history.push("Edit camera point", before, this._captureEditorSnapshot());
+                before = null;
+                this._renderCameraTracks();
+                this._scheduleSceneSave(0);
+                this._syncToolbar();
+            });
+        }
+        for (const control of this.els.inspector.querySelectorAll("[data-track-property],[data-keyframe-property]")) {
+            control.addEventListener("change", () => {
+                const original = this._captureEditorSnapshot();
+                const target = control.dataset.trackProperty ? track : frame;
+                const key = control.dataset.trackProperty || control.dataset.keyframeProperty;
+                target[key] = control.type === "checkbox" ? control.checked : control.value;
+                if (control.dataset.trackProperty === "building_id") {
+                    track.building_id = this._validBuildingId(control.value);
+                    this.editorView.active_building_id = track.building_id;
+                }
+                this.history.push("Edit camera path", original, this._captureEditorSnapshot());
+                this._renderCameraTracks();
+                this._scheduleSceneSave(0);
+                this._syncToolbar();
+            });
+        }
+        this.els.inspector.querySelector('[data-keyframe-action="update"]')?.addEventListener("click", () => {
+            const original = this._captureEditorSnapshot();
+            Object.assign(frame, cameraPoseFromLegacy(this.viewer.getCameraState()));
+            this.history.push("Update camera point", original, this._captureEditorSnapshot());
+            this._renderCameraTracks();
+            this._renderInspector();
+            this._scheduleSceneSave(0);
+        });
+        this.els.inspector.querySelector('[data-keyframe-action="delete"]')?.addEventListener("click", () => {
+            const original = this._captureEditorSnapshot();
+            track.keyframes = track.keyframes.filter(value => value.keyframe_id !== frame.keyframe_id);
+            this.selectedCameraKeyframeId = "";
+            this.history.push("Delete camera point", original, this._captureEditorSnapshot());
+            this._renderCameraTracks();
+            this._renderInspector();
+            this._scheduleSceneSave(0);
+        });
+    }
+
+    _renderObjectInspector(item) {
+        const transform = item.transform || { position: [0, 0, 0], rotation: [0, 0, 0], scale: 1 };
+        item.transform = {
+            position: Array.isArray(transform.position) ? [...transform.position] : [0, 0, 0],
+            rotation: Array.isArray(transform.rotation) ? [...transform.rotation] : [0, 0, 0],
+            scale: Math.max(0.001, Number(transform.scale) || 1),
+        };
+        const editor = normalizedObjectEditorProperties(item);
+        this.els.inspectorKind.textContent = "Gaussian object";
+        this.els.inspector.innerHTML = `
+            <div class="vnccs-i3s__inspector-title">${escapeHTML(item.name || "Object")}</div>
+            <div class="vnccs-i3s__inspector-group"><b>Position · m</b>
+                ${["X", "Y", "Z"].map((axis, index) => this._numericControl(axis, `position.${index}`, transform.position?.[index], { minimum: -1000, maximum: 1000, step: 0.01, disabled: editor.locked })).join("")}
+            </div>
+            <div class="vnccs-i3s__inspector-group"><b>Rotation · degrees</b>
+                ${["X", "Y", "Z"].map((axis, index) => this._numericControl(axis, `rotation.${index}`, transform.rotation?.[index], { minimum: -180, maximum: 180, step: 0.01, disabled: editor.locked })).join("")}
+            </div>
+            <div class="vnccs-i3s__inspector-group"><b>Uniform scale</b>
+                ${this._numericControl("Scale", "scale", transform.scale, { minimum: 0.001, maximum: 1000, step: 0.001, disabled: editor.locked })}
+            </div>
+            <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Floor level</span><select class="vnccs-i3s__select" data-object-property="level_id"${editor.locked ? " disabled" : ""}>
+                ${(this.scene?.levels || []).map(level => `<option value="${level.level_id}"${item.level_id === level.level_id ? " selected" : ""}>${escapeHTML(level.name)}</option>`).join("")}
+            </select></label>
+            <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Building</span><select class="vnccs-i3s__select" data-object-property="building_id"${editor.locked ? " disabled" : ""}>
+                ${this._buildingOptions(item.building_id)}
+            </select></label>
+            <div class="vnccs-i3s__inspector-grid">
+                <label><span>Collision</span><select class="vnccs-i3s__select" data-object-property="collision_proxy.mode">
+                    <option value="auto_box"${editor.collision_proxy.mode === "auto_box" ? " selected" : ""}>Automatic box</option>
+                    <option value="box"${editor.collision_proxy.mode === "box" ? " selected" : ""}>Custom box</option>
+                    <option value="off"${editor.collision_proxy.mode === "off" ? " selected" : ""}>Disabled</option>
+                </select></label>
+                <label><span>Light behavior</span><select class="vnccs-i3s__select" data-object-property="light_transport">
+                    <option value="opaque"${editor.light_transport === "opaque" ? " selected" : ""}>Opaque</option>
+                    <option value="cutout"${editor.light_transport === "cutout" ? " selected" : ""}>Cutout</option>
+                    <option value="transmissive"${editor.light_transport === "transmissive" ? " selected" : ""}>Glass / transmissive</option>
+                </select></label>
+            </div>
+            ${editor.collision_proxy.mode === "box" ? `
+                <div class="vnccs-i3s__inspector-group"><b>Custom collision box · local m</b>
+                    ${["X", "Y", "Z"].map((axis, index) => `<label class="vnccs-i3s__precision-row"><span>C${axis}</span><input class="vnccs-i3s__input" type="number" step="0.01" data-proxy-path="center.${index}" value="${editor.collision_proxy.center[index]}" /></label>`).join("")}
+                    ${["X", "Y", "Z"].map((axis, index) => `<label class="vnccs-i3s__precision-row"><span>S${axis}</span><input class="vnccs-i3s__input" type="number" min="0.001" step="0.01" data-proxy-path="size.${index}" value="${editor.collision_proxy.size[index]}" /></label>`).join("")}
+                </div>` : ""}
+            ${editor.light_transport === "transmissive" ? this._numericControl("Transmission", "object.transmission", editor.transmission, { minimum: 0, maximum: 1, step: 0.01 }) : ""}
+            <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-object-property="collision_proxy.supports_objects"${editor.collision_proxy.supports_objects ? " checked" : ""} /> Can support other objects</label>
+            <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-object-property="locked"${editor.locked ? " checked" : ""} /> Lock transform</label>
+            <div class="vnccs-i3s__inspector-actions">
+                <button class="vnccs-i3s__button" type="button" data-inspector-action="drop"${editor.locked ? " disabled" : ""}>Drop to surface</button>
+                <button class="vnccs-i3s__button" type="button" data-inspector-action="reset"${editor.locked ? " disabled" : ""}>Reset transform</button>
+            </div>`;
+        this._bindObjectInspector(item);
+    }
+
+    _bindObjectInspector(item) {
+        let before = null;
+        const begin = () => { before ||= this._captureEditorSnapshot(); };
+        const finish = label => {
+            if (!before) return;
+            this.history.push(label, before, this._captureEditorSnapshot());
+            before = null;
+            this._scheduleSceneSave(0);
+            this._scheduleStateSave(0);
+            this._scheduleScenePreview(160);
+        };
+        for (const control of this.els.inspector.querySelectorAll("[data-editor-path]")) {
+            control.addEventListener("pointerdown", begin);
+            control.addEventListener("focus", begin);
+            control.addEventListener("input", () => {
+                const [key, rawIndex] = control.dataset.editorPath.split(".");
+                const value = Number(control.value);
+                if (!Number.isFinite(value)) return;
+                if (key === "object" && rawIndex === "transmission") item.transmission = clamp(value, 0, 1);
+                else if (key === "scale") item.transform.scale = clamp(value, 0.001, 1000);
+                else item.transform[key][Number(rawIndex)] = value;
+                for (const peer of this.els.inspector.querySelectorAll(`[data-editor-path="${control.dataset.editorPath}"]`)) {
+                    if (peer !== control) peer.value = String(value);
+                }
+                this.viewer.updateObject(item.object_id, key === "object"
+                    ? { transmission: item.transmission }
+                    : { transform: item.transform });
+                this._scheduleSceneSave(180);
+                this._scheduleStateSave(180);
+            });
+            control.addEventListener("change", () => finish("Edit transform"));
+        }
+        for (const control of this.els.inspector.querySelectorAll("[data-proxy-path]")) {
+            control.addEventListener("focus", begin);
+            control.addEventListener("input", () => {
+                const [key, rawIndex] = control.dataset.proxyPath.split(".");
+                const value = Number(control.value);
+                if (!Number.isFinite(value)) return;
+                item.collision_proxy = normalizedObjectEditorProperties(item).collision_proxy;
+                item.collision_proxy[key][Number(rawIndex)] = key === "size"
+                    ? Math.max(0.001, value)
+                    : value;
+                this.viewer.updateObject(item.object_id, { collision_proxy: item.collision_proxy });
+                this._scheduleSceneSave(180);
+            });
+            control.addEventListener("change", () => finish("Edit collision box"));
+        }
+        for (const control of this.els.inspector.querySelectorAll("[data-object-property]")) {
+            control.addEventListener("change", () => {
+                const original = this._captureEditorSnapshot();
+                const key = control.dataset.objectProperty;
+                if (key === "collision_proxy.mode") {
+                    item.collision_proxy = normalizedObjectEditorProperties(item).collision_proxy;
+                    item.collision_proxy.mode = control.value;
+                } else if (key === "collision_proxy.supports_objects") {
+                    item.collision_proxy = normalizedObjectEditorProperties(item).collision_proxy;
+                    item.collision_proxy.supports_objects = control.checked;
+                } else if (key === "locked") item.locked = control.checked;
+                else if (key === "level_id") {
+                    const previousLevel = this.scene.levels.find(level => level.level_id === item.level_id);
+                    const nextLevel = this.scene.levels.find(level => level.level_id === control.value);
+                    item.transform.position[1] += (Number(nextLevel?.elevation) || 0)
+                        - (Number(previousLevel?.elevation) || 0);
+                    item.level_id = control.value;
+                }
+                else if (key === "building_id") {
+                    item.building_id = this._validBuildingId(control.value);
+                    if (item.building_id) this.editorView.active_building_id = item.building_id;
+                }
+                else {
+                    item[key] = control.value;
+                    if (key === "light_transport" && control.value === "transmissive" && !item.transmission) {
+                        item.transmission = 1;
+                    }
+                }
+                this.viewer.updateObject(item.object_id, item);
+                this.history.push("Edit object properties", original, this._captureEditorSnapshot());
+                this._scheduleSceneSave(0);
+                this._scheduleStateSave(0);
+                if (key === "building_id") this._syncToolbar();
+                if (["collision_proxy.mode", "light_transport", "locked"].includes(key)) this._renderInspector();
+            });
+        }
+        this.els.inspector.querySelector('[data-inspector-action="drop"]')?.addEventListener("click", () => {
+            this._dropSelectionToSurface(false);
+        });
+        this.els.inspector.querySelector('[data-inspector-action="reset"]')?.addEventListener("click", () => {
+            this._recordEditorCommand("Reset transform", () => {
+                const level = this.scene.levels.find(value => value.level_id === item.level_id);
+                const building = this.scene.architecture?.buildings?.find(
+                    value => value.building_id === item.building_id,
+                );
+                item.transform = {
+                    position: [
+                        Number(building?.position?.[0]) || 0,
+                        (Number(level?.elevation) || 0) + (Number(building?.position?.[1]) || 0),
+                        Number(building?.position?.[2]) || 0,
+                    ],
+                    rotation: [0, 0, 0],
+                    scale: 1,
+                };
+                this.viewer.updateObject(item.object_id, { transform: item.transform });
+                this._renderInspector();
+                this._scheduleSceneSave(0);
+            });
+        });
+    }
+
+    _materialOptions(selectedId = "") {
+        const materials = this.scene?.architecture?.materials || [];
+        return [
+            `<option value=""${selectedId ? "" : " selected"}>Default material</option>`,
+            ...materials.map(material => (
+                `<option value="${material.material_id}"${material.material_id === selectedId ? " selected" : ""}>${escapeHTML(material.name || "Material")}</option>`
+            )),
+        ].join("");
+    }
+
+    _materialControls(targetPath, selectedId = "", label = "Material") {
+        const material = this.scene?.architecture?.materials?.find(value => value.material_id === selectedId);
+        return `
+            <div class="vnccs-i3s__material-control">
+                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">${escapeHTML(label)}</span>
+                    <select class="vnccs-i3s__select" data-architecture-property="${targetPath}">${this._materialOptions(selectedId)}</select>
+                </label>
+                ${material ? `
+                    <details class="vnccs-i3s__material-details"><summary>Edit ${escapeHTML(material.name || "material")}</summary>
+                    <div class="vnccs-i3s__material-inline" data-material-id="${material.material_id}">
+                        <input type="color" data-material-property="color" value="${material.color || "#d7d2ca"}" aria-label="Material color" />
+                        <input class="vnccs-i3s__input" type="text" data-material-property="name" value="${escapeHTML(material.name || "Material")}" maxlength="80" aria-label="Material name" />
+                        <select class="vnccs-i3s__select" data-material-property="kind" aria-label="Material type"><option value="standard"${material.kind !== "glass" ? " selected" : ""}>Standard</option><option value="glass"${material.kind === "glass" ? " selected" : ""}>Glass</option></select>
+                        <label>Rough<input class="vnccs-i3s__input" type="number" min="0" max="1" step="0.01" data-material-property="roughness" value="${material.roughness ?? 0.78}" /></label>
+                        <label>Metal<input class="vnccs-i3s__input" type="number" min="0" max="1" step="0.01" data-material-property="metalness" value="${material.metalness ?? 0}" /></label>
+                        <label>Opacity<input class="vnccs-i3s__input" type="number" min="0" max="1" step="0.01" data-material-property="opacity" value="${material.opacity ?? 1}" /></label>
+                        <label>UV X<input class="vnccs-i3s__input" type="number" min="0.001" max="1000" step="0.01" data-material-property="uv_scale.0" value="${material.uv_scale?.[0] ?? 1}" /></label>
+                        <label>UV Y<input class="vnccs-i3s__input" type="number" min="0.001" max="1000" step="0.01" data-material-property="uv_scale.1" value="${material.uv_scale?.[1] ?? 1}" /></label>
+                        <label>UV °<input class="vnccs-i3s__input" type="number" step="0.01" data-material-property="uv_rotation" value="${material.uv_rotation ?? 0}" /></label>
+                        ${material.kind === "glass" ? `<label>Transmit<input class="vnccs-i3s__input" type="number" min="0" max="1" step="0.01" data-material-property="transmission" value="${material.transmission ?? 1}" /></label><label>IOR<input class="vnccs-i3s__input" type="number" min="1" max="2.5" step="0.01" data-material-property="ior" value="${material.ior ?? 1.5}" /></label>` : ""}
+                    </div></details>` : ""}
+            </div>`;
+    }
+
+    _materialActions(defaultTarget) {
+        return `
+            <input data-material-upload-input type="file" accept="image/jpeg,image/png,image/webp" hidden />
+            <div class="vnccs-i3s__inspector-actions">
+                <button class="vnccs-i3s__button" type="button" data-material-action="solid" data-material-target="${defaultTarget}">New solid material</button>
+                <button class="vnccs-i3s__button" type="button" data-material-action="upload" data-material-target="${defaultTarget}">Upload texture</button>
+            </div>`;
+    }
+
+    async _uploadTextureMaterial(file) {
+        if (!this.sceneId || !file) return null;
+        const sceneId = this.sceneId;
+        if ((this.scene?.architecture?.materials?.length || 0) >= 512) {
+            throw new Error("The scene material limit has been reached.");
+        }
+        if (
+            !["image/jpeg", "image/png", "image/webp"].includes(file.type)
+            || file.size > MAX_TEXTURE_BYTES
+        ) {
+            throw new Error("Texture must be a JPEG, PNG, or WebP image up to 32 MB.");
+        }
+        // Resolve any queued metadata edit first so the texture mutation and
+        // its following material PATCH share a current optimistic revision.
+        await this._saveSceneNow({ showError: false });
+        if (!this.scene || this.sceneId !== sceneId) {
+            throw new Error("The active scene changed before the texture upload started.");
+        }
+        const form = new FormData();
+        form.append("image", file, file.name);
+        const result = await this._fetchJSON(ENDPOINTS.textures(sceneId), {
+            method: "POST",
+            body: form,
+        });
+        if (!this.scene || this.sceneId !== sceneId) {
+            throw new Error("The active scene changed while the texture was uploading.");
+        }
+        this.scene.textures = result.scene?.textures || this.scene.textures || [];
+        this.scene.edit_revision = result.scene?.edit_revision ?? this.scene.edit_revision;
+        const material = {
+            material_id: factoryId(),
+            name: String(file.name || "Texture").replace(/\.[^.]+$/, "").slice(0, 80),
+            kind: "standard",
+            color: "#ffffff",
+            roughness: 0.78,
+            metalness: 0,
+            opacity: 1,
+            transmission: 0,
+            ior: 1.5,
+            uv_scale: [1, 1],
+            uv_rotation: 0,
+            texture_id: result.texture.texture_id,
+        };
+        this.scene.architecture.materials.push(material);
+        return material;
+    }
+
+    _renderArchitectureInspector(item) {
+        const type = this.selectedArchitecture?.type || "architecture";
+        const linkedRoom = type === "wall"
+            ? this.scene.architecture.rooms.find(room => room.wall_ids?.includes(item.wall_id))
+            : null;
+        this.els.inspectorKind.textContent = type[0].toUpperCase() + type.slice(1);
+        if (type === "building") {
+            const onlyBuilding = this.scene.architecture.buildings.length <= 1;
+            this.els.inspector.innerHTML = `
+                <div class="vnccs-i3s__inspector-title">${escapeHTML(item.name || "Building")}</div>
+                <div class="vnccs-i3s__hint">Moves and rotates the structure together with every assigned Gaussian object, saved camera, and local light.</div>
+                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Name</span><input class="vnccs-i3s__input" data-architecture-property="name" value="${escapeHTML(item.name || "Building")}" maxlength="80" /></label>
+                <div class="vnccs-i3s__inspector-group"><b>Building transform</b>
+                    ${this._numericControl("X", "position.0", item.position?.[0], { minimum: -10000, maximum: 10000, step: 0.01 })}
+                    ${this._numericControl("Y", "position.1", item.position?.[1], { minimum: -10000, maximum: 10000, step: 0.01 })}
+                    ${this._numericControl("Z", "position.2", item.position?.[2], { minimum: -10000, maximum: 10000, step: 0.01 })}
+                    ${this._numericControl("Rotation Y", "rotation_y", item.rotation_y, { minimum: -36000, maximum: 36000, step: 0.01 })}
+                </div>
+                <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-architecture-property="visible"${item.visible !== false ? " checked" : ""} /> Building visible</label>
+                <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-architecture-property="locked"${item.locked ? " checked" : ""} /> Lock building transform</label>
+                <div class="vnccs-i3s__hint">${onlyBuilding
+                    ? "Delete this Building and its architecture. Assigned models, cameras, paths, and lights will remain in the scene without a Building assignment."
+                    : "Delete this Building and its architecture. Assigned models, cameras, paths, and lights will move to another Building."}</div>
+                <button class="vnccs-i3s__button vnccs-i3s__button--danger" type="button" data-inspector-action="delete">Delete building</button>`;
+        } else if (type === "level") {
+            this.els.inspector.innerHTML = `
+                <div class="vnccs-i3s__inspector-title">${escapeHTML(item.name || "Floor level")}</div>
+                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Name</span><input class="vnccs-i3s__input" data-architecture-property="name" value="${escapeHTML(item.name || "Floor level")}" maxlength="80" /></label>
+                <div class="vnccs-i3s__inspector-group"><b>Level geometry · m</b>
+                    ${this._numericControl("Elevation", "elevation", item.elevation, { minimum: -10000, maximum: 10000, step: 0.01 })}
+                    ${this._numericControl("Height", "height", item.height, { minimum: 0.1, maximum: 1000, step: 0.01 })}
+                    ${this._numericControl("Slab", "slab_thickness", item.slab_thickness, { minimum: 0, maximum: 100, step: 0.01 })}
+                </div>
+                <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-architecture-property="visible"${item.visible !== false ? " checked" : ""} /> Level visible</label>
+                <button class="vnccs-i3s__button vnccs-i3s__button--danger" type="button" data-inspector-action="delete"${this.scene.levels.length <= 1 ? " disabled" : ""}>Delete level and its contents</button>`;
+        } else if (type === "wall") {
+            this.els.inspector.innerHTML = `
+                <div class="vnccs-i3s__inspector-title">${escapeHTML(item.name || "Wall")}</div>
+                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Name</span><input class="vnccs-i3s__input" data-architecture-property="name" value="${escapeHTML(item.name || "Wall")}" maxlength="80" /></label>
+                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Floor level${linkedRoom ? " · inherited from room" : ""}</span><select class="vnccs-i3s__select" data-architecture-property="level_id"${linkedRoom ? " disabled" : ""}>
+                    ${(this.scene?.levels || []).map(level => `<option value="${level.level_id}"${item.level_id === level.level_id ? " selected" : ""}>${escapeHTML(level.name)}</option>`).join("")}
+                </select></label>
+                <div class="vnccs-i3s__inspector-group"><b>Geometry · building-local m</b>
+                    ${this._numericControl("Start X", "start.0", item.start[0], { minimum: -10000, maximum: 10000, step: 0.01, range: false })}
+                    ${this._numericControl("Start Z", "start.1", item.start[1], { minimum: -10000, maximum: 10000, step: 0.01, range: false })}
+                    ${this._numericControl("End X", "end.0", item.end[0], { minimum: -10000, maximum: 10000, step: 0.01, range: false })}
+                    ${this._numericControl("End Z", "end.1", item.end[1], { minimum: -10000, maximum: 10000, step: 0.01, range: false })}
+                    ${this._numericControl("Height", "height", item.height, {
+                        minimum: 0.05,
+                        maximum: 1000,
+                        sliderMinimum: 0.05,
+                        sliderMaximum: 10,
+                        step: 0.01,
+                    })}
+                    ${this._numericControl("Thickness", "thickness", item.thickness, {
+                        minimum: 0.01,
+                        maximum: 10,
+                        sliderMinimum: 0.01,
+                        sliderMaximum: 1,
+                        step: 0.01,
+                    })}
+                    ${this._numericControl("Base offset", "elevation_offset", item.elevation_offset, {
+                        minimum: -1000,
+                        maximum: 1000,
+                        sliderMinimum: -5,
+                        sliderMaximum: 5,
+                        step: 0.01,
+                    })}
+                </div>
+                <div class="vnccs-i3s__inspector-group"><b>Surfaces</b>
+                    ${this._materialControls("material_left", item.material_left, "Left side")}
+                    ${this._materialControls("material_right", item.material_right, "Right side")}
+                    ${this._materialControls("material_caps", item.material_caps, "Edges")}
+                    ${this._materialActions("material_left")}
+                </div>
+                <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-architecture-property="visible"${item.visible !== false ? " checked" : ""} /> Wall visible</label>
+                <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-architecture-property="locked"${item.locked ? " checked" : ""} /> Lock wall</label>
+                <button class="vnccs-i3s__button vnccs-i3s__button--danger" type="button" data-inspector-action="delete">Delete wall</button>`;
+        } else if (type === "opening") {
+            const hostWall = this.scene.architecture.walls.find(wall => wall.wall_id === item.wall_id);
+            const limits = this._openingControlLimits(item, hostWall);
+            const hostLength = limits.wallLength;
+            this.els.inspector.innerHTML = `
+                <div class="vnccs-i3s__inspector-title">${escapeHTML(item.name || "Opening")}</div>
+                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Name</span><input class="vnccs-i3s__input" data-architecture-property="name" value="${escapeHTML(item.name || "Opening")}" maxlength="80" /></label>
+                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Type</span><select class="vnccs-i3s__select" data-architecture-property="kind">
+                    <option value="empty"${item.kind === "empty" ? " selected" : ""}>Empty opening</option>
+                    <option value="door"${item.kind === "door" ? " selected" : ""}>Door</option>
+                    <option value="window"${item.kind === "window" ? " selected" : ""}>Window / glass</option>
+                </select></label>
+                <div class="vnccs-i3s__hint">Host wall · ${this._formatControlNumber(limits.wallLength, 0.01)} m long · ${this._formatControlNumber(limits.wallHeight, 0.01)} m high</div>
+                ${this._numericControl("Center from wall start · m", "opening_offset_m", Number(item.offset) * hostLength, {
+                    minimum: limits.centerMinimum,
+                    maximum: limits.centerMaximum,
+                    step: 0.01,
+                    disabled: Math.abs(limits.centerMaximum - limits.centerMinimum) < 0.01,
+                })}
+                ${this._numericControl("Width", "width", item.width, { minimum: 0.05, maximum: limits.widthMaximum, step: 0.01 })}
+                ${this._numericControl("Height", "height", item.height, { minimum: 0.05, maximum: limits.wallHeight, step: 0.01 })}
+                ${item.kind === "door"
+                    ? this._numericControl("Sill", "sill_height", 0, { minimum: 0, maximum: 0, step: 0.01, range: false, disabled: true })
+                    : this._numericControl("Sill", "sill_height", item.sill_height, { minimum: 0, maximum: limits.sillMaximum, step: 0.01 })}
+                ${this._materialControls("material_id", item.material_id, "Glass / frame")}
+                ${this._materialActions("material_id")}
+                <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-architecture-property="visible"${item.visible !== false ? " checked" : ""} /> Opening visible</label>
+                <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-architecture-property="locked"${item.locked ? " checked" : ""} /> Lock opening</label>
+                <button class="vnccs-i3s__button vnccs-i3s__button--danger" type="button" data-inspector-action="delete">Delete opening</button>`;
+        } else {
+            const roomBounds = this._roomBounds(item);
+            const linkedRoomWalls = (this.scene.architecture.walls || []).filter(
+                wall => item.wall_ids?.includes(wall.wall_id),
+            );
+            const wallThickness = linkedRoomWalls.length
+                ? linkedRoomWalls.reduce(
+                    (total, wall) => total + (Number(wall.thickness) || 0.12),
+                    0,
+                ) / linkedRoomWalls.length
+                : 0.12;
+            const wallMaterial = linkedRoomWalls[0]?.material_left || "";
+            this.els.inspector.innerHTML = `
+                <div class="vnccs-i3s__inspector-title">${escapeHTML(item.name || "Room")}</div>
+                <div class="vnccs-i3s__hint">The room is one object. Walls, floor, and ceiling move and resize together.</div>
+                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Name</span><input class="vnccs-i3s__input" data-architecture-property="name" value="${escapeHTML(item.name || "Room")}" maxlength="80" /></label>
+                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Floor level</span><select class="vnccs-i3s__select" data-architecture-property="level_id">
+                    ${(this.scene?.levels || []).map(level => `<option value="${level.level_id}"${item.level_id === level.level_id ? " selected" : ""}>${escapeHTML(level.name)}</option>`).join("")}
+                </select></label>
+                <div class="vnccs-i3s__inspector-group"><b>Room envelope · building-local m</b>
+                    ${this._numericControl("Position X", "room_origin.0", roomBounds.center[0], { minimum: -10000, maximum: 10000, step: 0.01 })}
+                    ${this._numericControl("Position Z", "room_origin.1", roomBounds.center[1], { minimum: -10000, maximum: 10000, step: 0.01 })}
+                    ${this._numericControl("Width", "room_size.0", roomBounds.size[0], { minimum: 0.05, maximum: 10000, sliderMinimum: 0.05, sliderMaximum: Math.max(20, roomBounds.size[0]), step: 0.01 })}
+                    ${this._numericControl("Depth", "room_size.1", roomBounds.size[1], { minimum: 0.05, maximum: 10000, sliderMinimum: 0.05, sliderMaximum: Math.max(20, roomBounds.size[1]), step: 0.01 })}
+                    ${this._numericControl("Height", "ceiling.height", item.ceiling?.height, { minimum: 0.05, maximum: 1000, sliderMinimum: 0.05, sliderMaximum: 10, step: 0.01 })}
+                    ${this._numericControl("Wall thickness", "room_wall_thickness", wallThickness, { minimum: 0.01, maximum: 10, sliderMinimum: 0.01, sliderMaximum: 1, step: 0.01 })}
+                    ${this._numericControl("Floor slab", "floor.thickness", item.floor?.thickness, { minimum: 0, maximum: 10, sliderMinimum: 0, sliderMaximum: 1, step: 0.01 })}
+                    ${this._numericControl("Ceiling slab", "ceiling.thickness", item.ceiling?.thickness, { minimum: 0, maximum: 10, sliderMinimum: 0, sliderMaximum: 1, step: 0.01 })}
+                </div>
+                ${this._materialControls("room_wall_material", wallMaterial, "Wall material")}
+                ${this._materialActions("room_wall_material")}
+                ${this._materialControls("floor.material_id", item.floor?.material_id, "Floor material")}
+                ${this._materialControls("ceiling.material_id", item.ceiling?.material_id, "Ceiling material")}
+                <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-architecture-property="visible"${item.visible !== false ? " checked" : ""} /> Room visible</label>
+                <label class="vnccs-i3s__inspector-check"><input type="checkbox" data-architecture-property="locked"${item.locked ? " checked" : ""} /> Lock room</label>
+                <button class="vnccs-i3s__button vnccs-i3s__button--danger" type="button" data-inspector-action="delete">Delete room and perimeter walls</button>`;
+        }
+        const ownerBuilding = type === "opening"
+            ? this._buildingForItem(this.scene.architecture.walls.find(wall => wall.wall_id === item.wall_id))
+            : this._buildingForItem(item);
+        const linkedWallLocked = type === "room" && this.scene.architecture.walls.some(
+            wall => item.wall_ids?.includes(wall.wall_id) && wall.locked,
+        );
+        if ((item.locked || ownerBuilding?.locked || linkedWallLocked) && type !== "level") {
+            for (const control of this.els.inspector.querySelectorAll("[data-editor-path]")) {
+                control.disabled = true;
+            }
+            for (const control of this.els.inspector.querySelectorAll("[data-architecture-property]")) {
+                if (!["locked", "visible", "name"].includes(control.dataset.architectureProperty)) {
+                    control.disabled = true;
+                }
+            }
+        }
+        this._bindArchitectureInspector(item, type);
+    }
+
+    _bindArchitectureInspector(item, type) {
+        let before = null;
+        const begin = () => { before ||= this._captureEditorSnapshot(); };
+        const applyPath = (path, value) => {
+            if (type === "room" && path === "room_wall_material") {
+                const linked = new Set(item.wall_ids || []);
+                for (const wall of this.scene.architecture.walls || []) {
+                    if (!linked.has(wall.wall_id)) continue;
+                    wall.material_left = value;
+                    wall.material_right = value;
+                    wall.material_caps = value;
+                }
+                return;
+            }
+            const parts = path.split(".");
+            let target = item;
+            while (parts.length > 1) target = target[parts.shift()];
+            target[parts[0]] = value;
+        };
+        for (const control of this.els.inspector.querySelectorAll("[data-editor-path]")) {
+            control.addEventListener("pointerdown", begin);
+            control.addEventListener("focus", begin);
+            control.addEventListener("input", () => {
+                const value = Number(control.value);
+                if (!Number.isFinite(value)) return;
+                const path = control.dataset.editorPath;
+                if (type === "building" && (path.startsWith("position.") || path === "rotation_y")) {
+                    const nextPosition = [...item.position];
+                    if (path.startsWith("position.")) nextPosition[Number(path.split(".")[1])] = value;
+                    this._applyBuildingTransform(
+                        item,
+                        nextPosition,
+                        path === "rotation_y" ? value : item.rotation_y,
+                    );
+                } else if (type === "opening" && path === "opening_offset_m") {
+                    const wall = this.scene.architecture.walls.find(value => value.wall_id === item.wall_id);
+                    const length = Math.hypot(
+                        Number(wall?.end?.[0]) - Number(wall?.start?.[0]),
+                        Number(wall?.end?.[1]) - Number(wall?.start?.[1]),
+                    );
+                    if (length > 1e-9) item.offset = clamp(value / length, 0, 1);
+                } else if (type === "level" && path === "elevation") {
+                    const delta = value - (Number(item.elevation) || 0);
+                    item.elevation = value;
+                    if (Math.abs(delta) > 1e-12) {
+                        for (const object of this.scene.objects || []) {
+                            if (object.level_id !== item.level_id) continue;
+                            object.transform.position[1] += delta;
+                            this.viewer.updateObject(object.object_id, { transform: object.transform });
+                        }
+                        for (const camera of this.scene.cameras || []) {
+                            if (camera.level_id !== item.level_id) continue;
+                            camera.position[1] += delta;
+                            camera.target[1] += delta;
+                        }
+                        for (const light of this.lighting.lights || []) {
+                            if (light.level_id !== item.level_id) continue;
+                            light.position[1] += delta;
+                            light.target[1] += delta;
+                        }
+                        this.viewer.setCameraMarkers(this.scene.cameras || []);
+                        this._commitLighting();
+                    }
+                } else if (type === "room" && path.startsWith("room_origin.")) {
+                    const axis = Number(path.split(".")[1]);
+                    const center = this._roomBounds(item).center;
+                    const delta = [0, 0];
+                    delta[axis] = value - center[axis];
+                    item.polygon = item.polygon.map(point => [point[0] + delta[0], point[1] + delta[1]]);
+                    this._syncRoomPerimeter(item);
+                } else if (type === "room" && path.startsWith("room_size.")) {
+                    const axis = Number(path.split(".")[1]);
+                    const bounds = this._roomBounds(item);
+                    const currentSize = Math.max(0.001, bounds.size[axis]);
+                    const targetSize = Math.max(0.05, value);
+                    const scale = targetSize / currentSize;
+                    item.polygon = item.polygon.map(point => {
+                        const next = [...point];
+                        next[axis] = bounds.center[axis] + (next[axis] - bounds.center[axis]) * scale;
+                        return next;
+                    });
+                    this._syncRoomPerimeter(item);
+                } else if (type === "room" && path === "room_wall_thickness") {
+                    const thickness = clamp(value, 0.01, 10);
+                    const linked = new Set(item.wall_ids || []);
+                    for (const wall of this.scene.architecture.walls || []) {
+                        if (linked.has(wall.wall_id)) wall.thickness = thickness;
+                    }
+                } else {
+                    applyPath(path, value);
+                }
+                if (type === "room") this._syncRoomPerimeter(item);
+                if (type === "wall" && /^(start|end)\./.test(control.dataset.editorPath)) {
+                    this._syncRoomsForWall(item);
+                }
+                if (type === "opening") {
+                    const wall = this.scene.architecture.walls.find(value => value.wall_id === item.wall_id);
+                    if (wall) {
+                        item.height = clamp(Number(item.height) || 0.05, 0.05, wall.height);
+                        item.sill_height = clamp(Number(item.sill_height) || 0, 0, Math.max(0, wall.height - item.height));
+                    }
+                    const fitted = wall && this._fitOpeningOnWall(wall, item.offset, item.width, item.opening_id);
+                    const fallback = fitted || (wall && this._fitOpeningOnWall(wall, item.offset, 0.05, item.opening_id));
+                    if (fallback) {
+                        item.offset = fallback.offset;
+                        item.width = fallback.width;
+                    }
+                }
+                const appliedValue = type === "room" && path.startsWith("room_origin.")
+                    ? this._roomBounds(item).center[Number(path.split(".")[1])]
+                    : type === "room" && path.startsWith("room_size.")
+                        ? this._roomBounds(item).size[Number(path.split(".")[1])]
+                        : type === "room" && path === "room_wall_thickness"
+                            ? this.scene.architecture.walls.find(
+                                wall => item.wall_ids?.includes(wall.wall_id),
+                            )?.thickness
+                            : type === "opening" && path === "opening_offset_m"
+                    ? (() => {
+                        const wall = this.scene.architecture.walls.find(value => value.wall_id === item.wall_id);
+                        const length = Math.hypot(
+                            Number(wall?.end?.[0]) - Number(wall?.start?.[0]),
+                            Number(wall?.end?.[1]) - Number(wall?.start?.[1]),
+                        );
+                        return item.offset * length;
+                    })()
+                                : control.dataset.editorPath.split(".").reduce(
+                                    (target, key) => target?.[key],
+                                    item,
+                                );
+                for (const peer of this.els.inspector.querySelectorAll(`[data-editor-path="${control.dataset.editorPath}"]`)) {
+                    const peerValue = Number.isFinite(Number(appliedValue)) ? appliedValue : value;
+                    peer.value = this._formatControlNumber(peerValue, peer.step);
+                }
+                this._queueSelectedArchitecturePreview();
+            });
+            control.addEventListener("change", () => {
+                this._queueSelectedArchitecturePreview({ flush: true });
+                if (before) this.history.push("Edit architecture", before, this._captureEditorSnapshot());
+                before = null;
+                void this._commitArchitecture({ targeted: type !== "room" });
+                if (type === "opening") this._renderInspector();
+            });
+        }
+        for (const control of this.els.inspector.querySelectorAll("[data-architecture-property]")) {
+            control.addEventListener("change", () => {
+                const original = this._captureEditorSnapshot();
+                const property = control.dataset.architectureProperty;
+                const propertyValue = control.type === "checkbox" ? control.checked : control.value;
+                const previousValue = property.split(".").reduce(
+                    (target, key) => target?.[key],
+                    item,
+                );
+                applyPath(property, propertyValue);
+                if (property === "kind" && type === "opening" && previousValue !== propertyValue) {
+                    const wall = this.scene.architecture.walls.find(value => value.wall_id === item.wall_id);
+                    if (propertyValue === "door") {
+                        item.sill_height = 0;
+                        item.height = Math.min(2, Number(wall?.height) || 2);
+                    } else if (propertyValue === "window" && previousValue === "door") {
+                        item.height = Math.min(1.2, Number(wall?.height) || 1.2);
+                        item.sill_height = Math.min(0.9, Math.max(0, (Number(wall?.height) || 2.8) - item.height));
+                    }
+                }
+                if (property === "level_id" && type === "room") {
+                    this._syncRoomPerimeter(item);
+                }
+                if (type === "room" && property === "visible") {
+                    item.floor = { ...(item.floor || {}), enabled: propertyValue };
+                    item.ceiling = { ...(item.ceiling || {}), enabled: propertyValue };
+                }
+                if (type === "room" && ["visible", "locked"].includes(property)) {
+                    this._syncRoomPerimeter(item);
+                }
+                this.history.push("Edit architecture", original, this._captureEditorSnapshot());
+                void this._commitArchitecture({ targeted: type !== "room" });
+                if (property === "level_id") {
+                    this.editorView.active_level_id = propertyValue;
+                    this.viewer.setActiveLevel(propertyValue);
+                    this._syncToolbar();
+                }
+                if (["locked", "kind"].includes(property)) this._renderInspector();
+            });
+        }
+        let materialBefore = null;
+        for (const control of this.els.inspector.querySelectorAll("[data-material-property]")) {
+            const materialId = control.closest("[data-material-id]")?.dataset.materialId;
+            const material = this.scene.architecture.materials.find(value => value.material_id === materialId);
+            if (!material) continue;
+            const beginMaterial = () => { materialBefore ||= this._captureEditorSnapshot(); };
+            control.addEventListener("pointerdown", beginMaterial);
+            control.addEventListener("focus", beginMaterial);
+            control.addEventListener("input", () => {
+                const parts = control.dataset.materialProperty.split(".");
+                let target = material;
+                while (parts.length > 1) target = target[parts.shift()];
+                target[parts[0]] = control.type === "number" ? Number(control.value) : control.value;
+                if (
+                    control.dataset.materialProperty === "kind"
+                    && control.value === "glass"
+                    && !(Number(material.transmission) > 0)
+                ) material.transmission = 1;
+                this._previewArchitectureMaterials();
+            });
+            control.addEventListener("change", () => {
+                if (materialBefore) {
+                    this.history.push("Edit material", materialBefore, this._captureEditorSnapshot());
+                    materialBefore = null;
+                }
+                void this._commitArchitecture();
+                if (control.dataset.materialProperty === "kind") this._renderInspector();
+            });
+        }
+        const uploadInput = this.els.inspector.querySelector("[data-material-upload-input]");
+        let uploadTarget = "";
+        for (const control of this.els.inspector.querySelectorAll("[data-material-action]")) {
+            control.addEventListener("click", () => {
+                const target = control.dataset.materialTarget;
+                if (control.dataset.materialAction === "upload") {
+                    uploadTarget = target;
+                    uploadInput?.click();
+                    return;
+                }
+                this._recordEditorCommand("Add material", () => {
+                    if (this.scene.architecture.materials.length >= 512) {
+                        this.toast("The scene material limit has been reached.", "error");
+                        return;
+                    }
+                    const material = {
+                        material_id: factoryId(),
+                        name: `Material ${this.scene.architecture.materials.length + 1}`,
+                        kind: "standard",
+                        color: "#d7d2ca",
+                        roughness: 0.78,
+                        metalness: 0,
+                        opacity: 1,
+                        transmission: 0,
+                        ior: 1.5,
+                        uv_scale: [1, 1],
+                        uv_rotation: 0,
+                    };
+                    this.scene.architecture.materials.push(material);
+                    applyPath(target, material.material_id);
+                    void this._commitArchitecture();
+                    this._renderInspector();
+                });
+            });
+        }
+        uploadInput?.addEventListener("change", async () => {
+            const file = uploadInput.files?.[0];
+            uploadInput.value = "";
+            if (!file || !uploadTarget) return;
+            const beforeUpload = this._captureEditorSnapshot();
+            try {
+                const material = await this._uploadTextureMaterial(file);
+                if (!material) return;
+                applyPath(uploadTarget, material.material_id);
+                this.history.push("Add textured material", beforeUpload, this._captureEditorSnapshot());
+                await this._commitArchitecture();
+                this._renderInspector();
+                this.toast("Texture material added.", "success");
+            } catch (error) {
+                this._showError("Texture upload failed", error);
+            }
+        });
+        this.els.inspector.querySelector('[data-inspector-action="delete"]')?.addEventListener("click", () => {
+            const performDeletion = () => this._recordEditorCommand("Delete architecture", () => {
+                const architecture = this.scene.architecture;
+                if (type === "level") {
+                    if (this.scene.levels.length <= 1) return;
+                    const removedElevation = Number(item.elevation) || 0;
+                    const wallIds = new Set(architecture.walls.filter(value => value.level_id === item.level_id).map(value => value.wall_id));
+                    architecture.walls = architecture.walls.filter(value => value.level_id !== item.level_id);
+                    architecture.rooms = architecture.rooms.filter(value => value.level_id !== item.level_id);
+                    architecture.openings = architecture.openings.filter(value => !wallIds.has(value.wall_id));
+                    this.scene.levels = this.scene.levels.filter(value => value.level_id !== item.level_id);
+                    this.editorView.active_level_id = this.scene.levels[0].level_id;
+                    const fallbackElevation = Number(this.scene.levels[0].elevation) || 0;
+                    const elevationDelta = fallbackElevation - removedElevation;
+                    for (const object of this.scene.objects || []) {
+                        if (object.level_id !== item.level_id) continue;
+                        object.level_id = this.editorView.active_level_id;
+                        object.transform.position[1] += elevationDelta;
+                    }
+                    for (const camera of this.scene.cameras || []) {
+                        if (camera.level_id !== item.level_id) continue;
+                        camera.level_id = this.editorView.active_level_id;
+                        camera.position[1] += elevationDelta;
+                        camera.target[1] += elevationDelta;
+                    }
+                    for (const light of this.lighting.lights || []) {
+                        if (light.level_id !== item.level_id) continue;
+                        light.level_id = this.editorView.active_level_id;
+                        light.position[1] += elevationDelta;
+                        light.target[1] += elevationDelta;
+                    }
+                } else if (type === "building") {
+                    const wallIds = new Set(architecture.walls
+                        .filter(value => value.building_id === item.building_id)
+                        .map(value => value.wall_id));
+                    architecture.walls = architecture.walls.filter(value => value.building_id !== item.building_id);
+                    architecture.rooms = architecture.rooms.filter(value => value.building_id !== item.building_id);
+                    architecture.openings = architecture.openings.filter(value => !wallIds.has(value.wall_id));
+                    architecture.buildings = architecture.buildings.filter(value => value.building_id !== item.building_id);
+                    const fallbackBuildingId = architecture.buildings[0]?.building_id || "";
+                    this.editorView.active_building_id = fallbackBuildingId;
+                    for (const object of this.scene.objects || []) {
+                        if (object.building_id === item.building_id) object.building_id = fallbackBuildingId;
+                    }
+                    for (const camera of this.scene.cameras || []) {
+                        if (camera.building_id === item.building_id) camera.building_id = fallbackBuildingId;
+                    }
+                    for (const light of this.lighting.lights || []) {
+                        if (light.building_id === item.building_id) light.building_id = fallbackBuildingId;
+                    }
+                    for (const track of this.scene.camera_tracks || []) {
+                        if (track.building_id === item.building_id) track.building_id = fallbackBuildingId;
+                    }
+                } else if (type === "wall") {
+                    architecture.walls = architecture.walls.filter(value => value.wall_id !== item.wall_id);
+                    architecture.openings = architecture.openings.filter(value => value.wall_id !== item.wall_id);
+                    architecture.rooms = architecture.rooms.filter(
+                        room => !room.wall_ids?.includes(item.wall_id),
+                    );
+                } else if (type === "opening") {
+                    architecture.openings = architecture.openings.filter(value => value.opening_id !== item.opening_id);
+                } else {
+                    const perimeter = new Set(item.wall_ids || []);
+                    architecture.walls = architecture.walls.filter(value => !perimeter.has(value.wall_id));
+                    architecture.openings = architecture.openings.filter(value => !perimeter.has(value.wall_id));
+                    architecture.rooms = architecture.rooms.filter(value => value.room_id !== item.room_id);
+                }
+                this.selectedArchitecture = null;
+                void this._commitArchitecture();
+            });
+            if (type === "building") {
+                this._confirmBuildingDeletion(item, performDeletion);
+            } else {
+                performDeletion();
+            }
+        });
+    }
+
+    _confirmBuildingDeletion(building, onConfirm) {
+        if (!building?.building_id || typeof onConfirm !== "function") return;
+        const architecture = this.scene?.architecture;
+        if (!architecture) return;
+        const onlyBuilding = architecture.buildings.length <= 1;
+        const wallIds = new Set(architecture.walls
+            .filter(value => value.building_id === building.building_id)
+            .map(value => value.wall_id));
+        const wallCount = wallIds.size;
+        const roomCount = architecture.rooms.filter(
+            value => value.building_id === building.building_id,
+        ).length;
+        const openingCount = architecture.openings.filter(
+            value => wallIds.has(value.wall_id),
+        ).length;
+        const fallback = !onlyBuilding
+            ? architecture.buildings.find(value => value.building_id !== building.building_id)
+            : null;
+        const body = element("div");
+        body.append(
+            element(
+                "div",
+                "vnccs-i3s__failure-summary",
+                `Delete “${building.name || "Building"}”?`,
+            ),
+            element(
+                "div",
+                "vnccs-i3s__hint",
+                `${wallCount} wall${wallCount === 1 ? "" : "s"}, ${roomCount} room${roomCount === 1 ? "" : "s"}, and ${openingCount} opening${openingCount === 1 ? "" : "s"} will be removed.`,
+            ),
+            element(
+                "div",
+                "vnccs-i3s__hint",
+                onlyBuilding
+                    ? "Assigned models, cameras, paths, and lights will remain in the scene without a Building assignment. No replacement Building will be created. You can undo this action."
+                    : `Assigned models, cameras, paths, and lights will move to “${fallback?.name || "another Building"}”. You can undo this action.`,
+            ),
+        );
+        const cancel = button("vnccs-i3s__button", "Cancel");
+        const remove = button(
+            "vnccs-i3s__button vnccs-i3s__button--danger",
+            "Delete building",
+            "trash",
+        );
+        cancel.addEventListener("click", () => this.closeModal());
+        remove.addEventListener("click", () => {
+            this.closeModal();
+            onConfirm();
+            this.toast("Building deleted.", "success");
+        });
+        this.openModal({
+            title: "Delete building",
+            body,
+            actions: [cancel, remove],
+            initialFocus: cancel,
+        });
+    }
+
+    _activeCameraTrack() {
+        return (this.scene?.camera_tracks || []).find(track => track.track_id === this.activeCameraTrackId)
+            || this.scene?.camera_tracks?.[0]
+            || null;
+    }
+
+    _addCameraTrack() {
+        if (!this.scene) return;
+        if ((this.scene.camera_tracks?.length || 0) >= 16) {
+            this.toast("A scene can contain up to 16 camera paths.", "error");
+            return;
+        }
+        this._recordEditorCommand("Add camera path", () => {
+            const track = {
+                track_id: factoryId(),
+                name: `Path ${(this.scene.camera_tracks?.length || 0) + 1}`,
+                building_id: this._activeBuilding()?.building_id || "",
+                duration: 5,
+                fps: 30,
+                interpolation: "catmullrom",
+                constant_speed: true,
+                loop: false,
+                keyframes: [],
+            };
+            this.scene.camera_tracks = [...(this.scene.camera_tracks || []), track];
+            this.activeCameraTrackId = track.track_id;
+            this._renderCameraTracks();
+            this._scheduleSceneSave(0);
+        });
+    }
+
+    _deleteCameraTrack() {
+        const track = this._activeCameraTrack();
+        if (!track) return;
+        const before = this._captureEditorSnapshot();
+        if (this.cameraPlayback) this._toggleCameraPlayback();
+        this.scene.camera_tracks = (this.scene.camera_tracks || []).filter(
+            value => value.track_id !== track.track_id,
+        );
+        this.activeCameraTrackId = this.scene.camera_tracks[0]?.track_id || "";
+        this.selectedCameraKeyframeId = "";
+        this.history.push("Delete camera path", before, this._captureEditorSnapshot());
+        this._renderCameraTracks();
+        this._renderInspector();
+        this._scheduleSceneSave(0);
+        this._syncToolbar();
+    }
+
+    _addCameraKeyframe(cameraState = null) {
+        const track = this._activeCameraTrack();
+        if (!track || !this.viewer) return;
+        const total = (this.scene?.camera_tracks || []).reduce(
+            (count, value) => count + (value.keyframes?.length || 0),
+            0,
+        );
+        if (total >= 1000) {
+            this.toast("The scene camera-point limit has been reached.", "error");
+            return;
+        }
+        this._recordEditorCommand("Add camera point", () => {
+            let time = track.keyframes.length
+                ? Number(track.keyframes.at(-1).time) + 1
+                : 0;
+            if (time > track.duration && time <= 86400) track.duration = time;
+            time = Math.min(track.duration, time);
+            track.keyframes.push({
+                keyframe_id: factoryId(),
+                time,
+                ...cameraPoseFromLegacy(cameraState || this.viewer.getCameraState()),
+                easing: "smooth",
+            });
+            track.keyframes.sort((left, right) => left.time - right.time);
+            this._renderCameraTracks();
+            this._scheduleSceneSave(0);
+        });
+    }
+
+    _renderCameraTracks() {
+        if (!this.els?.cameraTrackSelect) return;
+        const tracks = Array.isArray(this.scene?.camera_tracks) ? this.scene.camera_tracks : [];
+        if (!tracks.some(track => track.track_id === this.activeCameraTrackId)) {
+            this.activeCameraTrackId = tracks[0]?.track_id || "";
+        }
+        this.els.cameraTrackSelect.replaceChildren();
+        if (!tracks.length) {
+            const option = element("option", "", "No paths");
+            option.value = "";
+            this.els.cameraTrackSelect.appendChild(option);
+        } else {
+            for (const track of tracks) {
+                const option = element("option", "", track.name || "Camera path");
+                option.value = track.track_id;
+                option.selected = track.track_id === this.activeCameraTrackId;
+                this.els.cameraTrackSelect.appendChild(option);
+            }
+        }
+        const active = this._activeCameraTrack();
+        this.els.cameraTrackDelete.disabled = !active;
+        this.els.cameraTrackName.disabled = !active;
+        this.els.cameraTrackName.value = active?.name || "";
+        this.els.cameraTrackBuilding.disabled = !active;
+        const unassignedBuilding = element("option", "", "No building");
+        unassignedBuilding.value = "";
+        unassignedBuilding.selected = !this._validBuildingId(active?.building_id);
+        this.els.cameraTrackBuilding.replaceChildren(unassignedBuilding, ...(this.scene?.architecture?.buildings || []).map(building => {
+            const option = element("option", "", building.name || "Building");
+            option.value = building.building_id;
+            option.selected = building.building_id === this._validBuildingId(active?.building_id);
+            return option;
+        }));
+        this.els.cameraKeyframeAdd.disabled = !active;
+        this.els.cameraTrackPlay.disabled = !active || active.keyframes.length < 2;
+        this.els.cameraTrackTime.max = String(active?.duration || 5);
+        this.els.cameraTrackMeta.textContent = active
+            ? `${active.keyframes.length} points · ${active.duration}s · ${active.fps} fps`
+            : "No camera path";
+        this.els.cameraKeyframes.replaceChildren();
+        if (!active?.keyframes?.length) {
+            this.els.cameraKeyframes.appendChild(element("div", "vnccs-i3s__camera-keyframe-empty", "Add at least two points."));
+            return;
+        }
+        if (!active.keyframes.some(frame => frame.keyframe_id === this.selectedCameraKeyframeId)) {
+            this.selectedCameraKeyframeId = "";
+        }
+        for (const [index, frame] of active.keyframes.entries()) {
+            const row = element(
+                "button",
+                `vnccs-i3s__camera-keyframe${frame.keyframe_id === this.selectedCameraKeyframeId ? " is-selected" : ""}`,
+            );
+            row.type = "button";
+            row.innerHTML = `<span>${index + 1}</span><b>Point ${index + 1}</b><time>${Number(frame.time).toFixed(2)}s</time>`;
+            row.addEventListener("click", () => {
+                this.editorView.active_building_id = this._validBuildingId(active.building_id);
+                this.selectedCameraKeyframeId = frame.keyframe_id;
+                this.selectedCameraId = "";
+                this.selectedArchitecture = null;
+                this.viewer.setArchitectureSelection(null);
+                this.selectedObjectId = "";
+                this.selectedObjectIds.clear();
+                this.viewer.select("");
+                this.viewer.setCameraState(legacyCameraFromPose(frame), { emit: false });
+                this.els.cameraTrackTime.value = String(frame.time);
+                this._renderCameraTracks();
+                this._renderInspector();
+                this._setWorkspaceTab("right", "inspector");
+                this._syncToolbar();
+                this._scheduleStateSave(0);
+            });
+            this.els.cameraKeyframes.appendChild(row);
+        }
+    }
+
+    _setCameraTrackTime(time, evaluator = null) {
+        const track = this._activeCameraTrack();
+        if (!track || track.keyframes.length < 1) return;
+        const pose = (evaluator || new FactoryCameraPath(track)).evaluate(time);
+        this.viewer.setCameraState(legacyCameraFromPose(pose), { emit: false });
+        this._syncViewportCameraHUD(this.viewer.getCameraState());
+        this.els.cameraTrackTime.value = String(time);
+        this.els.cameraTrackMeta.textContent = `${Number(time).toFixed(2)}s · ${track.keyframes.length} points`;
+    }
+
+    _toggleCameraPlayback() {
+        if (this.cameraPlayback) {
+            cancelAnimationFrame(this.cameraPlayback.frame);
+            this.cameraPlayback = null;
+            this.viewer.setCameraPlayback(false);
+            this.els.cameraTrackPlay.textContent = "Play";
+            this._syncViewportCameraHUD(this.viewer.getCameraState());
+            return;
+        }
+        const track = this._activeCameraTrack();
+        if (!track || track.keyframes.length < 2) return;
+        if (this.editorView.view_mode !== "3d") this._setViewMode("3d");
+        let startTime = Math.max(0, Number(this.els.cameraTrackTime.value) || 0);
+        if (!track.loop && startTime >= track.duration) startTime = 0;
+        const started = performance.now() - startTime * 1000;
+        const path = new FactoryCameraPath(track);
+        this.els.cameraTrackPlay.textContent = "Pause";
+        this.viewer.setCameraPlayback(true);
+        this.cameraPlayback = { frame: 0, started };
+        this._syncViewportCameraHUD(this.viewer.getCameraState());
+        const step = now => {
+            if (!this.cameraPlayback) return;
+            let time = (now - started) / 1000;
+            if (time > track.duration) {
+                if (track.loop) time %= track.duration;
+                else {
+                    this._setCameraTrackTime(track.duration);
+                    this._toggleCameraPlayback();
+                    return;
+                }
+            }
+            this._setCameraTrackTime(time, path);
+            this.cameraPlayback.frame = requestAnimationFrame(step);
+        };
+        this.cameraPlayback.frame = requestAnimationFrame(step);
+    }
+
     _normalizeCameraState(value = {}, fallback = {}) {
         const source = safeObject(value);
         const previous = safeObject(fallback);
@@ -1161,6 +4825,8 @@ class Factory3DWidget {
                 created_at: Number.isFinite(Number(camera.created_at))
                     ? Number(camera.created_at)
                     : 0,
+                level_id: String(camera.level_id || ""),
+                building_id: this._validBuildingId(camera.building_id),
                 ...this._normalizeCameraState(camera),
             });
         }
@@ -1170,12 +4836,13 @@ class Factory3DWidget {
     _bindCameraControls() {
         const rotate = delta => {
             this.viewer?.rotateCameraFPV?.(delta);
-            if (this.selectedCameraId && this.scene) {
+            if (this.previewCameraId && this.scene) {
                 const camera = this.scene.cameras?.find(
-                    item => item.camera_id === this.selectedCameraId,
+                    item => item.camera_id === this.previewCameraId,
                 );
                 if (camera) {
                     Object.assign(camera, this.viewer.getCameraState());
+                    this.viewer.setCameraMarkers(this.scene.cameras);
                     this._scheduleSceneSave(140);
                     this._scheduleStateSave(140);
                 }
@@ -1238,13 +4905,18 @@ class Factory3DWidget {
             this.toast("A scene can contain up to 32 cameras.", "error");
             return;
         }
+        const before = this._captureEditorSnapshot();
         const camera = {
             camera_id: randomLayerId(),
             name: `Camera ${this.scene.cameras.length + 1}`,
             created_at: Date.now() / 1000,
+            level_id: this.editorView.active_level_id || this.scene.levels?.[0]?.level_id || "",
+            building_id: this._activeBuilding()?.building_id || "",
             ...this._normalizeCameraState(this.viewer.getCameraState()),
         };
         this.scene.cameras.push(camera);
+        this.history.push("Add camera", before, this._captureEditorSnapshot());
+        this._selectCamera(camera.camera_id);
         this._renderCameras();
         this._updateSceneSummary();
         await this._saveSceneNow();
@@ -1254,39 +4926,62 @@ class Factory3DWidget {
     _selectCamera(cameraId) {
         const camera = this.scene?.cameras?.find(item => item.camera_id === cameraId);
         if (!camera) return;
-        if (this.selectedCameraId === cameraId) {
-            this._exitCameraView({ restore: true });
-            return;
-        }
-        if (!this.selectedCameraId) {
-            this._cameraReturnState = this._normalizeCameraState(
-                this.viewer.getCameraState(),
-                this.scene?.camera,
-            );
-        }
+        const selectedBuildingId = this._validBuildingId(camera.building_id);
+        if (selectedBuildingId) this.editorView.active_building_id = selectedBuildingId;
+        if (this.cameraPlayback) this._toggleCameraPlayback();
+        this.selectedCameraKeyframeId = "";
         this._cameraSelectionTransition = true;
         try {
             this.selectedObjectId = "";
             this.selectedObjectIds.clear();
             this.selectedGroupId = "";
             this.selectedSkydome = false;
+            this.selectedArchitecture = null;
+            this.viewer.setArchitectureSelection(null);
             this.viewer.select("");
             this.selectedCameraId = cameraId;
-            this.viewer.setCameraState(camera, { emit: false });
         } finally {
             this._cameraSelectionTransition = false;
         }
         this._syncSelectionPresentation();
         this._renderCameras();
+        this._renderInspector();
+        this._syncToolbar();
+        this._setWorkspaceTab("right", "inspector");
         this._scheduleStateSave();
     }
 
+    _enterCameraView(cameraId = this.selectedCameraId) {
+        const camera = this.scene?.cameras?.find(item => item.camera_id === cameraId);
+        if (!camera) return;
+        if (!this.previewCameraId) {
+            this._cameraReturnState = this._normalizeCameraState(
+                this.viewer.getCameraState(),
+                this.scene?.camera,
+            );
+        }
+        this.previewCameraId = cameraId;
+        if (this.scene.levels?.some(level => level.level_id === camera.level_id)) {
+            this.editorView.active_level_id = camera.level_id;
+            this.viewer.setActiveLevel(camera.level_id);
+        }
+        if (this.editorView.view_mode !== "3d") {
+            this.editorView.view_mode = "3d";
+            this.viewer.setViewMode("3d");
+        }
+        this.viewer.setCameraState(camera, { emit: false });
+        this._syncToolbar();
+        this._renderCameras();
+        this._renderInspector();
+        this._scheduleStateSave(0);
+    }
+
     _exitCameraView({ restore = true } = {}) {
-        if (!this.selectedCameraId && !this._cameraReturnState) return;
+        if (!this.previewCameraId && !this._cameraReturnState) return;
         const returnState = this._cameraReturnState;
         this._cameraSelectionTransition = true;
         try {
-            this.selectedCameraId = "";
+            this.previewCameraId = "";
             this._cameraReturnState = null;
             if (restore && returnState) {
                 this.viewer.setCameraState(returnState, { emit: false });
@@ -1299,6 +4994,7 @@ class Factory3DWidget {
             this._cameraSelectionTransition = false;
         }
         this._renderCameras();
+        this._renderInspector();
         this._scheduleStateSave();
     }
 
@@ -1306,12 +5002,19 @@ class Factory3DWidget {
         if (!this.scene) return;
         const camera = this.scene.cameras?.find(item => item.camera_id === cameraId);
         if (!camera) return;
-        if (this.selectedCameraId === cameraId) this._exitCameraView({ restore: true });
+        const before = this._captureEditorSnapshot();
+        if (this.previewCameraId === cameraId) this._exitCameraView({ restore: true });
+        if (this.selectedCameraId === cameraId) this.selectedCameraId = "";
         this.scene.cameras = this.scene.cameras.filter(
             item => item.camera_id !== cameraId,
         );
+        this.history.push("Delete camera", before, this._captureEditorSnapshot());
         this._renderCameras();
+        this._renderInspector();
+        this._syncSelectionPresentation();
+        this._syncToolbar();
         this._updateSceneSummary();
+        this._scheduleStateSave(0);
         await this._saveSceneNow();
         this.toast(`${camera.name} removed.`, "success");
     }
@@ -1319,6 +5022,7 @@ class Factory3DWidget {
     _renderCameras() {
         const cameras = this._normalizeSceneCameras(this.scene?.cameras);
         if (this.scene) this.scene.cameras = cameras;
+        this.viewer?.setCameraMarkers?.(cameras);
         this.els.cameraCount.textContent = String(cameras.length);
         this.els.cameraGroupCount.textContent = String(cameras.length);
         this.els.cameraAdd.disabled = !this.scene || cameras.length >= 32;
@@ -1335,9 +5039,10 @@ class Factory3DWidget {
                 "div",
                 `vnccs-i3s__camera-item${
                     camera.camera_id === this.selectedCameraId ? " is-selected" : ""
-                }`,
+                }${camera.camera_id === this.previewCameraId ? " is-previewing" : ""}`,
             );
             card.dataset.cameraId = camera.camera_id;
+            card.title = `${camera.name} · ${this.scene?.levels?.find(level => level.level_id === camera.level_id)?.name || "Unassigned floor"}`;
             card.tabIndex = 0;
             card.setAttribute("role", "button");
             card.setAttribute("aria-pressed", String(camera.camera_id === this.selectedCameraId));
@@ -1345,6 +5050,9 @@ class Factory3DWidget {
                 <span class="vnccs-i3s__camera-index">${index + 1}</span>
                 <span class="vnccs-i3s__camera-item-icon">${ICONS.camera}</span>
                 <span class="vnccs-i3s__camera-item-name"></span>
+                <button class="vnccs-i3s__camera-preview" type="button"
+                    title="${camera.camera_id === this.previewCameraId ? "Exit camera view" : "Enter camera view"}"
+                    aria-label="${camera.camera_id === this.previewCameraId ? "Exit camera view" : "Enter camera view"}">${ICONS.eye}</button>
                 <button class="vnccs-i3s__camera-delete" type="button"
                     title="Delete camera" aria-label="Delete camera">${ICONS.trash}</button>
             `;
@@ -1354,7 +5062,7 @@ class Factory3DWidget {
                 `Delete ${camera.name}`,
             );
             this._listen(card, "click", event => {
-                if (event.target.closest(".vnccs-i3s__camera-delete")) return;
+                if (event.target.closest(".vnccs-i3s__camera-delete, .vnccs-i3s__camera-preview")) return;
                 this._selectCamera(camera.camera_id);
             });
             this._listen(card, "keydown", event => {
@@ -1366,6 +5074,12 @@ class Factory3DWidget {
                 event.stopPropagation();
                 void this._deleteCamera(camera.camera_id);
             });
+            this._listen(card.querySelector(".vnccs-i3s__camera-preview"), "click", event => {
+                event.stopPropagation();
+                this._selectCamera(camera.camera_id);
+                if (this.previewCameraId === camera.camera_id) this._exitCameraView({ restore: true });
+                else this._enterCameraView(camera.camera_id);
+            });
             fragment.appendChild(card);
         }
         this.els.cameraList.appendChild(fragment);
@@ -1373,7 +5087,35 @@ class Factory3DWidget {
 
     _normalizeLighting(value = {}) {
         const data = { ...DEFAULT_LIGHTING, ...safeObject(value) };
+        const shadowSource = { ...DEFAULT_LIGHTING.shadows, ...safeObject(data.shadows) };
         const validColor = color => /^#[0-9a-f]{6}$/i.test(String(color || ""));
+        const lights = (Array.isArray(data.lights) ? data.lights : []).slice(0, 32).map((raw, index) => {
+            const light = safeObject(raw);
+            const vector = (key, fallback) => Array.isArray(light[key]) && light[key].length === 3
+                ? light[key].map((component, axis) => {
+                    const number = Number(component);
+                    return Number.isFinite(number) ? clamp(number, -10000, 10000) : fallback[axis];
+                })
+                : [...fallback];
+            return {
+                light_id: /^[a-f0-9]{32}$/.test(String(light.light_id || ""))
+                    ? String(light.light_id)
+                    : factoryId(),
+                name: String(light.name || `Light ${index + 1}`).slice(0, 80),
+                level_id: String(light.level_id || this.editorView.active_level_id || ""),
+                building_id: this._validBuildingId(light.building_id),
+                kind: ["point", "spot", "directional"].includes(light.kind) ? light.kind : "point",
+                color: validColor(light.color) ? String(light.color).toLowerCase() : "#ffffff",
+                intensity: clamp(light.intensity, 0, 100000),
+                position: vector("position", [0, 2.4, 0]),
+                target: vector("target", [0, 0, 0]),
+                distance: clamp(light.distance, 0, 1000000),
+                angle: clamp(light.angle, 1, 179),
+                penumbra: clamp(light.penumbra, 0, 1),
+                cast_shadow: light.cast_shadow !== false,
+                visible: light.visible !== false,
+            };
+        });
         return {
             preset: Object.hasOwn(LIGHTING_PRESETS, data.preset) || data.preset === "custom"
                 ? data.preset
@@ -1386,6 +5128,15 @@ class Factory3DWidget {
             background: validColor(data.background)
                 ? String(data.background).toLowerCase()
                 : DEFAULT_LIGHTING.background,
+            shadows: {
+                enabled: shadowSource.enabled !== false,
+                quality: ["off", "low", "medium", "high", "ultra"].includes(shadowSource.quality)
+                    ? shadowSource.quality
+                    : "medium",
+                bias: clamp(shadowSource.bias, -0.05, 0.05),
+                normal_bias: clamp(shadowSource.normal_bias, 0, 1),
+            },
+            lights,
         };
     }
 
@@ -1501,6 +5252,9 @@ class Factory3DWidget {
                 method: "POST",
                 body,
             });
+            // Asset replacement is a persistence boundary: older snapshots
+            // can reference a background file that no longer exists.
+            this.history.clear();
             this.selectedSkydome = true;
             await this._applyScene(scene, { preserveSource: true });
             this._selectSkydome();
@@ -1553,6 +5307,7 @@ class Factory3DWidget {
             const scene = await this._fetchJSON(ENDPOINTS.skydome(this.sceneId), {
                 method: "DELETE",
             });
+            this.history.clear();
             this.closeModal();
             this.selectedSkydome = false;
             await this._applyScene(scene, { preserveSource: true });
@@ -1598,7 +5353,125 @@ class Factory3DWidget {
                 String(presetButton.dataset.preset === this.lighting.preset),
             );
         }
+        this.els.shadowEnabled.setAttribute(
+            "aria-checked",
+            String(this.lighting.shadows.enabled),
+        );
+        this.els.shadowQuality.value = this.lighting.shadows.quality === "off"
+            ? "medium"
+            : this.lighting.shadows.quality;
+        this._renderLocalLights();
         this._drawLightingRadar();
+    }
+
+    _renderLocalLights() {
+        if (!this.els?.localLights) return;
+        this.els.localLights.replaceChildren();
+        if (!this.lighting.lights.length) {
+            this.els.localLights.appendChild(element("div", "vnccs-i3s__local-light-empty", "No local lights."));
+            return;
+        }
+        for (const light of this.lighting.lights) {
+            const card = element("details", "vnccs-i3s__local-light");
+            card.open = light.light_id === this._expandedLightId;
+            card.innerHTML = `
+                <summary><span>${escapeHTML(light.name)}</span><small>${escapeHTML(light.kind)} · ${Number(light.intensity).toFixed(2)}</small></summary>
+                <div class="vnccs-i3s__local-light-body">
+                <div class="vnccs-i3s__local-light-title">
+                    <input class="vnccs-i3s__input" data-light-path="name" value="${escapeHTML(light.name)}" maxlength="80" aria-label="Light name" />
+                    <button type="button" data-light-delete title="Delete light">${ICONS.trash}</button>
+                </div>
+                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Floor level</span><select class="vnccs-i3s__select" data-light-path="level_id">
+                    ${(this.scene?.levels || []).map(level => `<option value="${level.level_id}"${light.level_id === level.level_id ? " selected" : ""}>${escapeHTML(level.name)}</option>`).join("")}
+                </select></label>
+                <label class="vnccs-i3s__field"><span class="vnccs-i3s__label">Building</span><select class="vnccs-i3s__select" data-light-path="building_id">
+                    ${this._buildingOptions(light.building_id)}
+                </select></label>
+                <div class="vnccs-i3s__local-light-grid">
+                    <select class="vnccs-i3s__select" data-light-path="kind"><option value="point"${light.kind === "point" ? " selected" : ""}>Point</option><option value="spot"${light.kind === "spot" ? " selected" : ""}>Spot</option><option value="directional"${light.kind === "directional" ? " selected" : ""}>Directional</option></select>
+                    <input type="color" data-light-path="color" value="${light.color}" aria-label="Light color" />
+                    <input class="vnccs-i3s__input" type="number" min="0" max="100000" step="0.01" data-light-path="intensity" value="${light.intensity}" aria-label="Light intensity" />
+                    <input class="vnccs-i3s__input" type="number" min="0" max="1000000" step="0.01" data-light-path="distance" value="${light.distance}" aria-label="Light range" />
+                </div>
+                <div class="vnccs-i3s__local-light-position">
+                    ${["X", "Y", "Z"].map((axis, index) => `<label>${axis}<input class="vnccs-i3s__input" type="number" step="0.01" data-light-path="position.${index}" value="${light.position[index]}" /></label>`).join("")}
+                </div>
+                ${light.kind !== "point" ? `
+                    <div class="vnccs-i3s__local-light-position">
+                        ${["TX", "TY", "TZ"].map((axis, index) => `<label>${axis}<input class="vnccs-i3s__input" type="number" step="0.01" data-light-path="target.${index}" value="${light.target[index]}" /></label>`).join("")}
+                    </div>` : ""}
+                ${light.kind === "spot" ? `
+                    <div class="vnccs-i3s__local-light-grid">
+                        <label><span>Angle</span><input class="vnccs-i3s__input" type="number" min="1" max="179" step="0.01" data-light-path="angle" value="${light.angle}" /></label>
+                        <label><span>Penumbra</span><input class="vnccs-i3s__input" type="number" min="0" max="1" step="0.01" data-light-path="penumbra" value="${light.penumbra}" /></label>
+                    </div>` : ""}
+                <div class="vnccs-i3s__local-light-flags">
+                    <label><input type="checkbox" data-light-path="visible"${light.visible !== false ? " checked" : ""} /> Visible</label>
+                    <label><input type="checkbox" data-light-path="cast_shadow"${light.cast_shadow !== false ? " checked" : ""} /> Cast shadow</label>
+                </div></div>`;
+            card.addEventListener("toggle", () => {
+                if (card.open) this._expandedLightId = light.light_id;
+                else if (this._expandedLightId === light.light_id) this._expandedLightId = "";
+            });
+            let before = null;
+            const begin = () => { before ||= this._captureEditorSnapshot(); };
+            for (const control of card.querySelectorAll("[data-light-path]")) {
+                control.addEventListener("pointerdown", begin);
+                control.addEventListener("focus", begin);
+                const apply = () => {
+                    const targetLight = this.lighting.lights.find(
+                        value => value.light_id === light.light_id,
+                    );
+                    if (!targetLight) return;
+                    const [key, rawIndex] = control.dataset.lightPath.split(".");
+                    const value = control.type === "checkbox"
+                        ? control.checked
+                        : control.type === "number"
+                            ? Number(control.value)
+                            : control.value;
+                    if (rawIndex !== undefined) targetLight[key][Number(rawIndex)] = value;
+                    else if (key === "level_id") {
+                        const previousLevel = this.scene?.levels?.find(
+                            level => level.level_id === targetLight.level_id,
+                        );
+                        const nextLevel = this.scene?.levels?.find(
+                            level => level.level_id === value,
+                        );
+                        const delta = (Number(nextLevel?.elevation) || 0)
+                            - (Number(previousLevel?.elevation) || 0);
+                        targetLight.position[1] += delta;
+                        targetLight.target[1] += delta;
+                        targetLight.level_id = value;
+                    } else if (key === "building_id") {
+                        targetLight.building_id = this._validBuildingId(value);
+                        this.editorView.active_building_id = targetLight.building_id;
+                    } else targetLight[key] = value;
+                    if (["name", "kind", "intensity"].includes(key)) {
+                        card.querySelector("summary span").textContent = targetLight.name;
+                        card.querySelector("summary small").textContent = `${targetLight.kind} · ${Number(targetLight.intensity).toFixed(2)}`;
+                    }
+                    this._commitLighting();
+                };
+                control.addEventListener("input", apply);
+                control.addEventListener("change", () => {
+                    apply();
+                    if (before) this.history.push("Edit light", before, this._captureEditorSnapshot());
+                    before = null;
+                    this._commitLighting({ final: true });
+                    this._syncToolbar();
+                    if (["kind", "level_id", "building_id"].includes(control.dataset.lightPath)) this._renderLocalLights();
+                });
+            }
+            card.querySelector("[data-light-delete]").addEventListener("click", () => {
+                const original = this._captureEditorSnapshot();
+                this.lighting.lights = this.lighting.lights.filter(value => value.light_id !== light.light_id);
+                if (original) this.history.push("Delete light", original, this._captureEditorSnapshot());
+                this._syncLighting();
+                this._commitLighting({ final: true });
+                this._syncToolbar();
+            });
+            this.els.localLights.appendChild(card);
+        }
     }
 
     _commitLighting({ final = false } = {}) {
@@ -1625,6 +5498,17 @@ class Factory3DWidget {
         }
     }
 
+    _beginLightingHistory() {
+        this._lightingHistoryBefore ||= this._captureEditorSnapshot();
+    }
+
+    _finishLightingHistory(label) {
+        if (!this._lightingHistoryBefore) return;
+        this.history.push(label, this._lightingHistoryBefore, this._captureEditorSnapshot());
+        this._lightingHistoryBefore = null;
+        this._syncToolbar();
+    }
+
     _bindLightingRadar() {
         const canvas = this.els.lightRadar;
         if (!canvas) return;
@@ -1648,6 +5532,7 @@ class Factory3DWidget {
             if (event.button !== 0) return;
             event.preventDefault();
             event.stopPropagation();
+            this._beginLightingHistory();
             dragging = true;
             canvas.setPointerCapture?.(event.pointerId);
             update(event);
@@ -1662,6 +5547,7 @@ class Factory3DWidget {
                 canvas.releasePointerCapture(event.pointerId);
             }
             this._commitLighting({ final: true });
+            this._finishLightingHistory("Edit light direction");
         };
         this._listen(canvas, "pointerup", finish);
         this._listen(canvas, "pointercancel", finish);
@@ -1815,7 +5701,10 @@ class Factory3DWidget {
             });
             if (this.sourceFile === file) {
                 this.sourceAsset = { ...asset, scene_id: this.sceneId };
-                if (this.scene) this.scene.reference = { ...asset };
+                if (this.scene) {
+                    this.scene.reference = { ...asset };
+                    this.scene.edit_revision = asset.edit_revision ?? this.scene.edit_revision;
+                }
                 this._showSource({
                     url: apiUrl(asset.preview_url || asset.url),
                     name: asset.name || file.name,
@@ -1918,21 +5807,62 @@ class Factory3DWidget {
     }
 
     async _applyScene(scene, { preserveSource = false } = {}) {
+        const reopeningCurrentScene = Boolean(
+            this.sceneId && this.sceneId === scene?.scene_id,
+        );
         const incremental = Boolean(
             this.scene
             && this.sceneId
             && this.sceneId === scene?.scene_id,
         );
+        if (!incremental) this.history.clear();
         const desiredGroupId = this.selectedGroupId;
         const desiredObjectIds = new Set(this.selectedObjectIds);
-        const desiredSkydome = incremental && this.selectedSkydome;
-        const desiredCameraId = incremental ? this.selectedCameraId : "";
+        const desiredSkydome = reopeningCurrentScene && this.selectedSkydome;
+        const desiredCameraId = this.selectedCameraId;
+        const desiredArchitecture = this.selectedArchitecture?.id
+            ? { ...this.selectedArchitecture }
+            : null;
+        const desiredKeyframeId = this.selectedCameraKeyframeId;
+        this.selectedGroupId = "";
         this.selectedCameraId = "";
+        this.selectedCameraKeyframeId = "";
+        this.previewCameraId = "";
         this._cameraReturnState = null;
         if (this.selectedObjectId) desiredObjectIds.add(this.selectedObjectId);
         this.scene = scene;
         this.sceneId = scene.scene_id;
+        this.scene.edit_revision = Math.max(0, Number(scene.edit_revision) || 0);
+        this.scene.levels = normalizedLevels(scene.levels);
+        this.scene.architecture = normalizedArchitecture(scene.architecture, this.scene.levels);
+        this.scene.objects = (Array.isArray(scene.objects) ? scene.objects : []).map(item => ({
+            ...item,
+            level_id: this.scene.levels.some(level => level.level_id === item.level_id)
+                ? item.level_id
+                : this.scene.levels[0]?.level_id || "",
+            ...normalizedObjectEditorProperties(item),
+            building_id: this._validBuildingId(item.building_id),
+        }));
+        this.scene.camera_tracks = Array.isArray(scene.camera_tracks)
+            ? JSON.parse(JSON.stringify(scene.camera_tracks)).map(track => ({
+                ...track,
+                building_id: this._validBuildingId(track.building_id),
+            }))
+            : [];
+        this.editorView = normalizedEditorView(
+            this.editorView,
+            this.scene.levels[0]?.level_id,
+        );
+        if (!this.scene.levels.some(level => level.level_id === this.editorView.active_level_id)) {
+            this.editorView.active_level_id = this.scene.levels[0]?.level_id || "";
+        }
+        this.selectedArchitecture = null;
         this.scene.cameras = this._normalizeSceneCameras(scene.cameras);
+        for (const camera of this.scene.cameras) {
+            if (!this.scene.levels.some(level => level.level_id === camera.level_id)) {
+                camera.level_id = this.scene.levels[0]?.level_id || "";
+            }
+        }
         if (this.scene.skydome) {
             this.scene.skydome = this._normalizeSkydome(this.scene.skydome);
         }
@@ -1979,6 +5909,9 @@ class Factory3DWidget {
                 || { loaded: 0, failures: [] };
             this.viewerState = desiredViewerState;
             this.viewer.setState(desiredViewerState);
+            this.viewer.setViewMode(this.editorView.view_mode);
+            this.viewer.setPlanTool(this.editorView.plan_tool);
+            this.viewer.setActiveLevel(this.editorView.active_level_id);
             this.viewerState = { ...this.viewerState, ...this.viewer.getState() };
         } finally {
             this._suppressViewerStatePersistence = false;
@@ -1990,6 +5923,20 @@ class Factory3DWidget {
             viewportFailures.map(item => [item.objectId, errorText(item.error)]),
         );
         const desiredGroup = this._groupById(desiredGroupId);
+        const normalizedDesiredArchitecture = this._normalizeArchitectureSelection(desiredArchitecture);
+        const desiredArchitectureValid = Boolean(normalizedDesiredArchitecture && (
+            (normalizedDesiredArchitecture.type === "building" && this.scene.architecture.buildings.some(item => item.building_id === normalizedDesiredArchitecture.id))
+            || (normalizedDesiredArchitecture.type === "level" && this.scene.levels.some(item => item.level_id === normalizedDesiredArchitecture.id))
+            || (normalizedDesiredArchitecture.type === "wall" && this.scene.architecture.walls.some(item => item.wall_id === normalizedDesiredArchitecture.id))
+            || (normalizedDesiredArchitecture.type === "room" && this.scene.architecture.rooms.some(item => item.room_id === normalizedDesiredArchitecture.id))
+            || (normalizedDesiredArchitecture.type === "opening" && this.scene.architecture.openings.some(item => item.opening_id === normalizedDesiredArchitecture.id))
+        ));
+        const desiredCameraValid = this.scene.cameras.some(
+            camera => camera.camera_id === desiredCameraId,
+        );
+        const desiredKeyframeTrack = this.scene.camera_tracks.find(
+            track => track.keyframes?.some(frame => frame.keyframe_id === desiredKeyframeId),
+        );
         if (desiredSkydome && scene.skydome) {
             this._selectSkydome();
         } else if (desiredGroup) {
@@ -1998,6 +5945,24 @@ class Factory3DWidget {
             this.selectedObjectIds.clear();
             this.selectedObjectId = "";
             this.viewer.selectGroup(desiredGroup.group_id, desiredGroup.children);
+        } else if (desiredArchitectureValid) {
+            this.selectedSkydome = false;
+            this.selectedGroupId = "";
+            this.selectedObjectIds.clear();
+            this.selectedObjectId = "";
+            this.selectedArchitecture = normalizedDesiredArchitecture;
+            this.viewer.select("");
+            this.viewer.setArchitectureSelection(normalizedDesiredArchitecture);
+        } else if (desiredCameraValid) {
+            this._selectCamera(desiredCameraId);
+        } else if (desiredKeyframeTrack) {
+            this.selectedSkydome = false;
+            this.selectedGroupId = "";
+            this.selectedObjectIds.clear();
+            this.selectedObjectId = "";
+            this.activeCameraTrackId = desiredKeyframeTrack.track_id;
+            this.selectedCameraKeyframeId = desiredKeyframeId;
+            this.viewer.select("");
         } else {
             this.selectedSkydome = false;
             this.selectedGroupId = "";
@@ -2019,11 +5984,13 @@ class Factory3DWidget {
                 additive: this.selectedObjectIds.size > 1,
             });
         }
-        if (this.scene.cameras.some(camera => camera.camera_id === desiredCameraId)) {
-            this._selectCamera(desiredCameraId);
-        }
+        const selectionBuilding = this._activeBuilding();
+        if (selectionBuilding) this.editorView.active_building_id = selectionBuilding.building_id;
         this._renderObjects();
         this._renderCameras();
+        this._renderCameraTracks();
+        this._renderInspector();
+        this._syncToolbar();
         this._scheduleStateSave();
         this.syncToNode();
         const loaded = Number(viewportResult.loaded) || 0;
@@ -2213,11 +6180,16 @@ class Factory3DWidget {
 
     _updateSceneSummary() {
         const objects = this.scene?.objects || [];
+        const rooms = this.scene?.architecture?.rooms || [];
+        const roomWallIds = new Set(rooms.flatMap(room => room.wall_ids || []));
+        const wallCount = (this.scene?.architecture?.walls || []).filter(
+            wall => !roomWallIds.has(wall.wall_id),
+        ).length;
+        const roomCount = rooms.length;
         const skydome = this.scene?.skydome || null;
         const cameraCount = this.scene?.cameras?.length || 0;
         const visibleIds = this._effectiveVisibleObjectIds();
-        this.container.classList.toggle("has-scene", Boolean(objects.length || skydome));
-        this.els.objectCount.textContent = String(objects.length + (skydome ? 1 : 0));
+        this.els.objectCount.textContent = String(objects.length + (skydome ? 1 : 0) + wallCount + roomCount);
         const gaussianSummary = objects.length
             ? `${visibleIds.size}/${objects.length} models visible · ${objects.reduce(
                 (sum, item) => sum + (visibleIds.has(item.object_id) ? Number(item.gaussians) || 0 : 0),
@@ -2229,22 +6201,24 @@ class Factory3DWidget {
             : objects.length
                 ? gaussianSummary
                 : "No objects in this scene.";
-        this.els.sceneSummary.textContent = cameraCount
-            ? `${contentSummary} · ${cameraCount} camera${cameraCount === 1 ? "" : "s"}`
+        const architectureSummary = wallCount || roomCount
+            ? `${contentSummary} · ${wallCount} standalone walls · ${roomCount} rooms`
             : contentSummary;
+        this.els.sceneSummary.textContent = cameraCount
+            ? `${architectureSummary} · ${cameraCount} camera${cameraCount === 1 ? "" : "s"}`
+            : architectureSummary;
     }
 
     _hasRenderableScene() {
         return Boolean(
             this.scene?.objects?.length
+            || this.scene?.architecture?.walls?.length
+            || this.scene?.architecture?.rooms?.length
             || (this.scene?.skydome && this.scene.skydome.visible !== false),
         );
     }
 
     _selectSkydome() {
-        if (this.selectedCameraId && !this._cameraSelectionTransition) {
-            this._exitCameraView({ restore: true });
-        }
         if (!this.scene?.skydome) {
             this.selectedSkydome = false;
             return;
@@ -2252,21 +6226,50 @@ class Factory3DWidget {
         this.selectedGroupId = "";
         this.selectedObjectIds.clear();
         this.selectedObjectId = "";
+        this.selectedArchitecture = null;
+        this.selectedCameraKeyframeId = "";
+        this.selectedCameraId = "";
+        this.viewer.setArchitectureSelection(null);
         this.viewer.select("");
         this.selectedSkydome = true;
         this._syncSelectionPresentation();
+        this._renderInspector();
+        this._syncToolbar();
         this._scheduleStateSave();
     }
 
+    _clearSelection() {
+        this.selectedObjectId = "";
+        this.selectedObjectIds.clear();
+        this.selectedGroupId = "";
+        this.selectedSkydome = false;
+        this.selectedArchitecture = null;
+        this.selectedCameraId = "";
+        this.selectedCameraKeyframeId = "";
+        this.viewer.setArchitectureSelection(null);
+        this.viewer.select("");
+        this._syncSelectionPresentation();
+        this._renderCameras();
+        this._renderCameraTracks();
+        this._renderInspector();
+        this._syncToolbar();
+        this._scheduleStateSave(0);
+    }
+
     _selectObject(objectId, { fromViewer = false, additive = false } = {}) {
-        if (this.selectedCameraId && !this._cameraSelectionTransition) {
-            this._exitCameraView({ restore: true });
-        }
         const valid = this.scene?.objects?.some(item => item.object_id === objectId)
             ? objectId
             : "";
+        if (fromViewer && !valid && !additive) return;
         this.selectedSkydome = false;
+        const selectedItem = this.scene?.objects?.find(item => item.object_id === valid);
+        const selectedBuildingId = this._validBuildingId(selectedItem?.building_id);
+        if (selectedBuildingId) this.editorView.active_building_id = selectedBuildingId;
         this.selectedGroupId = "";
+        this.selectedArchitecture = null;
+        this.selectedCameraKeyframeId = "";
+        this.selectedCameraId = "";
+        this.viewer.setArchitectureSelection(null);
         if (!additive) {
             this.selectedObjectIds = new Set(valid ? [valid] : []);
         } else if (valid) {
@@ -2278,21 +6281,32 @@ class Factory3DWidget {
             : Array.from(this.selectedObjectIds).at(-1) || "";
         if (!fromViewer) this.viewer.select(this.selectedObjectId, { additive });
         this._syncSelectionPresentation();
+        this._renderInspector();
+        this._syncToolbar();
+        if (valid && fromViewer && !additive) this._setWorkspaceTab("right", "inspector");
         this._scheduleStateSave();
     }
 
     _selectGroup(groupId) {
-        if (this.selectedCameraId && !this._cameraSelectionTransition) {
-            this._exitCameraView({ restore: true });
-        }
         const group = this._groupById(groupId);
         this.selectedSkydome = false;
+        this.selectedArchitecture = null;
+        this.selectedCameraKeyframeId = "";
+        this.selectedCameraId = "";
+        this.viewer.setArchitectureSelection(null);
         this.selectedGroupId = group?.group_id || "";
+        const firstObject = group?.children?.length
+            ? this.scene?.objects?.find(item => item.object_id === group.children[0])
+            : null;
+        const selectedBuildingId = this._validBuildingId(firstObject?.building_id);
+        if (selectedBuildingId) this.editorView.active_building_id = selectedBuildingId;
         this.selectedObjectIds.clear();
         this.selectedObjectId = "";
         if (group) this.viewer.selectGroup(group.group_id, group.children);
         else this.viewer.select("");
         this._syncSelectionPresentation();
+        this._renderInspector();
+        this._syncToolbar();
         this._scheduleStateSave();
     }
 
@@ -2333,6 +6347,8 @@ class Factory3DWidget {
     }
 
     _renderObjects() {
+        const previousScrollTop = this.els.objectList.scrollTop;
+        const previousScrollLeft = this.els.objectList.scrollLeft;
         const query = this.els.objectSearch.value.trim().toLowerCase();
         const objects = new Map((this.scene?.objects || []).map(item => [item.object_id, item]));
         const skydome = this.scene?.skydome || null;
@@ -2341,11 +6357,28 @@ class Factory3DWidget {
         const fragment = document.createDocumentFragment();
         this._syncSelectionControls();
         let rendered = 0;
+        if (this.scene && !this.scene.architecture?.buildings?.length && !query) {
+            const emptyArchitecture = element("section", "vnccs-i3s__architecture-empty");
+            const copy = element("div", "vnccs-i3s__architecture-empty-copy");
+            copy.append(
+                element("b", "", "No buildings"),
+                element("small", "", "Create one only when you need walls, rooms, or openings."),
+            );
+            const create = button("vnccs-i3s__button vnccs-i3s__button--quiet", "Create building", "plus");
+            create.addEventListener("click", () => this._addBuilding());
+            emptyArchitecture.append(copy, create);
+            fragment.appendChild(emptyArchitecture);
+            rendered += 1;
+        }
+        for (const entry of this._createArchitectureTree(query)) {
+            fragment.appendChild(entry);
+            rendered += 1;
+        }
         if (skydome && (!query || skydome.name.toLowerCase().includes(query) || "skydome background environment".includes(query))) {
             fragment.appendChild(this._createSkydomeCard(skydome));
             rendered += 1;
         }
-        if (!objects.size && !skydome) {
+        if (!objects.size && !skydome && !rendered) {
             fragment.appendChild(element("div", "vnccs-i3s__tree-empty", query ? "No matching objects." : "Generated objects will appear here."));
             this.els.objectList.appendChild(fragment);
             return;
@@ -2387,6 +6420,85 @@ class Factory3DWidget {
             fragment.appendChild(element("div", "vnccs-i3s__tree-empty", "No matching objects."));
         }
         this.els.objectList.appendChild(fragment);
+        this.els.objectList.scrollTop = previousScrollTop;
+        this.els.objectList.scrollLeft = previousScrollLeft;
+    }
+
+    _createArchitectureTree(query = "") {
+        const architecture = this.scene?.architecture;
+        if (!architecture) return [];
+        const output = [];
+        const activeLevelId = this.editorView.active_level_id;
+        const openingsByWall = new Map();
+        for (const opening of architecture.openings || []) {
+            if (!openingsByWall.has(opening.wall_id)) openingsByWall.set(opening.wall_id, []);
+            openingsByWall.get(opening.wall_id).push(opening);
+        }
+        const createRow = (type, id, name, meta) => {
+            const row = element(
+                "button",
+                `vnccs-i3s__architecture-row${
+                    this.selectedArchitecture?.type === type && this.selectedArchitecture?.id === id
+                        ? " is-selected"
+                        : ""
+                }`,
+            );
+            row.type = "button";
+            row.dataset.architectureType = type;
+            row.dataset.architectureId = id;
+            row.innerHTML = `<span class="vnccs-i3s__architecture-kind">${escapeHTML(type.slice(0, 1).toUpperCase())}</span><span class="vnccs-i3s__architecture-copy"><b></b><small></small></span>`;
+            row.querySelector("b").textContent = name;
+            row.querySelector("small").textContent = meta;
+            row.addEventListener("click", () => this._selectArchitecture({ type, id }));
+            return row;
+        };
+        for (const building of architecture.buildings || []) {
+            const walls = (architecture.walls || []).filter(
+                item => item.building_id === building.building_id && item.level_id === activeLevelId,
+            );
+            const rooms = (architecture.rooms || []).filter(
+                item => item.building_id === building.building_id && item.level_id === activeLevelId,
+            );
+            const roomWallIds = new Set(rooms.flatMap(room => room.wall_ids || []));
+            const standaloneWalls = walls.filter(wall => !roomWallIds.has(wall.wall_id));
+            const openings = walls.flatMap(wall => openingsByWall.get(wall.wall_id) || []);
+            const assignedObjects = (this.scene?.objects || []).filter(
+                item => item.building_id === building.building_id,
+            ).length;
+            const assignedCameras = (this.scene?.cameras || []).filter(
+                item => item.building_id === building.building_id,
+            ).length;
+            const assignedLights = (this.lighting?.lights || []).filter(
+                item => item.building_id === building.building_id,
+            ).length;
+            const assignedPaths = (this.scene?.camera_tracks || []).filter(
+                item => item.building_id === building.building_id,
+            ).length;
+            const entries = [
+                ...rooms.map(item => ({ type: "room", id: item.room_id, name: item.name || "Room", meta: `Complete room · walls, floor and ceiling${item.locked ? " · Locked" : ""}${item.visible === false ? " · Hidden" : ""}` })),
+                ...standaloneWalls.map(item => ({ type: "wall", id: item.wall_id, name: item.name || "Wall", meta: `${Math.hypot(item.end[0] - item.start[0], item.end[1] - item.start[1]).toFixed(2)} m${item.locked ? " · Locked" : ""}${item.visible === false ? " · Hidden" : ""}` })),
+                ...openings.map(item => ({ type: "opening", id: item.opening_id, name: item.name || "Opening", meta: `${item.kind} · ${Number(item.width).toFixed(2)} m${item.locked ? " · Locked" : ""}${item.visible === false ? " · Hidden" : ""}` })),
+            ].filter(item => !query || `${item.name} ${item.type} ${item.meta}`.toLowerCase().includes(query));
+            if (query && !building.name.toLowerCase().includes(query) && !entries.length) continue;
+            const wrapper = element("section", "vnccs-i3s__architecture-group");
+            const heading = createRow(
+                "building",
+                building.building_id,
+                building.name || "Building",
+                `${standaloneWalls.length} standalone walls · ${rooms.length} rooms · ${assignedObjects} objects · ${assignedCameras} cameras · ${assignedPaths} paths · ${assignedLights} lights${building.locked ? " · Locked" : ""}${building.visible === false ? " · Hidden" : ""}`,
+            );
+            heading.classList.add("is-building");
+            const children = element("div", "vnccs-i3s__architecture-children");
+            for (const entry of entries) {
+                children.appendChild(createRow(entry.type, entry.id, entry.name, entry.meta));
+            }
+            if (!entries.length && !query) {
+                children.appendChild(element("div", "vnccs-i3s__group-empty", "Draw walls or a room in Plan view"));
+            }
+            wrapper.append(heading, children);
+            output.push(wrapper);
+        }
+        return output;
     }
 
     _createSkydomeCard(skydome) {
@@ -2413,10 +6525,13 @@ class Factory3DWidget {
         const beginRename = event => {
             event.stopPropagation();
             this._beginInlineRename(name, skydome.name || "Skydome", next => {
+                const before = this._captureEditorSnapshot();
                 skydome.name = next;
                 this._syncSkydome();
                 this._renderObjects();
                 this._commitSkydome({ final: true });
+                this.history.push("Rename skydome", before, this._captureEditorSnapshot());
+                this._syncToolbar();
             });
         };
         name.addEventListener("dblclick", beginRename);
@@ -2443,11 +6558,14 @@ class Factory3DWidget {
         visibility.title = skydome.visible === false ? "Show skydome" : "Hide skydome";
         visibility.addEventListener("click", event => {
             event.stopPropagation();
+            const before = this._captureEditorSnapshot();
             skydome.visible = skydome.visible === false;
             this._syncSkydome();
             this._commitSkydome({ final: true });
             this._updateSceneSummary();
             this._renderObjects();
+            this.history.push("Toggle skydome visibility", before, this._captureEditorSnapshot());
+            this._syncToolbar();
         });
         const save = button(
             "vnccs-i3s__button vnccs-i3s__button--quiet vnccs-i3s__icon-button",
@@ -2522,8 +6640,10 @@ class Factory3DWidget {
         const beginRename = event => {
             event.stopPropagation();
             this._beginInlineRename(name, item.name, next => {
+                const before = this._captureEditorSnapshot();
                 item.name = next;
                 this.viewer.updateObject(item.object_id, { name: next });
+                this.history.push("Rename object", before, this._captureEditorSnapshot());
                 this._renderObjects();
                 this._scheduleSceneSave(0);
                 this._scheduleStateSave(0);
@@ -2542,6 +6662,10 @@ class Factory3DWidget {
         );
         const importedPly = item.source?.type === "ply_import"
             || item.settings?.source === "ply_import";
+        const levelName = this.scene?.levels?.find(level => level.level_id === item.level_id)?.name || "";
+        const buildingName = this.scene?.architecture?.buildings?.find(
+            building => building.building_id === item.building_id,
+        )?.name || "";
         copy.append(
             name,
             element(
@@ -2551,6 +6675,9 @@ class Factory3DWidget {
                     viewportFailure ? "Viewport failed" : "",
                     `${Number(item.gaussians || 0).toLocaleString()} splats`,
                     importedPly ? "Imported PLY" : "",
+                    buildingName,
+                    levelName,
+                    item.locked ? "Locked" : "",
                     conditioning ? `${conditioning}² input` : "",
                     !importedPly && item.seed !== undefined ? `seed ${item.seed}` : "",
                 ].filter(Boolean).join(" · "),
@@ -2565,8 +6692,10 @@ class Factory3DWidget {
         visibility.title = item.visible === false ? "Show object" : "Hide object";
         visibility.addEventListener("click", event => {
             event.stopPropagation();
+            const before = this._captureEditorSnapshot();
             item.visible = item.visible === false;
             this.viewer.applySceneVisibility(this.scene);
+            this.history.push("Toggle object visibility", before, this._captureEditorSnapshot());
             this._updateSceneSummary();
             this._renderObjects();
             this._scheduleSceneSave(0);
@@ -2653,7 +6782,9 @@ class Factory3DWidget {
         const beginRename = event => {
             event.stopPropagation();
             this._beginInlineRename(name, group.name, next => {
+                const before = this._captureEditorSnapshot();
                 group.name = next;
+                this.history.push("Rename group", before, this._captureEditorSnapshot());
                 this._renderObjects();
                 this._scheduleSceneSave(0);
                 this._scheduleStateSave(0);
@@ -2683,6 +6814,7 @@ class Factory3DWidget {
         visibility.title = group.visible === false ? "Show group" : "Hide group";
         visibility.addEventListener("click", event => {
             event.stopPropagation();
+            const before = this._captureEditorSnapshot();
             const nextVisible = group.visible === false;
             group.visible = nextVisible;
             this.viewer.setGroupVisibility(
@@ -2691,6 +6823,7 @@ class Factory3DWidget {
                 nextVisible,
                 this.scene,
             );
+            this.history.push("Toggle group visibility", before, this._captureEditorSnapshot());
             this._updateSceneSummary();
             this._renderObjects();
             this._scheduleSceneSave(0);
@@ -2859,6 +6992,7 @@ class Factory3DWidget {
 
     _moveLayer(source, target, placement) {
         if (!source || (target && source.type === target.type && source.id === target.id)) return;
+        const before = this._captureEditorSnapshot();
         const visibleBefore = this._effectiveVisibleObjectIds();
         const layers = this._normalizeSceneLayers();
         const node = this._removeLayerSource(source, layers);
@@ -2905,6 +7039,7 @@ class Factory3DWidget {
         }
         this.dragLayer = null;
         this._normalizeSceneLayers();
+        this.history.push("Reorder scene hierarchy", before, this._captureEditorSnapshot());
         const visibleAfter = this._effectiveVisibleObjectIds();
         const visibilityChanged = (
             visibleBefore.size !== visibleAfter.size
@@ -2922,6 +7057,16 @@ class Factory3DWidget {
 
     async groupSelectedObjects() {
         if (this.selectedObjectIds.size < 2 || !this.scene) return;
+        const selectedBuildings = new Set(
+            this.scene.objects
+                .filter(item => this.selectedObjectIds.has(item.object_id))
+                .map(item => this._validBuildingId(item.building_id)),
+        );
+        if (selectedBuildings.size > 1) {
+            this.toast("Assign selected objects to one building before grouping them.", "info");
+            return;
+        }
+        const before = this._captureEditorSnapshot();
         const visibleBefore = this._effectiveVisibleObjectIds();
         const selected = new Set(this.selectedObjectIds);
         const ordered = [];
@@ -2953,6 +7098,8 @@ class Factory3DWidget {
         this.selectedObjectId = "";
         this.selectedSkydome = false;
         this.selectedGroupId = group.group_id;
+        this.editorView.active_building_id = selectedBuildings.values().next().value
+            || this.editorView.active_building_id;
         this.collapsedGroupIds.delete(group.group_id);
         const visibleAfter = this._effectiveVisibleObjectIds();
         const visibilityChanged = (
@@ -2964,13 +7111,17 @@ class Factory3DWidget {
             this._scheduleScenePreview(120);
         }
         this.viewer.selectGroup(group.group_id, group.children);
+        this.history.push("Group objects", before, this._captureEditorSnapshot());
         this._updateSceneSummary();
         this._renderObjects();
+        this._renderInspector();
+        this._syncToolbar();
         this._scheduleSceneSave(0);
         this._scheduleStateSave(0);
     }
 
     ungroupObjects(groupId) {
+        const before = this._captureEditorSnapshot();
         const layers = this._normalizeSceneLayers();
         const index = layers.findIndex(
             layer => layer.type === "group" && layer.group_id === groupId,
@@ -2998,8 +7149,12 @@ class Factory3DWidget {
             this._scheduleScenePreview(120);
         }
         this.viewer.select(this.selectedObjectId, { additive: true });
+        this.history.push("Ungroup objects", before, this._captureEditorSnapshot());
         this._updateSceneSummary();
         this._renderObjects();
+        this._syncSelectionPresentation();
+        this._renderInspector();
+        this._syncToolbar();
         this._scheduleSceneSave(0);
         this._scheduleStateSave(0);
     }
@@ -3007,7 +7162,23 @@ class Factory3DWidget {
     _onViewerTransform(objectId, transform, options = {}) {
         const item = this.scene?.objects?.find(value => value.object_id === objectId);
         if (!item) return;
+        if (!this._suppressViewerTransformHistory && !this._viewerTransformHistoryBefore) {
+            this._viewerTransformHistoryBefore = this._captureEditorSnapshot();
+            for (const [previousId, previousTransform] of Object.entries(options.previous_transforms || {})) {
+                const previousItem = this._viewerTransformHistoryBefore?.objects?.find(value => value.object_id === previousId);
+                if (previousItem && previousTransform) previousItem.transform = previousTransform;
+            }
+        }
         item.transform = transform;
+        if (!this._suppressViewerTransformHistory && options.final && options.command_last !== false) {
+            this.history.push(
+                "Transform object",
+                this._viewerTransformHistoryBefore,
+                this._captureEditorSnapshot(),
+            );
+            this._viewerTransformHistoryBefore = null;
+            this._renderInspector();
+        }
         this._scheduleSceneSave(options.final ? 0 : 160);
         this._scheduleStateSave(options.final ? 0 : 160);
         this._scheduleScenePreview(options.final ? 120 : 420);
@@ -3018,6 +7189,7 @@ class Factory3DWidget {
             ? this.scene?.camera
             : this.viewer?.getCameraState?.() || this.viewerState.camera;
         return {
+            base_edit_revision: Math.max(0, Number(this.scene?.edit_revision) || 0),
             name: this.els.sceneName.value.trim() || this.scene?.name || "Untitled scene",
             render: { ...this.exportSettings },
             lighting: { ...this.lighting },
@@ -3039,11 +7211,19 @@ class Factory3DWidget {
                 target: [...saved.target],
                 up: [...saved.up],
             })),
+            camera_tracks: JSON.parse(JSON.stringify(this.scene?.camera_tracks || [])),
+            levels: normalizedLevels(this.scene?.levels).map(level => ({ ...level })),
+            architecture: JSON.parse(JSON.stringify(normalizedArchitecture(
+                this.scene?.architecture,
+                normalizedLevels(this.scene?.levels),
+            ))),
             objects: (this.scene?.objects || []).map(item => ({
                 object_id: item.object_id,
                 name: item.name,
+                level_id: item.level_id,
                 transform: item.transform,
                 visible: item.visible !== false,
+                ...normalizedObjectEditorProperties(item),
             })),
             layers: this._normalizeSceneLayers().map(layer => ({
                 ...layer,
@@ -3066,8 +7246,8 @@ class Factory3DWidget {
         if (!this.sceneId || !this.scene) return;
         this.scene.name = this.els.sceneName.value.trim() || this.scene.name || "Untitled scene";
         const sceneId = this.sceneId;
-        const payload = this._scenePayload();
         const operation = this._sceneSaveSerial.then(async () => {
+            const payload = this._scenePayload();
             const updated = await this._fetchJSON(ENDPOINTS.scene(sceneId), {
                 method: "PATCH",
                 headers: { "Content-Type": "application/json" },
@@ -3076,15 +7256,15 @@ class Factory3DWidget {
             if (this.sceneId === sceneId && this.scene) {
                 this.scene.revision = updated.revision;
                 this.scene.render_revision = updated.render_revision;
+                this.scene.edit_revision = updated.edit_revision;
                 this.scene.updated_at = updated.updated_at;
                 this.scene.exports = updated.exports;
-                this.scene.render = updated.render || this.scene.render;
-                this.scene.camera = updated.camera || this.scene.camera;
-                this.scene.cameras = this._normalizeSceneCameras(
-                    updated.cameras || this.scene.cameras,
-                );
-                this.scene.lighting = updated.lighting || this.scene.lighting;
-                this.scene.skydome = updated.skydome || this.scene.skydome;
+                // The PATCH payload was captured before awaiting the server.
+                // Replacing live editor collections here invalidates every
+                // Inspector closure and can also overwrite input made while
+                // the request was in flight. The client already normalizes
+                // these values when building the payload; only server-owned
+                // revision/export metadata is merged into the live scene.
             }
             this._scheduleStateSave(0);
             return updated;
@@ -3095,7 +7275,16 @@ class Factory3DWidget {
         try {
             return await operation;
         } catch (error) {
-            if (showError) this._showError("Scene save failed", error);
+            if (showError) {
+                if (error.status === 409) {
+                    this._showError(
+                        "Scene changed elsewhere",
+                        new Error("Reload the scene before saving to avoid overwriting newer edits."),
+                    );
+                } else {
+                    this._showError("Scene save failed", error);
+                }
+            }
             throw error;
         }
     }
@@ -3428,6 +7617,7 @@ class Factory3DWidget {
                                 ? generatedScene
                                 : await this._fetchJSON(ENDPOINTS.scene(generatedSceneId));
                             await this._applyScene(scene, { preserveSource: true });
+                            this._placeNewObjectOnActiveFloor(generatedObjectId);
                             this._scheduleStateSave(0);
                             this.toast("Object added to the scene.", "success");
                         } else if (job.kind === "weights") {
@@ -3541,7 +7731,7 @@ class Factory3DWidget {
                 { method: "POST" },
             );
             await this._applyScene(result.scene, { preserveSource: true });
-            this._selectObject(result.object_id);
+            this._placeNewObjectOnActiveFloor(result.object_id);
             this._setStatus("Object duplicated", "success");
             this.toast("Object duplicated.", "success");
         } catch (error) {
@@ -4339,7 +8529,8 @@ class Factory3DWidget {
                 this._selectSkydome();
                 this._setSkydomePanelOpen(true);
             } else if (result.object_id) {
-                this._selectObject(result.object_id);
+                if (result.created_scene) this._selectObject(result.object_id);
+                else this._placeNewObjectOnActiveFloor(result.object_id);
             }
             this.toast(
                 result.created_scene
@@ -5216,9 +9407,9 @@ class Factory3DWidget {
         this._syncSeedMode();
         this._syncDensityMode();
         const exportLabel = this.els.sceneExport?.querySelector("span:last-child");
-        if (exportLabel) exportLabel.textContent = "Scene PLY";
+        if (exportLabel) exportLabel.textContent = "Gaussian PLY";
         if (this.els.sceneExport) {
-            this.els.sceneExport.title = "Export visible scene as PLY";
+            this.els.sceneExport.title = "Export visible Gaussian models as PLY; architecture is stored in the scene";
         }
         this._customSelects?.refresh?.();
     }
@@ -5250,11 +9441,112 @@ class Factory3DWidget {
     }
 
     _syncToolbar() {
+        this._syncWorkspace();
         const mode = this.viewerState.mode || "translate";
         this.els.modeMove.setAttribute("aria-pressed", String(mode === "translate"));
         this.els.modeRotate.setAttribute("aria-pressed", String(mode === "rotate"));
         this.els.modeScale.setAttribute("aria-pressed", String(mode === "scale"));
         this.els.grid.setAttribute("aria-pressed", String(Boolean(this.viewerState.grid)));
+        const plan = this.editorView.view_mode === "plan";
+        this.els.viewportCamera.hidden = plan;
+        this.els.fit.disabled = plan;
+        this.els.fit.title = plan ? "Available in 3D view" : "Frame complete 3D scene";
+        this._syncViewportCameraHUD();
+        this.els.view3d.setAttribute("aria-pressed", String(!plan));
+        this.els.viewPlan.setAttribute("aria-pressed", String(plan));
+        this.els.planTools.hidden = !plan;
+        this.els.openingKindShortcut.hidden = !plan || this.editorView.plan_tool !== "opening";
+        this.els.modeMove.disabled = plan && this.editorView.plan_tool !== "select";
+        this.els.modeRotate.disabled = plan;
+        this.els.modeScale.disabled = plan;
+        const planToolTitles = {
+            select: "Select and edit architecture",
+            wall: "Press and drag to draw a wall",
+            room: "Press and drag diagonally to draw a rectangular room",
+            opening: "Press on a wall and drag to set the opening width",
+            camera: "Press and drag to place and aim a saved camera",
+        };
+        for (const control of this.els.planToolButtons) {
+            control.disabled = false;
+            control.title = planToolTitles[control.dataset.planTool] || "";
+            control.setAttribute(
+                "aria-pressed",
+                String(control.dataset.planTool === this.editorView.plan_tool),
+            );
+        }
+        const planHints = {
+            select: "Click to select · Drag wall points",
+            wall: "Press and drag to draw a wall",
+            room: "Press and drag diagonally to draw a room",
+            opening: "Press on a wall and drag to set width",
+            camera: "Press and drag to place and aim",
+        };
+        this.els.planHint.textContent = planHints[this.editorView.plan_tool] || planHints.select;
+        this.els.planGridToggle.setAttribute(
+            "aria-pressed",
+            String(this.editorView.plan_grid.visible),
+        );
+        this.els.snapToggle.setAttribute("aria-pressed", String(this.editorView.snap.enabled));
+        this.els.snapGrid.value = String(this.editorView.plan_grid.step);
+        for (const control of this.els.planSettings) {
+            const key = control.dataset.planSetting;
+            const value = key === "major_every"
+                ? this.editorView.plan_grid.major_every
+                : key === "grid_step"
+                    ? this.editorView.plan_grid.step
+                    : key === "opening_kind"
+                        ? this.editorView.opening_kind
+                        : this.editorView.snap[key];
+            if (control.type === "checkbox") control.checked = value !== false;
+            else control.value = String(value ?? 0);
+        }
+        this.viewer?.setPlanGrid?.({
+            visible: this.editorView.plan_grid.visible,
+            step: this.editorView.plan_grid.step,
+            majorEvery: this.editorView.plan_grid.major_every,
+        });
+        const levels = this.scene ? normalizedLevels(this.scene.levels) : [];
+        const selectedLevelId = levels.some(level => level.level_id === this.editorView.active_level_id)
+            ? this.editorView.active_level_id
+            : levels[0]?.level_id || "";
+        if (this.els.levelSelect.dataset.signature !== levels.map(level => `${level.level_id}:${level.name}`).join("|")) {
+            this.els.levelSelect.replaceChildren(...levels.map(level => {
+                const option = element("option", "", `${level.name} · ${Number(level.elevation).toFixed(2)} m`);
+                option.value = level.level_id;
+                return option;
+            }));
+            this.els.levelSelect.dataset.signature = levels.map(level => `${level.level_id}:${level.name}`).join("|");
+        }
+        this.editorView.active_level_id = selectedLevelId;
+        this.els.levelSelect.value = selectedLevelId;
+        this.els.levelSelect.hidden = !this.scene;
+        const buildings = this.scene?.architecture?.buildings || [];
+        const selectedBuildingId = buildings.some(
+            building => building.building_id === this.editorView.active_building_id,
+        ) ? this.editorView.active_building_id : buildings[0]?.building_id || "";
+        const buildingSignature = buildings.map(
+            building => `${building.building_id}:${building.name}`,
+        ).join("|");
+        if (this.els.buildingSelect.dataset.signature !== buildingSignature) {
+            const noBuildings = element("option", "", "No buildings");
+            noBuildings.value = "";
+            noBuildings.disabled = true;
+            noBuildings.selected = !buildings.length;
+            this.els.buildingSelect.replaceChildren(...(buildings.length ? buildings.map(building => {
+                const option = element("option", "", building.name || "Building");
+                option.value = building.building_id;
+                return option;
+            }) : [noBuildings]));
+            this.els.buildingSelect.dataset.signature = buildingSignature;
+        }
+        this.editorView.active_building_id = selectedBuildingId;
+        this.els.buildingSelect.value = selectedBuildingId;
+        this.els.buildingSelect.hidden = !this.scene;
+        this.els.buildingSelect.disabled = !buildings.length;
+        this.els.levelAdd.disabled = !this.scene;
+        this.els.buildingAdd.disabled = !this.scene || (this.scene.architecture?.buildings?.length || 0) >= 64;
+        if (this.els.undo) this.els.undo.disabled = !this.history.canUndo;
+        if (this.els.redo) this.els.redo.disabled = !this.history.canRedo;
     }
 
     serializeState() {
@@ -5265,11 +9557,19 @@ class Factory3DWidget {
             selected_object_ids: Array.from(this.selectedObjectIds),
             selected_group_id: this.selectedGroupId,
             selected_skydome: this.selectedSkydome,
+            selected_architecture: this.selectedArchitecture,
+            selected_camera_id: this.selectedCameraId,
             collapsed_group_ids: Array.from(this.collapsedGroupIds),
             settings: { ...this.settings },
             render_settings: { ...this.exportSettings },
             lighting_settings: { ...this.lighting },
             viewer_state: this.viewer?.getState?.() || this.viewerState,
+            editor_view: {
+                ...this.editorView,
+                plan_camera: this.viewer?.getState?.().plan_camera || this.editorView.plan_camera,
+            },
+            active_camera_track_id: this.activeCameraTrackId,
+            selected_camera_keyframe_id: this.selectedCameraKeyframeId,
             scene_snapshot: this.scene ? this._scenePayload() : null,
             source: this.sourceAsset
                 ? { ...this.sourceAsset, scene_id: this.sceneId }
@@ -5315,6 +9615,11 @@ class Factory3DWidget {
             if (this.selectedObjectId) this.selectedObjectIds.add(this.selectedObjectId);
             this.selectedGroupId = String(state.selected_group_id || "");
             this.selectedSkydome = state.selected_skydome === true;
+            this.selectedArchitecture = safeObject(state.selected_architecture);
+            if (!this.selectedArchitecture.type || !this.selectedArchitecture.id) {
+                this.selectedArchitecture = null;
+            }
+            this.selectedCameraId = String(state.selected_camera_id || "");
             this.collapsedGroupIds = new Set(
                 Array.isArray(state.collapsed_group_ids)
                     ? state.collapsed_group_ids.map(String)
@@ -5352,11 +9657,20 @@ class Factory3DWidget {
                 state.lighting_settings || safeObject(state.scene_snapshot).lighting,
             );
             this.viewerState = { ...this.viewerState, ...safeObject(state.viewer_state) };
+            this.editorView = normalizedEditorView(
+                state.editor_view || state.viewer_state,
+                safeObject(state.scene_snapshot).levels?.[0]?.level_id,
+            );
+            this.activeCameraTrackId = String(state.active_camera_track_id || "");
+            this.selectedCameraKeyframeId = String(state.selected_camera_keyframe_id || "");
             this._syncSettings();
             this._syncExportSettings();
             this._syncLighting();
             this.viewer.setLighting(this.lighting);
             this.viewer.setState(this.viewerState);
+            this.viewer.setViewMode(this.editorView.view_mode);
+            this.viewer.setPlanTool(this.editorView.plan_tool);
+            this.viewer.setActiveLevel(this.editorView.active_level_id);
             await Promise.all([
                 this.loadCapabilities(),
                 this.ensureScene(safeObject(state.scene_snapshot)),
@@ -5384,6 +9698,8 @@ class Factory3DWidget {
     resize() {
         const width = this.container.clientWidth || DEFAULT_NODE_SIZE[0];
         const height = this.container.clientHeight || DEFAULT_NODE_SIZE[1];
+        this.container.classList.toggle("is-compact", width < 980);
+        this.container.classList.toggle("is-narrow", width < 760);
         const scale = clamp(Math.min(width / 1100, height / 720), 0.72, 1.08);
         const scaleValue = scale.toFixed(3);
         if (scaleValue !== this._uiScaleValue) {
@@ -5407,6 +9723,14 @@ class Factory3DWidget {
         clearTimeout(this._sceneSaveTimer);
         clearTimeout(this._previewSaveTimer);
         clearTimeout(this._lightingApplyTimer);
+        clearTimeout(this._architecturePreviewTimer);
+        if (this._architectureGeometryFrame) cancelAnimationFrame(this._architectureGeometryFrame);
+        this._architectureGeometryFrame = 0;
+        if (this.cameraPlayback?.frame) cancelAnimationFrame(this.cameraPlayback.frame);
+        this.cameraPlayback = null;
+        if (this._planHoverFrame) cancelAnimationFrame(this._planHoverFrame);
+        this._planHoverFrame = 0;
+        this._pendingPlanHover = null;
         if (this._previewIdleHandle && typeof cancelIdleCallback === "function") {
             cancelIdleCallback(this._previewIdleHandle);
         }

--- a/web/vnccs_3d_factory_viewer.js
+++ b/web/vnccs_3d_factory_viewer.js
@@ -18,6 +18,8 @@ const INTERACTIVE_FRAME_MS = 1000 / 30;
 const LIGHTING_UPDATE_MS = 1000 / 15;
 const LIGHTING_BASE_RESPONSE = 0.65;
 const MAX_PLAN_GRID_LINES_PER_AXIS = 800;
+const CUTAWAY_MAX_VERTICAL_DOT = 0.7;
+const MIN_DIRECTIONAL_SHADOW_HALF_SPAN = 2;
 export const FACTORY_VIEWER_BUILD = "20260825.16";
 
 const DEFAULT_LIGHTING = Object.freeze({
@@ -28,7 +30,7 @@ const DEFAULT_LIGHTING = Object.freeze({
     elevation: 42,
     ambient: 0.5,
     background: "#171b25",
-    shadows: Object.freeze({ enabled: true, quality: "medium", bias: -0.0005, normal_bias: 0.02 }),
+    shadows: Object.freeze({ enabled: true, quality: "medium", bias: -0.0002, normal_bias: 0.0015 }),
     lights: Object.freeze([]),
 });
 
@@ -73,6 +75,12 @@ export function normalizedLighting(value = {}) {
     const quality = ["off", "low", "medium", "high", "ultra"].includes(shadows.quality)
         ? shadows.quality
         : "medium";
+    const requestedNormalBias = numberOr(shadows.normal_bias, DEFAULT_LIGHTING.shadows.normal_bias);
+    const normalBias = [0.015, 0.02].some(
+        legacy => Math.abs(requestedNormalBias - legacy) < 1e-9,
+    )
+        ? DEFAULT_LIGHTING.shadows.normal_bias
+        : requestedNormalBias;
     return {
         preset,
         intensity: Math.max(0, Math.min(3, Number(data.intensity) || 0)),
@@ -84,8 +92,8 @@ export function normalizedLighting(value = {}) {
         shadows: {
             enabled: shadows.enabled !== false && quality !== "off",
             quality,
-            bias: Math.max(-0.1, Math.min(0.1, numberOr(shadows.bias, -0.0005))),
-            normal_bias: Math.max(0, Math.min(10, numberOr(shadows.normal_bias, 0.02))),
+            bias: Math.max(-0.1, Math.min(0.1, numberOr(shadows.bias, DEFAULT_LIGHTING.shadows.bias))),
+            normal_bias: Math.max(0, Math.min(10, normalBias)),
         },
         lights,
     };
@@ -610,6 +618,9 @@ export class Factory3DViewer {
             onError: options.onError || EMPTY,
             onArchitectureSelection: options.onArchitectureSelection || EMPTY,
             onArchitectureEdit: options.onArchitectureEdit || EMPTY,
+            onLightSelection: options.onLightSelection || EMPTY,
+            onLightTransform: options.onLightTransform || EMPTY,
+            onPlanMarqueeSelection: options.onPlanMarqueeSelection || EMPTY,
             snapPlanPoint: options.snapPlanPoint || ((point) => point),
             onPlanGesture: options.onPlanGesture || EMPTY,
             onPlanHover: options.onPlanHover || EMPTY,
@@ -621,16 +632,23 @@ export class Factory3DViewer {
         this.selectedGroupId = "";
         this.selectedGroupObjectIds = [];
         this.architectureSelection = null;
+        this.architectureSelections = [];
+        this.selectedCameraMarkerIds = new Set();
+        this.selectedLightMarkerId = "";
         this._groupTransformStart = null;
         this.mode = "translate";
         this.gridVisible = false;
         this.viewMode = "3d";
+        this.interiorCutaway = false;
+        this._cutawaySignature = "";
         this.planTool = "select";
         this.activeLevelId = "";
         this.planCameraState = { target: [0, 0], zoom: 24 };
         this.planGridState = { visible: true, step: 0.1, majorEvery: 10 };
         this._planGridSignature = "";
         this._planPan = null;
+        this._planMarquee = null;
+        this._lightDrag = null;
         this.captureWidth = 1024;
         this.captureHeight = 1024;
         this.captureFov = 42;
@@ -692,6 +710,11 @@ export class Factory3DViewer {
             outline: "none",
         });
         this.host.appendChild(this.canvas);
+        this.planMarqueeElement = document.createElement("div");
+        this.planMarqueeElement.className = "vnccs-i3s__plan-marquee";
+        this.planMarqueeElement.hidden = true;
+        this.planMarqueeElement.setAttribute("aria-hidden", "true");
+        this.host.appendChild(this.planMarqueeElement);
         this.cameraFrame = document.createElement("div");
         this.cameraFrame.className = "vnccs-i3s__camera-frame";
         this.cameraFrame.setAttribute("aria-hidden", "true");
@@ -708,6 +731,9 @@ export class Factory3DViewer {
         this.sunLight.target.position.set(0, 0, 0);
         this.lightRig.add(this.ambientLight, this.sunLight, this.sunLight.target);
         this.scene.add(this.lightRig);
+        this.lightHelperRoot = new THREE.Group();
+        this.lightHelperRoot.name = "VNCCS Factory editor light helpers";
+        this.scene.add(this.lightHelperRoot);
         this.camera = new THREE.PerspectiveCamera(42, 1, 0.0001, 100000);
         this.camera.position.set(2.8, 2.1, 4.2);
         this.planCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.01, 10000);
@@ -837,6 +863,9 @@ export class Factory3DViewer {
         this.selectionBounds.material.transparent = true;
         this.selectionBounds.material.opacity = 0.72;
         this.scene.add(this.selectionBounds);
+        this.multiSelectionBoundsRoot = new THREE.Group();
+        this.multiSelectionBoundsRoot.name = "VNCCS Factory multiple selection bounds";
+        this.scene.add(this.multiSelectionBoundsRoot);
         this.groupPivot = new THREE.Group();
         this.groupPivot.name = "VNCCS Factory group transform pivot";
         this.scene.add(this.groupPivot);
@@ -845,7 +874,18 @@ export class Factory3DViewer {
             this._setInteractive("transform", Boolean(event.value));
             if (event.value && this.selectedGroupId) this._beginGroupTransform();
             if (!event.value) {
-                if (this.selectedGroupId) {
+                if (this.selectedLightMarkerId) {
+                    const helper = this.lightHelperRoot?.children?.find(
+                        item => item.userData?.factoryId === this.selectedLightMarkerId,
+                    );
+                    if (helper) {
+                        this.options.onLightTransform(
+                            this.selectedLightMarkerId,
+                            helper.position.toArray(),
+                            { final: true },
+                        );
+                    }
+                } else if (this.selectedGroupId) {
                     this._applyGroupTransform(true);
                     this._configureGroupPivot();
                 } else {
@@ -868,7 +908,9 @@ export class Factory3DViewer {
             this.invalidate();
         });
         this.transform.addEventListener("mouseDown", () => {
-            if (this.selectedGroupId) {
+            if (this.selectedLightMarkerId) {
+                this._singleTransformStart = null;
+            } else if (this.selectedGroupId) {
                 this._beginGroupTransform();
                 this._scaleDragStart = 1;
             } else {
@@ -880,6 +922,7 @@ export class Factory3DViewer {
         this.transform.addEventListener("objectChange", () => this._onTransformObjectChange());
 
         this.raycaster = new THREE.Raycaster();
+        this._cutawayRaycaster = new THREE.Raycaster();
         this.pointer = new THREE.Vector2();
         this._pointerDown = null;
         this._planDraw = null;
@@ -928,6 +971,29 @@ export class Factory3DViewer {
                 return;
             }
             if (this.viewMode === "plan" && event.button === 0 && this.planTool === "select") {
+                const lightMarker = this._planLightHit(event);
+                if (lightMarker) {
+                    const lightId = lightMarker.userData.factoryId;
+                    const light = this.lighting?.lights?.find(item => item.light_id === lightId);
+                    if (light) {
+                        this.options.onLightSelection(lightId);
+                        const selectedMarker = this.lightMarkerRoot.children.find(
+                            item => item.userData?.factoryId === lightId,
+                        ) || lightMarker;
+                        this._lightDrag = {
+                            pointerId: event.pointerId,
+                            lightId,
+                            marker: selectedMarker,
+                            originPosition: [...light.position],
+                            moved: false,
+                            originX: event.clientX,
+                            originY: event.clientY,
+                        };
+                        this.canvas.setPointerCapture?.(event.pointerId);
+                        event.preventDefault();
+                        return;
+                    }
+                }
                 const handle = this._planHandleHit(event);
                 if (handle) {
                     const wall = handle.userData.factoryHandleType === "wall"
@@ -962,6 +1028,21 @@ export class Factory3DViewer {
                             event,
                         });
                     }
+                    event.preventDefault();
+                    return;
+                }
+                if (!this._planSelectionHit(event)) {
+                    this._planMarquee = {
+                        pointerId: event.pointerId,
+                        originX: event.clientX,
+                        originY: event.clientY,
+                        currentX: event.clientX,
+                        currentY: event.clientY,
+                        moved: false,
+                        additive: event.shiftKey,
+                    };
+                    this.canvas.setPointerCapture?.(event.pointerId);
+                    this._updatePlanMarqueeElement();
                     event.preventDefault();
                     return;
                 }
@@ -1013,6 +1094,41 @@ export class Factory3DViewer {
                     event.preventDefault();
                     return;
                 }
+            }
+            if (this._planMarquee?.pointerId === event.pointerId) {
+                this._planMarquee.currentX = event.clientX;
+                this._planMarquee.currentY = event.clientY;
+                this._planMarquee.moved = this._planMarquee.moved || Math.hypot(
+                    event.clientX - this._planMarquee.originX,
+                    event.clientY - this._planMarquee.originY,
+                ) > 4;
+                this._updatePlanMarqueeElement();
+                event.preventDefault();
+                return;
+            }
+            if (this._lightDrag?.pointerId === event.pointerId) {
+                const drag = this._lightDrag;
+                drag.moved = drag.moved || Math.hypot(
+                    event.clientX - drag.originX,
+                    event.clientY - drag.originY,
+                ) > 3;
+                if (!drag.moved) {
+                    event.preventDefault();
+                    return;
+                }
+                const point = this.options.snapPlanPoint(this.screenToPlan(event), event, null);
+                const position = [point[0], drag.originPosition[1], point[1]];
+                drag.position = position;
+                drag.marker.position.x = point[0];
+                drag.marker.position.z = point[1];
+                const helper = this.lightHelperRoot?.children?.find(
+                    item => item.userData?.factoryId === drag.lightId,
+                );
+                if (helper) helper.position.fromArray(position);
+                this.options.onLightTransform(drag.lightId, position, { final: false });
+                this.invalidate();
+                event.preventDefault();
+                return;
             }
             if (this._architectureDrag) {
                 const distance = Math.hypot(
@@ -1112,6 +1228,42 @@ export class Factory3DViewer {
                     return;
                 }
             }
+            const marquee = this._planMarquee?.pointerId === event.pointerId
+                ? this._planMarquee
+                : null;
+            if (marquee) {
+                this._planMarquee = null;
+                this.planMarqueeElement.hidden = true;
+                this.canvas.releasePointerCapture?.(event.pointerId);
+                const items = marquee.moved
+                    ? this._planItemsInBounds(
+                        this.screenToPlan({ clientX: marquee.originX, clientY: marquee.originY }),
+                        this.screenToPlan(event),
+                    )
+                    : [];
+                this.options.onPlanMarqueeSelection(items, {
+                    additive: marquee.additive,
+                    emptyClick: !marquee.moved,
+                });
+                this._pointerDown = null;
+                event.preventDefault();
+                return;
+            }
+            if (this._lightDrag?.pointerId === event.pointerId) {
+                const drag = this._lightDrag;
+                this._lightDrag = null;
+                this.canvas.releasePointerCapture?.(event.pointerId);
+                if (drag.moved) {
+                    this.options.onLightTransform(
+                        drag.lightId,
+                        drag.position || drag.originPosition,
+                        { final: true },
+                    );
+                }
+                this._pointerDown = null;
+                event.preventDefault();
+                return;
+            }
             if (this._architectureDrag) {
                 const drag = this._architectureDrag;
                 this._architectureDrag = null;
@@ -1184,6 +1336,23 @@ export class Factory3DViewer {
                         id: drag.id,
                         event,
                     });
+                }
+            }
+            if (
+                this._planMarquee
+                && (event.pointerId === undefined || this._planMarquee.pointerId === event.pointerId)
+            ) {
+                this._planMarquee = null;
+                this.planMarqueeElement.hidden = true;
+            }
+            if (
+                this._lightDrag
+                && (event.pointerId === undefined || this._lightDrag.pointerId === event.pointerId)
+            ) {
+                const drag = this._lightDrag;
+                this._lightDrag = null;
+                if (drag.moved) {
+                    this.options.onLightTransform(drag.lightId, drag.originPosition, { final: true });
                 }
             }
             if (!this._lookDrag || (event.pointerId !== undefined && this._lookDrag.pointerId !== event.pointerId)) return;
@@ -1305,6 +1474,8 @@ export class Factory3DViewer {
             ? Math.min(0.1, Math.max(0, time - this._lastRenderTime) / 1000)
             : null;
         const cameraChanged = this.controls.update(deltaSeconds);
+        this._syncViewportCutaway();
+        this._syncLightHelperScale();
         this.renderer.render(this.scene, this.activeCamera());
         this._lastRenderTime = time;
         if (this._interactionReasons.size || cameraChanged || this._renderRequested) {
@@ -1314,6 +1485,19 @@ export class Factory3DViewer {
         if (this._cameraStateDirty) {
             this._cameraStateDirty = false;
             this._emitState();
+        }
+    }
+
+    _syncLightHelperScale() {
+        if (this.viewMode !== "3d" || !this.lightHelperRoot?.visible) return;
+        const viewportHeight = Math.max(1, this.host.clientHeight || 1);
+        const halfFov = THREE.MathUtils.degToRad(this.camera.fov * 0.5);
+        for (const helper of this.lightHelperRoot.children) {
+            const radius = Math.max(0.001, Number(helper.userData?.factoryHelperRadius) || 0.11);
+            const distance = Math.max(0.001, this.camera.position.distanceTo(helper.position));
+            const desiredRadius = distance * Math.tan(halfFov) * 18 / viewportHeight;
+            const scale = Math.max(0.2, Math.min(1000, desiredRadius / radius));
+            helper.scale.setScalar(scale);
         }
     }
 
@@ -1507,12 +1691,13 @@ export class Factory3DViewer {
                 if (lightDirection.lengthSq() < 1e-12) lightDirection.set(0, 1, 0);
                 lightDirection.normalize();
             }
-            if (
+            const requiresOcclusion = Boolean(
                 light.cast_shadow
                 && this.lighting.shadows?.enabled
-                && this.lighting.shadows?.quality !== "off"
-                && shadowCount < shadowBudget
-            ) {
+                && this.lighting.shadows?.quality !== "off",
+            );
+            if (requiresOcclusion && shadowCount >= shadowBudget) continue;
+            if (requiresOcclusion) {
                 response *= this._visibilityAlongRay(entry, lightDirection, maximumDistance);
                 shadowCount += 1;
             }
@@ -1530,16 +1715,13 @@ export class Factory3DViewer {
         this.ambientLight.intensity = this.lighting.preset === "off" ? 1 : this.lighting.ambient;
         this.sunLight.color.set(this.lighting.color);
         this.sunLight.intensity = this.lighting.preset === "off" ? 0 : this.lighting.intensity;
-        this.sunLight.position.copy(this._lightSourceWorld).multiplyScalar(100);
         this.sunLight.castShadow = shadowsEnabled;
         const mapSize = qualitySizes[this.lighting.shadows?.quality] || 1024;
         this.sunLight.shadow.mapSize.set(mapSize, mapSize);
-        this.sunLight.shadow.bias = this.lighting.shadows?.bias ?? -0.0005;
-        this.sunLight.shadow.normalBias = this.lighting.shadows?.normal_bias ?? 0.02;
-        this.sunLight.shadow.camera.left = -50;
-        this.sunLight.shadow.camera.right = 50;
-        this.sunLight.shadow.camera.top = 50;
-        this.sunLight.shadow.camera.bottom = -50;
+        this.sunLight.shadow.bias = this.lighting.shadows?.bias ?? DEFAULT_LIGHTING.shadows.bias;
+        this.sunLight.shadow.normalBias = this.lighting.shadows?.normal_bias
+            ?? DEFAULT_LIGHTING.shadows.normal_bias;
+        this._fitSunShadowCamera();
         for (const child of [...this.lightRig.children]) {
             if ([this.ambientLight, this.sunLight, this.sunLight.target].includes(child)) continue;
             this.lightRig.remove(child);
@@ -1555,6 +1737,8 @@ export class Factory3DViewer {
                 building => building.building_id === data.building_id,
             );
             if (owner?.visible === false) continue;
+            const requiresShadow = Boolean(data.cast_shadow && shadowsEnabled);
+            if (requiresShadow && shadowLightCount >= shadowLightBudget) continue;
             let light;
             if (data.kind === "spot") {
                 light = new THREE.SpotLight(
@@ -1570,18 +1754,22 @@ export class Factory3DViewer {
                 light = new THREE.PointLight(data.color, data.intensity, data.distance);
             }
             light.name = data.name || "Factory light";
+            light.userData.factoryLightId = data.light_id || "";
             light.position.fromArray(data.position);
             light.visible = data.visible !== false;
-            light.castShadow = Boolean(
-                data.cast_shadow
-                && shadowsEnabled
-                && shadowLightCount < shadowLightBudget,
-            );
+            light.castShadow = requiresShadow;
             if (light.castShadow) shadowLightCount += 1;
             if (light.shadow) {
                 light.shadow.mapSize.set(mapSize, mapSize);
-                light.shadow.bias = this.lighting.shadows?.bias ?? -0.0005;
-                light.shadow.normalBias = this.lighting.shadows?.normal_bias ?? 0.02;
+                light.shadow.bias = this.lighting.shadows?.bias ?? DEFAULT_LIGHTING.shadows.bias;
+                light.shadow.normalBias = this.lighting.shadows?.normal_bias
+                    ?? DEFAULT_LIGHTING.shadows.normal_bias;
+                light.shadow.camera.near = 0.02;
+                if (data.kind === "point" || data.kind === "spot") {
+                    light.shadow.camera.far = data.distance > 0
+                        ? Math.max(0.03, data.distance)
+                        : 1000;
+                }
                 if (data.kind === "directional") {
                     light.shadow.camera.left = -25;
                     light.shadow.camera.right = 25;
@@ -1595,6 +1783,40 @@ export class Factory3DViewer {
             }
             this.lightRig.add(light);
         }
+    }
+
+    _fitSunShadowCamera() {
+        const bounds = this._viewBounds({ scope: "scene" });
+        const center = new THREE.Vector3();
+        let radius = 50;
+        if (hasFiniteBounds(bounds)) {
+            bounds.getCenter(center);
+            radius = Math.max(
+                MIN_DIRECTIONAL_SHADOW_HALF_SPAN,
+                bounds.getSize(new THREE.Vector3()).length() * 0.5,
+            );
+        }
+        const halfSpan = Math.max(
+            MIN_DIRECTIONAL_SHADOW_HALF_SPAN,
+            radius * 1.08 + 0.25,
+        );
+        const distance = Math.max(50, halfSpan * 2.5);
+        const direction = this._lightSourceWorld.clone();
+        if (direction.lengthSq() < 1e-12) direction.set(0, 1, 0);
+        direction.normalize();
+        this.sunLight.target.position.copy(center);
+        this.sunLight.position.copy(center).addScaledVector(direction, distance);
+        this.sunLight.target.updateMatrixWorld(true);
+        this.sunLight.updateMatrixWorld(true);
+        const camera = this.sunLight.shadow.camera;
+        camera.left = -halfSpan;
+        camera.right = halfSpan;
+        camera.top = halfSpan;
+        camera.bottom = -halfSpan;
+        camera.near = Math.max(0.05, distance - halfSpan * 1.5);
+        camera.far = distance + halfSpan * 1.5;
+        camera.updateProjectionMatrix();
+        this.sunLight.shadow.needsUpdate = true;
     }
 
     _scheduleDirectionalLighting(entry, { immediate = false } = {}) {
@@ -2060,6 +2282,126 @@ export class Factory3DViewer {
         return [Number(point.x.toFixed(6)), Number(point.z.toFixed(6))];
     }
 
+    _updatePlanMarqueeElement() {
+        const drag = this._planMarquee;
+        if (!drag || !this.planMarqueeElement) return;
+        const rect = this.canvas.getBoundingClientRect();
+        const left = Math.min(drag.originX, drag.currentX) - rect.left;
+        const top = Math.min(drag.originY, drag.currentY) - rect.top;
+        this.planMarqueeElement.hidden = false;
+        Object.assign(this.planMarqueeElement.style, {
+            left: `${left}px`,
+            top: `${top}px`,
+            width: `${Math.abs(drag.currentX - drag.originX)}px`,
+            height: `${Math.abs(drag.currentY - drag.originY)}px`,
+        });
+    }
+
+    _planSelectionHit(event) {
+        const rect = this.canvas.getBoundingClientRect();
+        this.pointer.set(
+            ((event.clientX - rect.left) / Math.max(1, rect.width)) * 2 - 1,
+            -((event.clientY - rect.top) / Math.max(1, rect.height)) * 2 + 1,
+        );
+        this.raycaster.setFromCamera(this.pointer, this.planCamera);
+        const architectureHit = [
+            ...this.raycaster.intersectObject(this.planOverlay, true),
+            ...this.raycaster.intersectObject(this.architecture.root, true),
+        ].some(hit => hit.object?.userData?.factoryId);
+        return architectureHit || Boolean(boundedObjectHit(this.raycaster.ray, this.objects));
+    }
+
+    _planLightHit(event) {
+        if (!this.lightMarkerRoot?.visible) return null;
+        const rect = this.canvas.getBoundingClientRect();
+        this.pointer.set(
+            ((event.clientX - rect.left) / Math.max(1, rect.width)) * 2 - 1,
+            -((event.clientY - rect.top) / Math.max(1, rect.height)) * 2 + 1,
+        );
+        this.raycaster.setFromCamera(this.pointer, this.planCamera);
+        return this.raycaster.intersectObject(this.lightMarkerRoot, true).find(
+            hit => hit.object?.userData?.factoryType === "light"
+                && hit.object.userData.factoryId,
+        )?.object || null;
+    }
+
+    _planItemsInBounds(start, end) {
+        const minimumX = Math.min(start[0], end[0]);
+        const maximumX = Math.max(start[0], end[0]);
+        const minimumZ = Math.min(start[1], end[1]);
+        const maximumZ = Math.max(start[1], end[1]);
+        const intersects = (minX, minZ, maxX, maxZ) => (
+            maxX >= minimumX
+            && minX <= maximumX
+            && maxZ >= minimumZ
+            && minZ <= maximumZ
+        );
+        const output = [];
+        for (const [objectId, entry] of this.objects) {
+            if (
+                !entry?.mesh?.visible
+                || !entry.localBounds
+                || entry.localBounds.isEmpty()
+                || (entry.data?.level_id && entry.data.level_id !== this.activeLevelId)
+            ) continue;
+            entry.mesh.updateMatrixWorld(true);
+            const bounds = entry.localBounds.clone().applyMatrix4(entry.mesh.matrixWorld);
+            if (intersects(bounds.min.x, bounds.min.z, bounds.max.x, bounds.max.z)) {
+                output.push({ kind: "object", id: objectId });
+            }
+        }
+        const architecture = this.sceneData?.architecture || {};
+        const roomWallIds = new Set((architecture.rooms || []).flatMap(room => room.wall_ids || []));
+        const worldPoint = (point, buildingId) => {
+            const position = new THREE.Vector3(point[0], 0, point[1]);
+            this.architecture.buildingRoots.get(buildingId)?.localToWorld(position);
+            return position;
+        };
+        for (const room of architecture.rooms || []) {
+            if (
+                room.visible === false
+                || room.level_id !== this.activeLevelId
+                || !Array.isArray(room.polygon)
+                || !room.polygon.length
+            ) continue;
+            const points = room.polygon.map(point => worldPoint(point, room.building_id));
+            const xs = points.map(point => point.x);
+            const zs = points.map(point => point.z);
+            if (intersects(Math.min(...xs), Math.min(...zs), Math.max(...xs), Math.max(...zs))) {
+                output.push({ kind: "architecture", type: "room", id: room.room_id });
+            }
+        }
+        for (const wall of architecture.walls || []) {
+            if (
+                wall.visible === false
+                || wall.level_id !== this.activeLevelId
+                || roomWallIds.has(wall.wall_id)
+            ) continue;
+            const first = worldPoint(wall.start, wall.building_id);
+            const second = worldPoint(wall.end, wall.building_id);
+            if (intersects(
+                Math.min(first.x, second.x),
+                Math.min(first.z, second.z),
+                Math.max(first.x, second.x),
+                Math.max(first.z, second.z),
+            )) {
+                output.push({ kind: "architecture", type: "wall", id: wall.wall_id });
+            }
+        }
+        for (const camera of this.sceneData?.cameras || []) {
+            if (
+                camera.level_id
+                && camera.level_id !== this.activeLevelId
+            ) continue;
+            const x = Number(camera.position?.[0]) || 0;
+            const z = Number(camera.position?.[2]) || 0;
+            if (intersects(x, z, x, z)) {
+                output.push({ kind: "camera", id: camera.camera_id });
+            }
+        }
+        return output;
+    }
+
     _updateCameraFrame(width = 0, height = 0) {
         if (!this.cameraFrame) return;
         const layout = this._cameraFrameLayout(width, height);
@@ -2082,8 +2424,18 @@ export class Factory3DViewer {
         this.raycaster.setFromCamera(this.pointer, this.activeCamera());
         const editorHits = [
             ...this.raycaster.intersectObject(this.planOverlay, true),
+            ...(this.viewMode === "3d"
+                ? this.raycaster.intersectObject(this.lightHelperRoot, true)
+                : []),
             ...this.raycaster.intersectObject(this.architecture.root, true),
         ].sort((left, right) => left.distance - right.distance);
+        const lightHit = editorHits.find(
+            hit => hit.object?.userData?.factoryType === "light" && hit.object.userData.factoryId,
+        );
+        if (lightHit) {
+            this.options.onLightSelection(lightHit.object.userData.factoryId);
+            return;
+        }
         const architectureHit = editorHits.find(hit => hit.object?.userData?.factoryId);
         // Per-Gaussian raycasting creates long pointer tasks on dense scenes.
         // Robust trimmed bounds already describe every object well enough for
@@ -2095,6 +2447,7 @@ export class Factory3DViewer {
                 type: architectureHit.object.userData.factoryType,
                 id: architectureHit.object.userData.factoryId,
                 wallId: architectureHit.object.userData.wallId || "",
+                additive: event.shiftKey,
             });
             return;
         }
@@ -2132,6 +2485,19 @@ export class Factory3DViewer {
 
     _onTransformObjectChange() {
         if (this._suppressTransform) return;
+        if (this.selectedLightMarkerId) {
+            const helper = this.lightHelperRoot?.children?.find(
+                item => item.userData?.factoryId === this.selectedLightMarkerId,
+            );
+            if (!helper) return;
+            this.options.onLightTransform(
+                this.selectedLightMarkerId,
+                helper.position.toArray(),
+                { final: !this.transform.dragging },
+            );
+            this.invalidate();
+            return;
+        }
         if (this.selectedGroupId) {
             if (this.mode === "scale") {
                 const values = [this.groupPivot.scale.x, this.groupPivot.scale.y, this.groupPivot.scale.z];
@@ -2296,6 +2662,29 @@ export class Factory3DViewer {
         this.selectionBounds.updateMatrixWorld(true);
     }
 
+    setObjectSelectionHighlights(objectIds = [], primaryId = this.selectedId) {
+        this._clearPlanRoot(this.multiSelectionBoundsRoot);
+        const selectedIds = Array.from(new Set(objectIds)).filter(
+            objectId => objectId && objectId !== primaryId && this.objects.has(objectId),
+        );
+        for (const objectId of selectedIds) {
+            const entry = this.objects.get(objectId);
+            if (!entry?.mesh?.visible || !entry.localBounds || entry.localBounds.isEmpty()) continue;
+            entry.mesh.updateMatrixWorld(true);
+            const helper = new THREE.Box3Helper(
+                entry.localBounds.clone().applyMatrix4(entry.mesh.matrixWorld),
+                0xb8a9e8,
+            );
+            helper.renderOrder = 9_998;
+            helper.material.depthTest = false;
+            helper.material.depthWrite = false;
+            helper.material.transparent = true;
+            helper.material.opacity = 0.62;
+            this.multiSelectionBoundsRoot.add(helper);
+        }
+        this.invalidate();
+    }
+
     setScene(sceneData, options = {}) {
         const operation = this._sceneSetSerial.then(
             () => this._setSceneNow(sceneData, options),
@@ -2319,6 +2708,7 @@ export class Factory3DViewer {
         if (this._disposed) return { loaded: 0, failures: [] };
         this.architecture.sceneData = this.sceneData;
         this.architecture.setActiveLevel(this.activeLevelId, this.viewMode === "plan");
+        this._cutawaySignature = "";
         this.setCameraMarkers(this.sceneData.cameras || []);
         this.setLighting(this.sceneData.lighting);
         const skydomePromise = this.setSkydome(this.sceneData.skydome);
@@ -2510,6 +2900,7 @@ export class Factory3DViewer {
             this.select("");
         }
         if (this.objects.size && (!incremental || previousCount === 0)) this.fit();
+        this._fitSunShadowCamera();
         this.resize();
         this.invalidate();
         return { loaded: this.objects.size, failures };
@@ -2597,7 +2988,7 @@ export class Factory3DViewer {
         this.invalidate();
     }
 
-    select(objectId, { additive = false } = {}) {
+    select(objectId, { additive = false, emit = true } = {}) {
         const id = this.objects.has(objectId) ? objectId : "";
         this.selectedId = id;
         this.selectedGroupId = "";
@@ -2609,7 +3000,7 @@ export class Factory3DViewer {
             && Boolean(id)
             && this.objects.get(id)?.data?.locked !== true;
         this._refreshSelectionBounds();
-        this.options.onSelectionChange(id, { additive });
+        if (emit) this.options.onSelectionChange(id, { additive });
         this._emitState();
         this.invalidate();
     }
@@ -2657,6 +3048,7 @@ export class Factory3DViewer {
 
     setMode(mode) {
         if (!["translate", "rotate", "scale"].includes(mode)) return;
+        if (this.selectedLightMarkerId && mode !== "translate") return;
         this.mode = mode;
         this.transform.setMode(mode);
         this.transform.showX = true;
@@ -2690,6 +3082,82 @@ export class Factory3DViewer {
         this.invalidate();
     }
 
+    _nearestCutawayWallId() {
+        if (this.viewMode !== "3d" || !this.architecture?.root) return "";
+        const direction = this.controls.target.clone().sub(this.camera.position);
+        const distance = direction.length();
+        if (distance <= 0.03) return "";
+        direction.divideScalar(distance);
+        // A top/down or steep architectural view should retain every wall.
+        // Cutaway walls are only meaningful when the camera projects mostly
+        // along the floor plane.
+        if (Math.abs(direction.y) > CUTAWAY_MAX_VERTICAL_DOT) return "";
+        this.architecture.root.updateMatrixWorld(true);
+        this._cutawayRaycaster.set(
+            this.camera.position,
+            direction,
+        );
+        this._cutawayRaycaster.near = 0.02;
+        this._cutawayRaycaster.far = Math.max(0.02, distance - 0.01);
+        const visibleInHierarchy = object => {
+            for (let current = object; current; current = current.parent) {
+                if (current.visible === false) return false;
+                if (current === this.architecture.root) break;
+            }
+            return true;
+        };
+        const firstSurface = this._cutawayRaycaster
+            .intersectObject(this.architecture.root, true)
+            .find(hit => (
+                visibleInHierarchy(hit.object)
+                && ["wall", "opening"].includes(hit.object.userData?.factoryType)
+            ));
+        // A ray already passing through a window/door needs no cutaway. This
+        // also prevents a wall behind the opening from being removed instead.
+        return firstSurface?.object.userData?.factoryType === "wall"
+            ? String(firstSurface.object.userData.factoryId || "")
+            : "";
+    }
+
+    _syncViewportCutaway(force = false) {
+        if (this._capturing || !this.architecture) return;
+        const camera = this.viewMode === "plan" ? this.planCamera : this.camera;
+        const target = this.viewMode === "plan"
+            ? [this.planCameraState.target[0], 0, this.planCameraState.target[1]]
+            : this.controls.target.toArray();
+        const signature = [
+            this.interiorCutaway,
+            this.viewMode,
+            this.activeLevelId,
+            ...camera.position.toArray(),
+            ...target,
+        ].map(value => typeof value === "number" ? value.toFixed(5) : String(value)).join(":");
+        if (!force && signature === this._cutawaySignature) return;
+        this._cutawaySignature = signature;
+        const planMode = this.viewMode === "plan";
+        this.architecture.setActiveLevel(this.activeLevelId, planMode, {
+            hideCeilings: this.interiorCutaway,
+            hiddenWallId: "",
+        });
+        if (!this.interiorCutaway) return;
+        const hiddenWallId = this._nearestCutawayWallId();
+        if (hiddenWallId) {
+            this.architecture.setActiveLevel(this.activeLevelId, planMode, {
+                hideCeilings: true,
+                hiddenWallId,
+            });
+        }
+    }
+
+    setInteriorCutaway(enabled) {
+        const next = Boolean(enabled);
+        if (next === this.interiorCutaway && this._cutawaySignature) return;
+        this.interiorCutaway = next;
+        this._cutawaySignature = "";
+        this._syncViewportCutaway(true);
+        this.invalidate();
+    }
+
     setViewMode(mode) {
         const next = mode === "plan" ? "plan" : "3d";
         if (next === this.viewMode) return;
@@ -2698,11 +3166,16 @@ export class Factory3DViewer {
         this.transform.camera = this.activeCamera();
         const selectionEditable = this.selectedGroupId
             ? this._groupEntries().length > 0
-            : Boolean(this.selectedId) && this.objects.get(this.selectedId)?.data?.locked !== true;
+            : this.selectedLightMarkerId
+                ? true
+                : Boolean(this.selectedId) && this.objects.get(this.selectedId)?.data?.locked !== true;
         this.transform.enabled = next === "3d" && selectionEditable;
-        this.transformHelper.visible = next === "3d" && Boolean(this.selectedId || this.selectedGroupId);
+        this.transformHelper.visible = next === "3d" && Boolean(
+            this.selectedId || this.selectedGroupId || this.selectedLightMarkerId,
+        );
         this.cameraFrame.style.display = next === "3d" && this.cameraFrameVisible ? "block" : "none";
         this.grid.visible = next === "3d" && this.gridVisible;
+        this.lightHelperRoot.visible = next === "3d";
         this.architecture.setActiveLevel(this.activeLevelId, next === "plan");
         this.applySceneVisibility(this.sceneData);
         this._syncThreeLights();
@@ -2711,6 +3184,8 @@ export class Factory3DViewer {
             ? "crosshair"
             : "default";
         if (next === "plan") this._syncPlanGrid();
+        this._cutawaySignature = "";
+        this._syncViewportCutaway(true);
         this.resize();
         this.spark.setDirty?.();
         this._emitState();
@@ -2746,32 +3221,133 @@ export class Factory3DViewer {
             .find(hit => hit.object?.userData?.factoryHandleType)?.object || null;
     }
 
-    setArchitectureSelection(selection) {
+    setArchitectureSelection(selection, selections = null) {
         this.architectureSelection = selection?.id
             ? { type: String(selection.type || ""), id: String(selection.id) }
             : null;
+        const selectedItems = Array.isArray(selections)
+            ? selections
+            : this.architectureSelection
+                ? [this.architectureSelection]
+                : [];
+        this.architectureSelections = Array.from(new Map(selectedItems
+            .filter(item => item?.id)
+            .map(item => {
+                const normalized = { type: String(item.type || ""), id: String(item.id) };
+                return [`${normalized.type}:${normalized.id}`, normalized];
+            })).values());
         this._clearPlanRoot(this.architectureHandleRoot);
-        if (!selection?.id) {
+        if (!this.architectureSelection?.id) {
             this.invalidate();
             return;
         }
+        selection = this.architectureSelection;
         const architecture = this.sceneData?.architecture || {};
-        const addHandle = ({ type, id, point, elevation, endpoint = "", color = "#ff8fa3" }) => {
-            const radius = Math.max(0.055, 8 / Math.max(1, Number(this.planCameraState.zoom) || 24));
+        const addHandle = ({
+            type,
+            id,
+            point,
+            elevation,
+            endpoint = "",
+            color = "#ff8fa3",
+            interactive = true,
+            opacity = 1,
+            scale = 1,
+        }) => {
+            const radius = Math.max(0.055, 8 / Math.max(1, Number(this.planCameraState.zoom) || 24)) * scale;
             const handle = new THREE.Mesh(
                 new THREE.CircleGeometry(radius, 20),
-                new THREE.MeshBasicMaterial({ color, depthTest: false, side: THREE.DoubleSide }),
+                new THREE.MeshBasicMaterial({
+                    color,
+                    depthTest: false,
+                    depthWrite: false,
+                    side: THREE.DoubleSide,
+                    transparent: opacity < 1,
+                    opacity,
+                }),
             );
             handle.rotation.x = -Math.PI / 2;
             handle.position.set(point[0], elevation, point[1]);
-            handle.renderOrder = 60;
-            handle.userData = {
-                factoryHandleType: type,
-                factoryHandleId: id,
-                endpoint,
-            };
+            handle.renderOrder = interactive ? 60 : 58;
+            if (interactive) {
+                handle.userData = {
+                    factoryHandleType: type,
+                    factoryHandleId: id,
+                    endpoint,
+                };
+            }
             this.architectureHandleRoot.add(handle);
         };
+        const selectionMarker = candidate => {
+            if (candidate.type === "building") {
+                const building = architecture.buildings?.find(item => item.building_id === candidate.id);
+                const level = this.sceneData?.levels?.find(item => item.level_id === this.activeLevelId);
+                if (!building || building.visible === false) return null;
+                return {
+                    point: [Number(building.position?.[0]) || 0, Number(building.position?.[2]) || 0],
+                    elevation: (Number(level?.elevation) || 0)
+                        + (Number(building.position?.[1]) || 0)
+                        + 0.06,
+                };
+            }
+            if (candidate.type === "room") {
+                const room = architecture.rooms?.find(item => item.room_id === candidate.id);
+                if (!room?.polygon?.length || room.visible === false || room.level_id !== this.activeLevelId) return null;
+                const level = this.sceneData?.levels?.find(item => item.level_id === room.level_id);
+                const center = room.polygon.reduce(
+                    (sum, point) => [sum[0] + point[0], sum[1] + point[1]],
+                    [0, 0],
+                ).map(value => value / room.polygon.length);
+                const position = new THREE.Vector3(
+                    center[0],
+                    (Number(level?.elevation) || 0) + 0.06,
+                    center[1],
+                );
+                this.architecture.buildingRoots.get(room.building_id)?.localToWorld(position);
+                return { point: [position.x, position.z], elevation: position.y };
+            }
+            if (candidate.type === "wall") {
+                const wall = architecture.walls?.find(item => item.wall_id === candidate.id);
+                if (!wall || wall.visible === false || wall.level_id !== this.activeLevelId) return null;
+                const level = this.sceneData?.levels?.find(item => item.level_id === wall.level_id);
+                const position = new THREE.Vector3(
+                    (wall.start[0] + wall.end[0]) * 0.5,
+                    (Number(level?.elevation) || 0) + 0.06,
+                    (wall.start[1] + wall.end[1]) * 0.5,
+                );
+                this.architecture.buildingRoots.get(wall.building_id)?.localToWorld(position);
+                return { point: [position.x, position.z], elevation: position.y };
+            }
+            if (candidate.type === "opening") {
+                const opening = architecture.openings?.find(item => item.opening_id === candidate.id);
+                const wall = architecture.walls?.find(item => item.wall_id === opening?.wall_id);
+                if (!opening || !wall || opening.visible === false || wall.level_id !== this.activeLevelId) return null;
+                const level = this.sceneData?.levels?.find(item => item.level_id === wall.level_id);
+                const offset = Math.max(0, Math.min(1, Number(opening.offset) || 0));
+                const position = new THREE.Vector3(
+                    wall.start[0] + (wall.end[0] - wall.start[0]) * offset,
+                    (Number(level?.elevation) || 0) + 0.065,
+                    wall.start[1] + (wall.end[1] - wall.start[1]) * offset,
+                );
+                this.architecture.buildingRoots.get(wall.building_id)?.localToWorld(position);
+                return { point: [position.x, position.z], elevation: position.y };
+            }
+            return null;
+        };
+        for (const candidate of this.architectureSelections) {
+            if (candidate.type === selection.type && candidate.id === selection.id) continue;
+            const marker = selectionMarker(candidate);
+            if (!marker) continue;
+            addHandle({
+                type: candidate.type,
+                id: candidate.id,
+                ...marker,
+                color: "#b8a9e8",
+                interactive: false,
+                opacity: 0.68,
+                scale: 0.82,
+            });
+        }
         if (selection.type === "building") {
             const building = architecture.buildings?.find(item => item.building_id === selection.id);
             if (!building || building.locked) return this.invalidate();
@@ -3020,7 +3596,8 @@ export class Factory3DViewer {
         this.invalidate();
     }
 
-    setCameraMarkers(cameras = []) {
+    setCameraMarkers(cameras = [], selectedIds = null) {
+        if (selectedIds) this.selectedCameraMarkerIds = new Set(selectedIds);
         this._clearPlanRoot(this.cameraMarkerRoot);
         const level = this.sceneData?.levels?.find(item => item.level_id === this.activeLevelId);
         const elevation = (Number(level?.elevation) || 0) + 0.045;
@@ -3035,12 +3612,17 @@ export class Factory3DViewer {
             const target = new THREE.Vector3().fromArray(camera.target || [0, 1.6, -1]);
             const direction = target.sub(position);
             const angle = Math.atan2(direction.x, -direction.z);
+            const selected = this.selectedCameraMarkerIds.has(camera.camera_id);
             const group = new THREE.Group();
             group.position.set(position.x, elevation, position.z);
             group.userData = { factoryType: "camera", factoryId: camera.camera_id };
             const marker = new THREE.Mesh(
-                new THREE.CircleGeometry(markerRadius, 24),
-                new THREE.MeshBasicMaterial({ color: "#b8a9e8", depthTest: false, side: THREE.DoubleSide }),
+                new THREE.CircleGeometry(markerRadius * (selected ? 1.22 : 1), 24),
+                new THREE.MeshBasicMaterial({
+                    color: selected ? "#ff8fa3" : "#b8a9e8",
+                    depthTest: false,
+                    side: THREE.DoubleSide,
+                }),
             );
             marker.rotation.x = -Math.PI / 2;
             marker.userData = group.userData;
@@ -3051,7 +3633,7 @@ export class Factory3DViewer {
             ]);
             const arrow = new THREE.Line(
                 arrowGeometry,
-                new THREE.LineBasicMaterial({ color: "#d7ccff", depthTest: false }),
+                new THREE.LineBasicMaterial({ color: selected ? "#ffd0da" : "#d7ccff", depthTest: false }),
             );
             arrow.userData = marker.userData;
             const halfFov = THREE.MathUtils.degToRad(Math.max(5, Math.min(120, Number(camera.fov) || 42)) / 2);
@@ -3065,7 +3647,12 @@ export class Factory3DViewer {
             ]);
             const frustum = new THREE.Line(
                 frustumGeometry,
-                new THREE.LineBasicMaterial({ color: "#9f8cde", transparent: true, opacity: 0.8, depthTest: false }),
+                new THREE.LineBasicMaterial({
+                    color: selected ? "#ff8fa3" : "#9f8cde",
+                    transparent: true,
+                    opacity: selected ? 1 : 0.8,
+                    depthTest: false,
+                }),
             );
             frustum.userData = marker.userData;
             frustum.renderOrder = 44;
@@ -3076,32 +3663,87 @@ export class Factory3DViewer {
     }
 
     setLightMarkers(lights = []) {
-        if (!this.lightMarkerRoot) return;
+        if (!this.lightMarkerRoot || !this.lightHelperRoot) return;
+        if (this.transform.object?.userData?.factoryType === "light") this.transform.detach();
         this._clearPlanRoot(this.lightMarkerRoot);
+        this._clearPlanRoot(this.lightHelperRoot);
         const level = this.sceneData?.levels?.find(item => item.level_id === this.activeLevelId);
         const elevation = (Number(level?.elevation) || 0) + 0.05;
         const radius = Math.max(0.07, 8 / Math.max(1, Number(this.planCameraState.zoom) || 24));
         for (const light of lights) {
-            if (light.visible === false || (light.level_id && light.level_id !== this.activeLevelId)) continue;
+            if (light.visible === false) continue;
             const owner = this.sceneData?.architecture?.buildings?.find(
                 building => building.building_id === light.building_id,
             );
             if (owner?.visible === false) continue;
-            const [x, , z] = light.position || [0, 0, 0];
-            const marker = new THREE.Mesh(
-                new THREE.CircleGeometry(radius, 20),
+            const [x, y, z] = light.position || [0, 0, 0];
+            const selected = light.light_id === this.selectedLightMarkerId;
+            const helper = new THREE.Mesh(
+                new THREE.SphereGeometry(selected ? 0.14 : 0.11, 18, 12),
                 new THREE.MeshBasicMaterial({
                     color: light.color || "#ffffff",
                     depthTest: false,
+                    depthWrite: false,
+                    transparent: true,
+                    opacity: selected ? 1 : 0.86,
+                    toneMapped: false,
+                }),
+            );
+            helper.name = `${light.name || "Point light"} editor helper`;
+            helper.position.set(Number(x) || 0, Number(y) || 0, Number(z) || 0);
+            helper.renderOrder = 10_020;
+            helper.userData = {
+                factoryType: "light",
+                factoryId: light.light_id,
+                factoryHelperRadius: selected ? 0.14 : 0.11,
+            };
+            this.lightHelperRoot.add(helper);
+            if (light.level_id && light.level_id !== this.activeLevelId) continue;
+            const marker = new THREE.Mesh(
+                new THREE.CircleGeometry(radius * (selected ? 1.22 : 1), 20),
+                new THREE.MeshBasicMaterial({
+                    color: light.color || "#ffffff",
+                    depthTest: false,
+                    depthWrite: false,
                     side: THREE.DoubleSide,
                 }),
             );
             marker.rotation.x = -Math.PI / 2;
             marker.position.set(Number(x) || 0, elevation, Number(z) || 0);
             marker.renderOrder = 43;
-            marker.raycast = EMPTY;
+            marker.userData = { factoryType: "light", factoryId: light.light_id };
             this.lightMarkerRoot.add(marker);
         }
+        this.lightHelperRoot.visible = this.viewMode === "3d";
+        const selectedHelper = this.lightHelperRoot.children.find(
+            item => item.userData?.factoryId === this.selectedLightMarkerId,
+        );
+        if (selectedHelper && this.viewMode === "3d") {
+            this.transform.attach(selectedHelper);
+            this.transform.enabled = true;
+            this.transformHelper.visible = true;
+        } else if (!this.selectedId && !this.selectedGroupId) {
+            this.transformHelper.visible = false;
+        }
+        this.invalidate();
+    }
+
+    selectLightMarker(lightId = "") {
+        this.selectedLightMarkerId = String(lightId || "");
+        if (this.selectedLightMarkerId && this.mode !== "translate") this.setMode("translate");
+        this.setLightMarkers(this.lighting.lights || []);
+    }
+
+    previewLightPosition(lightId, position) {
+        const light = this.lighting?.lights?.find(item => item.light_id === lightId);
+        if (!light || !Array.isArray(position) || position.length !== 3) return;
+        light.position = position.map(value => Number(value) || 0);
+        const runtimeLight = this.lightRig.children.find(
+            item => item.userData?.factoryLightId === lightId,
+        );
+        runtimeLight?.position?.fromArray(light.position);
+        for (const entry of this.objects.values()) this._scheduleDirectionalLighting(entry);
+        this.spark?.setDirty?.();
         this.invalidate();
     }
 
@@ -3109,6 +3751,8 @@ export class Factory3DViewer {
         if (!this.sceneData?.levels?.some(item => item.level_id === levelId)) return;
         this.activeLevelId = levelId;
         this.architecture.setActiveLevel(levelId, this.viewMode === "plan");
+        this._cutawaySignature = "";
+        this._syncViewportCutaway(true);
         this.applySceneVisibility(this.sceneData);
         const level = this.sceneData.levels.find(item => item.level_id === levelId);
         this.grid.position.y = Number(level?.elevation) || 0;
@@ -3127,7 +3771,10 @@ export class Factory3DViewer {
         const updated = this.architecture.updateItem(type, id, this.sceneData);
         if (!updated) return false;
         this.architecture.setActiveLevel(this.activeLevelId, this.viewMode === "plan");
-        this.setArchitectureSelection(this.architectureSelection);
+        this._cutawaySignature = "";
+        this._syncViewportCutaway(true);
+        this.setArchitectureSelection(this.architectureSelection, this.architectureSelections);
+        this._fitSunShadowCamera();
         this.invalidate();
         return true;
     }
@@ -3136,8 +3783,11 @@ export class Factory3DViewer {
         this.sceneData = sceneData || this.sceneData;
         await this.architecture.set(this.sceneData);
         this.architecture.setActiveLevel(this.activeLevelId, this.viewMode === "plan");
-        this.setArchitectureSelection(this.architectureSelection);
+        this._cutawaySignature = "";
+        this._syncViewportCutaway(true);
+        this.setArchitectureSelection(this.architectureSelection, this.architectureSelections);
         this.setCameraMarkers(this.sceneData?.cameras || []);
+        this._fitSunShadowCamera();
         this.invalidate();
     }
 
@@ -3706,14 +4356,21 @@ export class Factory3DViewer {
             grid: this.grid.visible,
             transform: this.transformHelper.visible,
             bounds: this.selectionBounds.visible,
+            multiBounds: this.multiSelectionBoundsRoot.visible,
+            lightHelpers: this.lightHelperRoot.visible,
             plan: this.planOverlay.visible,
         };
         const previousCaptureState = this._capturing;
         this.grid.visible = false;
         this.transformHelper.visible = false;
         this.selectionBounds.visible = false;
+        this.multiSelectionBoundsRoot.visible = false;
+        this.lightHelperRoot.visible = false;
         this.planOverlay.visible = false;
-        this.architecture.setActiveLevel(this.activeLevelId, false);
+        this.architecture.setActiveLevel(this.activeLevelId, false, {
+            hideCeilings: false,
+            hiddenWallId: "",
+        });
         this._capturing = true;
         if (captureSkydomeTexture) {
             this.skydomeTexture = captureSkydomeTexture;
@@ -3789,9 +4446,16 @@ export class Factory3DViewer {
             this.grid.visible = overlayVisibility.grid;
             this.transformHelper.visible = overlayVisibility.transform;
             this.selectionBounds.visible = overlayVisibility.bounds;
+            this.multiSelectionBoundsRoot.visible = overlayVisibility.multiBounds;
+            this.lightHelperRoot.visible = overlayVisibility.lightHelpers;
             this.planOverlay.visible = overlayVisibility.plan;
-            this.architecture.setActiveLevel(this.activeLevelId, this.viewMode === "plan");
             this._capturing = previousCaptureState;
+            this._cutawaySignature = "";
+            if (this._capturing) {
+                this.architecture.setActiveLevel(this.activeLevelId, this.viewMode === "plan");
+            } else {
+                this._syncViewportCutaway(true);
+            }
             // Re-read the local viewport after capture. The Comfy graph may
             // have been zoomed or the node resized while the exact-size render
             // was being encoded.
@@ -4027,12 +4691,17 @@ export class Factory3DViewer {
         this.scene.remove(this.selectionBounds);
         this.selectionBounds.geometry.dispose();
         this.selectionBounds.material.dispose();
+        this._clearPlanRoot(this.multiSelectionBoundsRoot);
+        this.scene.remove(this.multiSelectionBoundsRoot);
         this.controls.dispose();
         this.architecture?.dispose?.();
         this._clearPlanRoot(this.planGridRoot);
         this._clearPlanRoot(this.planDraftRoot);
         this._clearPlanRoot(this.cameraMarkerRoot);
+        this._clearPlanRoot(this.lightMarkerRoot);
         this._clearPlanRoot(this.architectureHandleRoot);
+        this._clearPlanRoot(this.lightHelperRoot);
+        this.scene.remove(this.lightHelperRoot);
         this.scene.remove(this.planOverlay);
         for (const entry of this.objects.values()) this._disposeEntry(entry);
         this.objects.clear();
@@ -4047,6 +4716,7 @@ export class Factory3DViewer {
         this.grid.geometry.dispose();
         this.grid.material.dispose();
         this.renderer.dispose();
+        this.planMarqueeElement?.remove();
         this.cameraFrame?.remove();
         this.canvas.remove();
     }

--- a/web/vnccs_3d_factory_viewer.js
+++ b/web/vnccs_3d_factory_viewer.js
@@ -947,8 +947,21 @@ export class Factory3DViewer {
                         fixedPoint,
                         thickness: Number(wall?.thickness) || 0.12,
                         handle,
+                        pointerId: event.pointerId,
+                        originX: event.clientX,
+                        originY: event.clientY,
+                        moved: false,
                     };
                     this.canvas.setPointerCapture?.(event.pointerId);
+                    if (this._architectureDrag.type === "room") {
+                        this.canvas.style.cursor = "grabbing";
+                        this.options.onArchitectureEdit({
+                            phase: "start",
+                            type: "room",
+                            id: this._architectureDrag.id,
+                            event,
+                        });
+                    }
                     event.preventDefault();
                     return;
                 }
@@ -1002,6 +1015,11 @@ export class Factory3DViewer {
                 }
             }
             if (this._architectureDrag) {
+                const distance = Math.hypot(
+                    event.clientX - this._architectureDrag.originX,
+                    event.clientY - this._architectureDrag.originY,
+                );
+                if (distance > 3) this._architectureDrag.moved = true;
                 const point = this.options.snapPlanPoint(
                     this.screenToPlan(event),
                     event,
@@ -1022,6 +1040,15 @@ export class Factory3DViewer {
                         thickness: this._architectureDrag.thickness,
                     });
                 }
+                if (this._architectureDrag.type === "room" && this._architectureDrag.moved) {
+                    this.options.onArchitectureEdit({
+                        phase: "move",
+                        type: "room",
+                        id: this._architectureDrag.id,
+                        point,
+                        event,
+                    });
+                }
                 this.invalidate();
                 event.preventDefault();
                 return;
@@ -1033,7 +1060,7 @@ export class Factory3DViewer {
             const zoom = Math.max(0.01, this.planCameraState.zoom);
             this.planCameraState.target = [
                 this._planPan.target[0] - (event.clientX - this._planPan.x) / zoom,
-                this._planPan.target[1] + (event.clientY - this._planPan.y) / zoom,
+                this._planPan.target[1] - (event.clientY - this._planPan.y) / zoom,
             ];
             this._syncPlanCamera();
             this.invalidate();
@@ -1090,7 +1117,18 @@ export class Factory3DViewer {
                 this._architectureDrag = null;
                 this.setPlanDraft(null);
                 this.canvas.releasePointerCapture?.(event.pointerId);
+                if (drag.type === "room") this.canvas.style.cursor = "default";
+                if (drag.type === "room" && !drag.moved) {
+                    this.options.onArchitectureEdit({
+                        phase: "cancel",
+                        type: drag.type,
+                        id: drag.id,
+                        event,
+                    });
+                    return;
+                }
                 this.options.onArchitectureEdit({
+                    phase: "end",
                     type: drag.type,
                     id: drag.id,
                     endpoint: drag.endpoint,
@@ -1131,6 +1169,23 @@ export class Factory3DViewer {
                     distance: 0,
                 });
             }
+            if (
+                this._architectureDrag
+                && (event.pointerId === undefined || this._architectureDrag.pointerId === event.pointerId)
+            ) {
+                const drag = this._architectureDrag;
+                this._architectureDrag = null;
+                this.setPlanDraft(null);
+                if (drag.type === "room") this.canvas.style.cursor = "default";
+                if (drag.type === "room") {
+                    this.options.onArchitectureEdit({
+                        phase: "cancel",
+                        type: drag.type,
+                        id: drag.id,
+                        event,
+                    });
+                }
+            }
             if (!this._lookDrag || (event.pointerId !== undefined && this._lookDrag.pointerId !== event.pointerId)) return;
             this._lookDrag = null;
             this._pointerDown = null;
@@ -1147,18 +1202,25 @@ export class Factory3DViewer {
             }
             if (this.viewMode !== "plan") return;
             const before = this.screenToPlan(event);
+            const deltaScale = event.deltaMode === WheelEvent.DOM_DELTA_LINE
+                ? 16
+                : event.deltaMode === WheelEvent.DOM_DELTA_PAGE
+                    ? Math.max(1, this.host.clientHeight)
+                    : 1;
+            const wheelDelta = Math.max(-240, Math.min(240, event.deltaY * deltaScale));
             this.planCameraState.zoom = Math.max(
                 0.01,
-                Math.min(100000, this.planCameraState.zoom * Math.exp(-event.deltaY * 0.001)),
+                Math.min(100000, this.planCameraState.zoom * Math.exp(-wheelDelta * 0.002)),
             );
-            this._syncPlanCamera();
+            this._updatePlanProjection();
             const after = this.screenToPlan(event);
             this.planCameraState.target[0] += before[0] - after[0];
             this.planCameraState.target[1] += before[1] - after[1];
             this._syncPlanCamera();
-            this.resize();
             this._emitState();
+            this.invalidate();
             event.preventDefault();
+            event.stopImmediatePropagation();
         }, { capture: true, passive: false });
         this.canvas.addEventListener("keydown", event => {
             const mode = { w: "translate", e: "rotate", r: "scale" }[event.key.toLowerCase()];

--- a/web/vnccs_3d_factory_viewer.js
+++ b/web/vnccs_3d_factory_viewer.js
@@ -652,6 +652,7 @@ export class Factory3DViewer {
         this.captureWidth = 1024;
         this.captureHeight = 1024;
         this.captureFov = 42;
+        this.zoomSensitivity = 0.1;
         this.cameraFrameVisible = false;
         this._capturing = false;
         this._disposed = false;
@@ -1364,7 +1365,7 @@ export class Factory3DViewer {
         this.canvas.addEventListener("lostpointercapture", cancelLook);
         this.canvas.addEventListener("wheel", event => {
             if (this.viewMode === "3d") {
-                this.dollyCamera(-event.deltaY / 100, { emit: true });
+                this.dollyCamera((-event.deltaY / 100) * this.zoomSensitivity, { emit: true });
                 event.preventDefault();
                 event.stopImmediatePropagation();
                 return;
@@ -1762,8 +1763,15 @@ export class Factory3DViewer {
             if (light.shadow) {
                 light.shadow.mapSize.set(mapSize, mapSize);
                 light.shadow.bias = this.lighting.shadows?.bias ?? DEFAULT_LIGHTING.shadows.bias;
-                light.shadow.normalBias = this.lighting.shadows?.normal_bias
+                const configuredNormalBias = this.lighting.shadows?.normal_bias
                     ?? DEFAULT_LIGHTING.shadows.normal_bias;
+                // Opaque architecture casts back faces into the shadow map,
+                // so a large receiver offset is unnecessary and would open
+                // gaps at wall/slab junctions. Retain only the small baseline
+                // offset for local lights to absorb depth quantization.
+                light.shadow.normalBias = data.kind === "directional"
+                    ? configuredNormalBias
+                    : Math.max(configuredNormalBias, DEFAULT_LIGHTING.shadows.normal_bias);
                 light.shadow.camera.near = 0.02;
                 if (data.kind === "point" || data.kind === "spot") {
                     light.shadow.camera.far = data.distance > 0
@@ -2286,14 +2294,25 @@ export class Factory3DViewer {
         const drag = this._planMarquee;
         if (!drag || !this.planMarqueeElement) return;
         const rect = this.canvas.getBoundingClientRect();
-        const left = Math.min(drag.originX, drag.currentX) - rect.left;
-        const top = Math.min(drag.originY, drag.currentY) - rect.top;
+        // LiteGraph scales the complete DOM widget while absolute children
+        // remain positioned in the host's unscaled layout coordinates.
+        // Convert client-space pointer coordinates into that local space;
+        // subtracting only rect.left/top shifts the marquee toward the
+        // top-left whenever the ComfyUI graph zoom is not 100%.
+        const scaleX = Math.max(1, this.host?.clientWidth || this.canvas.clientWidth || rect.width)
+            / Math.max(1, rect.width);
+        const scaleY = Math.max(1, this.host?.clientHeight || this.canvas.clientHeight || rect.height)
+            / Math.max(1, rect.height);
+        const originX = (drag.originX - rect.left) * scaleX;
+        const originY = (drag.originY - rect.top) * scaleY;
+        const currentX = (drag.currentX - rect.left) * scaleX;
+        const currentY = (drag.currentY - rect.top) * scaleY;
         this.planMarqueeElement.hidden = false;
         Object.assign(this.planMarqueeElement.style, {
-            left: `${left}px`,
-            top: `${top}px`,
-            width: `${Math.abs(drag.currentX - drag.originX)}px`,
-            height: `${Math.abs(drag.currentY - drag.originY)}px`,
+            left: `${Math.min(originX, currentX)}px`,
+            top: `${Math.min(originY, currentY)}px`,
+            width: `${Math.abs(currentX - originX)}px`,
+            height: `${Math.abs(currentY - originY)}px`,
         });
     }
 
@@ -4141,6 +4160,13 @@ export class Factory3DViewer {
         }
     }
 
+    setZoomSensitivity(value, { emit = true } = {}) {
+        const requested = Number(value);
+        if (!Number.isFinite(requested)) return;
+        this.zoomSensitivity = THREE.MathUtils.clamp(requested, 0.01, 2);
+        if (emit) this._emitState();
+    }
+
     setCameraHeight(value, { emit = true } = {}) {
         const height = THREE.MathUtils.clamp(Number(value) || 0, -1_000_000, 1_000_000);
         const delta = height - this.camera.position.y;
@@ -4183,6 +4209,7 @@ export class Factory3DViewer {
                 target: [...this.planCameraState.target],
                 zoom: this.planCameraState.zoom,
             },
+            zoom_sensitivity: this.zoomSensitivity,
             camera: this.getCameraState(),
         };
     }
@@ -4282,6 +4309,9 @@ export class Factory3DViewer {
                 ).slice(0, 2),
                 zoom: Math.max(0.01, Number(value.plan_camera.zoom) || 24),
             };
+        }
+        if ("zoom_sensitivity" in value) {
+            this.setZoomSensitivity(value.zoom_sensitivity, { emit: false });
         }
         if (value.active_level_id) this.setActiveLevel(value.active_level_id);
         if (value.plan_tool) this.setPlanTool(value.plan_tool);

--- a/web/vnccs_3d_factory_viewer.js
+++ b/web/vnccs_3d_factory_viewer.js
@@ -14,6 +14,8 @@ const EMPTY = () => {};
 const HEAVY_SCENE_GAUSSIANS = 262_145;
 const SPLAT_SCAN_CHUNK = 16_384;
 const SPLAT_BOUND_SAMPLES = 4_096;
+const SHADOW_PROXY_MAX_SPLATS = 1_536;
+const SHADOW_PROXY_CANDIDATE_MULTIPLIER = 4;
 const INTERACTIVE_FRAME_MS = 1000 / 30;
 const LIGHTING_UPDATE_MS = 1000 / 15;
 const LIGHTING_BASE_RESPONSE = 0.65;
@@ -558,6 +560,96 @@ export function computeRobustSplatBounds(mesh, options = {}) {
     }
 }
 
+/**
+ * Select a bounded, deterministic subset of visible Gaussians for a cheap
+ * shadow-only silhouette. This preserves an object's actual outline without
+ * asking the browser to render every source splat into every shadow map.
+ */
+export function gaussianShadowProxyTransforms(mesh, bounds, options = {}) {
+    if (!mesh || !hasFiniteBounds(bounds)) return [];
+    const maxInstances = Math.max(
+        32,
+        Math.min(4_096, Math.floor(Number(options.maxInstances) || SHADOW_PROXY_MAX_SPLATS)),
+    );
+    const opacityThreshold = Math.max(
+        0,
+        Math.min(1, Number(options.opacityThreshold) || 0.08),
+    );
+    const splatCount = Math.max(0, Number(mesh.numSplats) || 0);
+    if (!splatCount) return [];
+
+    const candidateLimit = maxInstances * SHADOW_PROXY_CANDIDATE_MULTIPLIER;
+    const stride = Math.max(1, Math.ceil(splatCount / candidateLimit));
+    const safeBounds = bounds.clone();
+    const boundsSize = safeBounds.getSize(new THREE.Vector3());
+    const largestExtent = Math.max(boundsSize.x, boundsSize.y, boundsSize.z, 0.001);
+    safeBounds.expandByScalar(largestExtent * 0.04);
+    const maximumRadius = largestExtent * 0.16;
+    const minimumRadius = Math.max(largestExtent * 0.00035, 0.00001);
+    const candidates = [];
+
+    const collect = (index, center, scales, quaternion, opacity) => {
+        if (index % stride !== 0) return;
+        const alpha = Number(opacity);
+        if (Number.isFinite(alpha) && alpha < opacityThreshold) return;
+        const position = new THREE.Vector3(
+            Number(center?.x),
+            Number(center?.y),
+            Number(center?.z),
+        );
+        if (
+            !position.toArray().every(Number.isFinite)
+            || !safeBounds.containsPoint(position)
+        ) return;
+        const radiusFactor = 1.35 + 0.9 * Math.max(
+            0,
+            Math.min(1, Number.isFinite(alpha) ? alpha : 1),
+        );
+        const scale = new THREE.Vector3(
+            Math.max(
+                minimumRadius,
+                Math.min(maximumRadius, Math.abs(Number(scales?.x)) || minimumRadius),
+            ),
+            Math.max(
+                minimumRadius,
+                Math.min(maximumRadius, Math.abs(Number(scales?.y)) || minimumRadius),
+            ),
+            Math.max(
+                minimumRadius,
+                Math.min(maximumRadius, Math.abs(Number(scales?.z)) || minimumRadius),
+            ),
+        ).multiplyScalar(radiusFactor);
+        const rotation = new THREE.Quaternion(
+            Number(quaternion?.x) || 0,
+            Number(quaternion?.y) || 0,
+            Number(quaternion?.z) || 0,
+            Number.isFinite(Number(quaternion?.w)) ? Number(quaternion.w) : 1,
+        ).normalize();
+        candidates.push({ position, scale, quaternion: rotation });
+    };
+
+    try {
+        if (typeof mesh.splats?.getSplat === "function") {
+            for (let index = 0; index < splatCount; index += stride) {
+                const splat = mesh.splats.getSplat(index);
+                collect(index, splat.center, splat.scales, splat.quaternion, splat.opacity);
+            }
+        } else if (typeof mesh.forEachSplat === "function") {
+            mesh.forEachSplat(collect);
+        }
+    } catch (_) {
+        return [];
+    }
+    if (candidates.length <= maxInstances) return candidates;
+
+    const output = [];
+    const step = candidates.length / maxInstances;
+    for (let index = 0; index < maxInstances; index += 1) {
+        output.push(candidates[Math.min(candidates.length - 1, Math.floor((index + 0.5) * step))]);
+    }
+    return output;
+}
+
 function robustCoordinateBounds(coordinates, options = {}) {
     const trimFraction = Math.max(
         0,
@@ -606,6 +698,15 @@ export function boundedObjectHit(ray, entries) {
     return nearest;
 }
 
+export function isObjectPickableInHierarchy(object) {
+    for (let current = object; current; current = current.parent) {
+        if (current.visible === false || current.userData?.factoryPointerPassthrough === true) {
+            return false;
+        }
+    }
+    return Boolean(object);
+}
+
 export class Factory3DViewer {
     constructor(host, options = {}) {
         if (!host?.appendChild) throw new TypeError("Factory3DViewer requires a host element");
@@ -648,6 +749,8 @@ export class Factory3DViewer {
         this._planGridSignature = "";
         this._planPan = null;
         this._planMarquee = null;
+        this._objectPlanDrag = null;
+        this.planSelectedObjectIds = [];
         this._lightDrag = null;
         this.captureWidth = 1024;
         this.captureHeight = 1024;
@@ -1032,6 +1135,12 @@ export class Factory3DViewer {
                     event.preventDefault();
                     return;
                 }
+                const objectHit = this._planObjectHit(event);
+                if (objectHit?.objectId) {
+                    this._beginPlanObjectDrag(event, objectHit.objectId);
+                    event.preventDefault();
+                    return;
+                }
                 if (!this._planSelectionHit(event)) {
                     this._planMarquee = {
                         pointerId: event.pointerId,
@@ -1128,6 +1237,11 @@ export class Factory3DViewer {
                 if (helper) helper.position.fromArray(position);
                 this.options.onLightTransform(drag.lightId, position, { final: false });
                 this.invalidate();
+                event.preventDefault();
+                return;
+            }
+            if (this._objectPlanDrag?.pointerId === event.pointerId) {
+                this._updatePlanObjectDrag(event);
                 event.preventDefault();
                 return;
             }
@@ -1265,6 +1379,11 @@ export class Factory3DViewer {
                 event.preventDefault();
                 return;
             }
+            if (this._objectPlanDrag?.pointerId === event.pointerId) {
+                this._finishPlanObjectDrag(event);
+                event.preventDefault();
+                return;
+            }
             if (this._architectureDrag) {
                 const drag = this._architectureDrag;
                 this._architectureDrag = null;
@@ -1355,6 +1474,12 @@ export class Factory3DViewer {
                 if (drag.moved) {
                     this.options.onLightTransform(drag.lightId, drag.originPosition, { final: true });
                 }
+            }
+            if (
+                this._objectPlanDrag
+                && (event.pointerId === undefined || this._objectPlanDrag.pointerId === event.pointerId)
+            ) {
+                this._finishPlanObjectDrag(event, { cancelled: true });
             }
             if (!this._lookDrag || (event.pointerId !== undefined && this._lookDrag.pointerId !== event.pointerId)) return;
             this._lookDrag = null;
@@ -1512,22 +1637,33 @@ export class Factory3DViewer {
     }
 
     _attachShadowProxy(entry) {
-        if (!entry?.mesh || !entry?.localBounds || entry.localBounds.isEmpty()) return;
-        const center = entry.localBounds.getCenter(new THREE.Vector3());
-        const size = entry.localBounds.getSize(new THREE.Vector3());
-        const geometry = new THREE.BoxGeometry(
-            Math.max(0.001, size.x),
-            Math.max(0.001, size.y),
-            Math.max(0.001, size.z),
-        );
-        geometry.translate(center.x, center.y, center.z);
+        if (!entry?.mesh || !entry?.splat || !hasFiniteBounds(entry.splatBounds)) return;
+        const transforms = gaussianShadowProxyTransforms(entry.splat, entry.splatBounds);
+        if (!transforms.length) return;
+        // One low-poly ellipsoid per sampled Gaussian gives the shadow map a
+        // recognizable silhouette in one instanced draw call. A 1,536-instance
+        // cap keeps point-light cube shadows practical in large scenes.
+        const geometry = new THREE.IcosahedronGeometry(1, 0);
         const material = new THREE.MeshBasicMaterial({
             colorWrite: false,
             depthWrite: false,
             transparent: true,
             opacity: 0,
         });
-        const proxy = new THREE.Mesh(geometry, material);
+        const proxy = new THREE.InstancedMesh(geometry, material, transforms.length);
+        const matrix = new THREE.Matrix4();
+        for (let index = 0; index < transforms.length; index += 1) {
+            const transform = transforms[index];
+            matrix.compose(transform.position, transform.quaternion, transform.scale);
+            proxy.setMatrixAt(index, matrix);
+        }
+        proxy.instanceMatrix.needsUpdate = true;
+        proxy.computeBoundingBox?.();
+        proxy.computeBoundingSphere?.();
+        proxy.position.copy(entry.splat.position);
+        proxy.quaternion.copy(entry.splat.quaternion);
+        proxy.scale.copy(entry.splat.scale);
+        proxy.updateMatrix();
         proxy.name = "VNCCS Gaussian shadow proxy";
         proxy.customDepthMaterial = new THREE.MeshDepthMaterial({
             depthPacking: THREE.RGBADepthPacking,
@@ -2326,8 +2462,164 @@ export class Factory3DViewer {
         const architectureHit = [
             ...this.raycaster.intersectObject(this.planOverlay, true),
             ...this.raycaster.intersectObject(this.architecture.root, true),
-        ].some(hit => hit.object?.userData?.factoryId);
+        ].some(hit => (
+            isObjectPickableInHierarchy(hit.object)
+            && hit.object?.userData?.factoryId
+        ));
         return architectureHit || Boolean(boundedObjectHit(this.raycaster.ray, this.objects));
+    }
+
+    _planObjectHit(event) {
+        const rect = this.canvas.getBoundingClientRect();
+        this.pointer.set(
+            ((event.clientX - rect.left) / Math.max(1, rect.width)) * 2 - 1,
+            -((event.clientY - rect.top) / Math.max(1, rect.height)) * 2 + 1,
+        );
+        this.raycaster.setFromCamera(this.pointer, this.planCamera);
+        return boundedObjectHit(this.raycaster.ray, this.objects);
+    }
+
+    _beginPlanObjectDrag(event, objectId) {
+        const hitEntry = this.objects.get(objectId);
+        if (!hitEntry) return false;
+
+        const belongsToSelectedGroup = this.selectedGroupId
+            && this.selectedGroupObjectIds.includes(objectId);
+        const belongsToSelection = this.planSelectedObjectIds.includes(objectId);
+        if (!belongsToSelectedGroup && !belongsToSelection) {
+            this.select(objectId, { additive: Boolean(event.shiftKey) });
+        }
+
+        // Clicking a locked object must still select it, but cannot start a
+        // move that silently drags another member of the current selection.
+        if (hitEntry.data?.locked === true) {
+            this._pointerDown = null;
+            return false;
+        }
+
+        const candidates = belongsToSelectedGroup
+            ? this.selectedGroupObjectIds
+            : this.planSelectedObjectIds.includes(objectId)
+                ? this.planSelectedObjectIds
+                : [objectId];
+        const objectIds = Array.from(new Set(candidates)).filter(id => {
+            const entry = this.objects.get(id);
+            return entry?.mesh?.visible !== false && entry?.data?.locked !== true;
+        });
+        if (!objectIds.length) {
+            this._pointerDown = null;
+            return false;
+        }
+
+        const previousTransforms = {};
+        for (const id of objectIds) {
+            const entry = this.objects.get(id);
+            previousTransforms[id] = this._meshTransform(entry.mesh);
+        }
+        const anchorTransform = previousTransforms[objectId] || previousTransforms[objectIds[0]];
+        this._objectPlanDrag = {
+            pointerId: event.pointerId,
+            objectIds,
+            originPoint: this.screenToPlan(event),
+            anchorPosition: [anchorTransform.position[0], anchorTransform.position[2]],
+            previousTransforms,
+            currentTransforms: { ...previousTransforms },
+            originX: event.clientX,
+            originY: event.clientY,
+            moved: false,
+            interactive: false,
+        };
+        this.canvas.setPointerCapture?.(event.pointerId);
+        return true;
+    }
+
+    _updatePlanObjectDrag(event) {
+        const drag = this._objectPlanDrag;
+        if (!drag || (event.pointerId !== undefined && drag.pointerId !== event.pointerId)) return false;
+        const distance = Math.hypot(
+            event.clientX - drag.originX,
+            event.clientY - drag.originY,
+        );
+        if (!drag.moved && distance <= 3) return false;
+        if (!drag.moved) {
+            drag.moved = true;
+            drag.interactive = true;
+            this._setInteractive("plan-object", true);
+            this.canvas.style.cursor = "grabbing";
+        }
+
+        const pointer = this.screenToPlan(event);
+        const proposedAnchor = [
+            drag.anchorPosition[0] + pointer[0] - drag.originPoint[0],
+            drag.anchorPosition[1] + pointer[1] - drag.originPoint[1],
+        ];
+        const snappedAnchor = this.options.snapPlanPoint(proposedAnchor, event, null);
+        const deltaX = snappedAnchor[0] - drag.anchorPosition[0];
+        const deltaZ = snappedAnchor[1] - drag.anchorPosition[1];
+        drag.currentTransforms = {};
+        for (const [index, objectId] of drag.objectIds.entries()) {
+            const entry = this.objects.get(objectId);
+            const previous = drag.previousTransforms[objectId];
+            if (!entry || !previous) continue;
+            const transform = {
+                ...previous,
+                position: [
+                    previous.position[0] + deltaX,
+                    previous.position[1],
+                    previous.position[2] + deltaZ,
+                ].map(value => Number(value.toFixed(6))),
+                rotation: [...previous.rotation],
+            };
+            drag.currentTransforms[objectId] = transform;
+            entry.data.transform = transform;
+            this._applyTransform(entry.mesh, transform);
+            this.options.onTransformChange(objectId, transform, {
+                final: false,
+                group_id: this.selectedGroupId || "",
+                previous_transforms: drag.previousTransforms,
+                command_last: index === drag.objectIds.length - 1,
+            });
+        }
+        this._refreshSelectionBounds();
+        this._refreshObjectSelectionHighlights();
+        this.spark.setDirty?.();
+        this.invalidate();
+        return true;
+    }
+
+    _finishPlanObjectDrag(event, { cancelled = false } = {}) {
+        const drag = this._objectPlanDrag;
+        if (!drag || (event.pointerId !== undefined && drag.pointerId !== event.pointerId)) return false;
+        if (!cancelled) this._updatePlanObjectDrag(event);
+        this._objectPlanDrag = null;
+        this._pointerDown = null;
+        this.canvas.releasePointerCapture?.(drag.pointerId);
+        this.canvas.style.cursor = "default";
+        if (drag.interactive) this._setInteractive("plan-object", false);
+        if (!drag.moved) return true;
+
+        const transforms = cancelled ? drag.previousTransforms : drag.currentTransforms;
+        for (const [index, objectId] of drag.objectIds.entries()) {
+            const entry = this.objects.get(objectId);
+            const transform = transforms[objectId];
+            if (!entry || !transform) continue;
+            if (cancelled) {
+                entry.data.transform = transform;
+                this._applyTransform(entry.mesh, transform);
+            }
+            this.options.onTransformChange(objectId, transform, {
+                final: true,
+                cancelled,
+                group_id: this.selectedGroupId || "",
+                previous_transforms: drag.previousTransforms,
+                command_last: index === drag.objectIds.length - 1,
+            });
+        }
+        this._refreshSelectionBounds();
+        this._refreshObjectSelectionHighlights();
+        this.spark.setDirty?.();
+        this.invalidate();
+        return true;
     }
 
     _planLightHit(event) {
@@ -2447,7 +2739,9 @@ export class Factory3DViewer {
                 ? this.raycaster.intersectObject(this.lightHelperRoot, true)
                 : []),
             ...this.raycaster.intersectObject(this.architecture.root, true),
-        ].sort((left, right) => left.distance - right.distance);
+        ]
+            .filter(hit => isObjectPickableInHierarchy(hit.object))
+            .sort((left, right) => left.distance - right.distance);
         const lightHit = editorHits.find(
             hit => hit.object?.userData?.factoryType === "light" && hit.object.userData.factoryId,
         );
@@ -2682,8 +2976,11 @@ export class Factory3DViewer {
     }
 
     setObjectSelectionHighlights(objectIds = [], primaryId = this.selectedId) {
+        this.planSelectedObjectIds = Array.from(new Set(objectIds)).filter(
+            objectId => objectId && this.objects.has(objectId),
+        );
         this._clearPlanRoot(this.multiSelectionBoundsRoot);
-        const selectedIds = Array.from(new Set(objectIds)).filter(
+        const selectedIds = this.planSelectedObjectIds.filter(
             objectId => objectId && objectId !== primaryId && this.objects.has(objectId),
         );
         for (const objectId of selectedIds) {
@@ -2699,9 +2996,24 @@ export class Factory3DViewer {
             helper.material.depthWrite = false;
             helper.material.transparent = true;
             helper.material.opacity = 0.62;
+            helper.userData.factoryObjectId = objectId;
             this.multiSelectionBoundsRoot.add(helper);
         }
         this.invalidate();
+    }
+
+    _refreshObjectSelectionHighlights() {
+        for (const helper of this.multiSelectionBoundsRoot.children) {
+            const entry = this.objects.get(helper.userData?.factoryObjectId);
+            if (!entry?.mesh?.visible || !entry.localBounds || entry.localBounds.isEmpty()) {
+                helper.visible = false;
+                continue;
+            }
+            entry.mesh.updateMatrixWorld(true);
+            helper.visible = true;
+            helper.box.copy(entry.localBounds).applyMatrix4(entry.mesh.matrixWorld);
+            helper.updateMatrixWorld(true);
+        }
     }
 
     setScene(sceneData, options = {}) {

--- a/web/vnccs_3d_factory_viewer.js
+++ b/web/vnccs_3d_factory_viewer.js
@@ -6,6 +6,8 @@ import {
     SparkRenderer,
     SplatMesh,
 } from "./vendor/spark/spark.module.js";
+import { FactoryArchitectureRuntime } from "./factory3d/plan_geometry.mjs?v=20260825.4";
+import { solveDropToSurface } from "./factory3d/support_solver.mjs?v=20260825.3";
 
 
 const EMPTY = () => {};
@@ -15,7 +17,8 @@ const SPLAT_BOUND_SAMPLES = 4_096;
 const INTERACTIVE_FRAME_MS = 1000 / 30;
 const LIGHTING_UPDATE_MS = 1000 / 15;
 const LIGHTING_BASE_RESPONSE = 0.65;
-export const FACTORY_VIEWER_BUILD = "20260726.18";
+const MAX_PLAN_GRID_LINES_PER_AXIS = 800;
+export const FACTORY_VIEWER_BUILD = "20260825.16";
 
 const DEFAULT_LIGHTING = Object.freeze({
     preset: "day",
@@ -25,6 +28,8 @@ const DEFAULT_LIGHTING = Object.freeze({
     elevation: 42,
     ambient: 0.5,
     background: "#171b25",
+    shadows: Object.freeze({ enabled: true, quality: "medium", bias: -0.0005, normal_bias: 0.02 }),
+    lights: Object.freeze([]),
 });
 
 const DEFAULT_SKYDOME = Object.freeze({
@@ -38,6 +43,10 @@ const DEFAULT_SKYDOME = Object.freeze({
 
 export function normalizedLighting(value = {}) {
     const data = { ...DEFAULT_LIGHTING, ...(value && typeof value === "object" ? value : {}) };
+    const numberOr = (candidate, fallback) => {
+        const number = Number(candidate);
+        return Number.isFinite(number) ? number : fallback;
+    };
     const color = /^#[0-9a-f]{6}$/i.test(String(data.color || ""))
         ? String(data.color).toLowerCase()
         : DEFAULT_LIGHTING.color;
@@ -47,6 +56,23 @@ export function normalizedLighting(value = {}) {
     const preset = ["off", "day", "night", "dawn", "sunset", "custom"].includes(data.preset)
         ? data.preset
         : DEFAULT_LIGHTING.preset;
+    const shadows = data.shadows && typeof data.shadows === "object" ? data.shadows : {};
+    const lights = (Array.isArray(data.lights) ? data.lights : []).slice(0, 32).map(light => ({
+        ...light,
+        kind: ["point", "spot", "directional"].includes(light?.kind) ? light.kind : "point",
+        position: finiteVector(light?.position, [0, 2, 0]),
+        target: finiteVector(light?.target, [0, 0, -1]),
+        color: /^#[0-9a-f]{6}$/i.test(String(light?.color || "")) ? light.color : "#ffffff",
+        intensity: Math.max(0, Math.min(100000, Number(light?.intensity) || 0)),
+        distance: Math.max(0, Math.min(1000000, Number(light?.distance) || 0)),
+        angle: Math.max(1, Math.min(179, numberOr(light?.angle, 45))),
+        penumbra: Math.max(0, Math.min(1, numberOr(light?.penumbra, 0.2))),
+        cast_shadow: light?.cast_shadow !== false,
+        visible: light?.visible !== false,
+    }));
+    const quality = ["off", "low", "medium", "high", "ultra"].includes(shadows.quality)
+        ? shadows.quality
+        : "medium";
     return {
         preset,
         intensity: Math.max(0, Math.min(3, Number(data.intensity) || 0)),
@@ -55,6 +81,13 @@ export function normalizedLighting(value = {}) {
         elevation: Math.max(-10, Math.min(90, Number(data.elevation) || 0)),
         ambient: Math.max(0, Math.min(1.5, Number(data.ambient) || 0)),
         background,
+        shadows: {
+            enabled: shadows.enabled !== false && quality !== "off",
+            quality,
+            bias: Math.max(-0.1, Math.min(0.1, numberOr(shadows.bias, -0.0005))),
+            normal_bias: Math.max(0, Math.min(10, numberOr(shadows.normal_bias, 0.02))),
+        },
+        lights,
     };
 }
 
@@ -194,25 +227,32 @@ export function effectiveVisibleObjectIds(sceneData = {}) {
             .map(item => [item.object_id, item]),
     );
     const visible = new Set();
+    const hiddenBuildingIds = new Set(
+        (sceneData.architecture?.buildings || [])
+            .filter(building => building?.visible === false)
+            .map(building => building.building_id),
+    );
+    const objectVisible = item => item?.visible !== false
+        && (!item?.building_id || !hiddenBuildingIds.has(item.building_id));
     const layers = Array.isArray(sceneData.layers) ? sceneData.layers : [];
     const assigned = new Set();
     for (const layer of layers) {
         if (layer?.type === "object" && objects.has(layer.object_id)) {
             assigned.add(layer.object_id);
-            if (objects.get(layer.object_id).visible !== false) visible.add(layer.object_id);
+            if (objectVisible(objects.get(layer.object_id))) visible.add(layer.object_id);
             continue;
         }
         if (layer?.type !== "group" || !Array.isArray(layer.children)) continue;
         for (const objectId of layer.children) {
             if (!objects.has(objectId) || assigned.has(objectId)) continue;
             assigned.add(objectId);
-            if (layer.visible !== false && objects.get(objectId).visible !== false) {
+            if (layer.visible !== false && objectVisible(objects.get(objectId))) {
                 visible.add(objectId);
             }
         }
     }
     for (const [objectId, item] of objects) {
-        if (!assigned.has(objectId) && item.visible !== false) visible.add(objectId);
+        if (!assigned.has(objectId) && objectVisible(item)) visible.add(objectId);
     }
     return visible;
 }
@@ -568,6 +608,11 @@ export class Factory3DViewer {
             onStateChange: options.onStateChange || EMPTY,
             onLoadingChange: options.onLoadingChange || EMPTY,
             onError: options.onError || EMPTY,
+            onArchitectureSelection: options.onArchitectureSelection || EMPTY,
+            onArchitectureEdit: options.onArchitectureEdit || EMPTY,
+            snapPlanPoint: options.snapPlanPoint || ((point) => point),
+            onPlanGesture: options.onPlanGesture || EMPTY,
+            onPlanHover: options.onPlanHover || EMPTY,
             resolveAssetURL: options.resolveAssetURL || (value => value),
         };
         this.objects = new Map();
@@ -575,9 +620,17 @@ export class Factory3DViewer {
         this.selectedId = "";
         this.selectedGroupId = "";
         this.selectedGroupObjectIds = [];
+        this.architectureSelection = null;
         this._groupTransformStart = null;
         this.mode = "translate";
         this.gridVisible = false;
+        this.viewMode = "3d";
+        this.planTool = "select";
+        this.activeLevelId = "";
+        this.planCameraState = { target: [0, 0], zoom: 24 };
+        this.planGridState = { visible: true, step: 0.1, majorEvery: 10 };
+        this._planGridSignature = "";
+        this._planPan = null;
         this.captureWidth = 1024;
         this.captureHeight = 1024;
         this.captureFov = 42;
@@ -585,6 +638,7 @@ export class Factory3DViewer {
         this._capturing = false;
         this._disposed = false;
         this._loadingToken = 0;
+        this._sceneSetSerial = Promise.resolve();
         this._loadController = null;
         this._suppressTransform = false;
         this._suppressStateEvents = false;
@@ -606,6 +660,7 @@ export class Factory3DViewer {
         this._qualityRestoreTimer = 0;
         this._lightingUpdateTimer = 0;
         this._pendingLightingEntries = new Set();
+        this._lightingRigSignature = "";
         this.lighting = { ...DEFAULT_LIGHTING };
         this._lightColor = new THREE.Color(DEFAULT_LIGHTING.color);
         this._lightBaseGain = new THREE.Vector3(1, 1, 1);
@@ -627,7 +682,7 @@ export class Factory3DViewer {
         this.canvas.tabIndex = 0;
         this.canvas.setAttribute(
             "aria-label",
-            "3D scene. Click an object to select it, then drag the transform gizmo.",
+            "3D scene. Drag to look around in place, use the mouse wheel to move forward or backward, or click an object to select it.",
         );
         Object.assign(this.canvas.style, {
             width: "100%",
@@ -646,8 +701,19 @@ export class Factory3DViewer {
 
         this.scene = new THREE.Scene();
         this.scene.background = new THREE.Color("#171b25");
+        this.lightRig = new THREE.Group();
+        this.lightRig.name = "VNCCS Factory lights";
+        this.ambientLight = new THREE.AmbientLight("#ffffff", 0.5);
+        this.sunLight = new THREE.DirectionalLight("#fff1d6", 0.72);
+        this.sunLight.target.position.set(0, 0, 0);
+        this.lightRig.add(this.ambientLight, this.sunLight, this.sunLight.target);
+        this.scene.add(this.lightRig);
         this.camera = new THREE.PerspectiveCamera(42, 1, 0.0001, 100000);
         this.camera.position.set(2.8, 2.1, 4.2);
+        this.planCamera = new THREE.OrthographicCamera(-1, 1, 1, -1, 0.01, 10000);
+        this.planCamera.position.set(0, 1000, 0);
+        this.planCamera.up.set(0, 0, -1);
+        this.planCamera.lookAt(0, 0, 0);
         this.captureCamera = new THREE.PerspectiveCamera(42, 1, 0.0001, 100000);
 
         this.renderer = new THREE.WebGLRenderer({
@@ -659,6 +725,8 @@ export class Factory3DViewer {
             powerPreference: "high-performance",
         });
         this.renderer.outputColorSpace = THREE.SRGBColorSpace;
+        this.renderer.shadowMap.enabled = true;
+        this.renderer.shadowMap.type = THREE.PCFSoftShadowMap;
         this._nativePixelRatio = Math.min(window.devicePixelRatio || 1, 1.5);
         this.renderer.setPixelRatio(1);
 
@@ -683,6 +751,35 @@ export class Factory3DViewer {
         this.spark.onDirty = () => this.invalidate();
         this.setLighting(this.lighting);
         this.scene.add(this.spark);
+        this.architecture = new FactoryArchitectureRuntime(this.scene, {
+            resolveTexture: textureId => new THREE.TextureLoader().loadAsync(
+                this.options.resolveAssetURL(
+                    `/vnccs/3d-factory/scenes/${encodeURIComponent(this.sceneData?.scene_id || "")}`
+                    + `/textures/${encodeURIComponent(textureId)}`,
+                ),
+            ),
+        });
+        this.planOverlay = new THREE.Group();
+        this.planOverlay.name = "VNCCS Factory plan overlay";
+        this.planOverlay.visible = false;
+        this.planGridRoot = new THREE.Group();
+        this.planGridRoot.name = "VNCCS Factory plan grid";
+        this.planGridMinor = this._createPlanGridLines("#575269", 0.34, 1);
+        this.planGridMajor = this._createPlanGridLines("#8f82b4", 0.5, 2);
+        this.planGridAxis = this._createPlanGridLines("#d7ccff", 0.72, 3);
+        this.planGridRoot.add(this.planGridMinor, this.planGridMajor, this.planGridAxis);
+        this.planDraftRoot = new THREE.Group();
+        this.cameraMarkerRoot = new THREE.Group();
+        this.lightMarkerRoot = new THREE.Group();
+        this.architectureHandleRoot = new THREE.Group();
+        this.planOverlay.add(
+            this.planGridRoot,
+            this.planDraftRoot,
+            this.cameraMarkerRoot,
+            this.lightMarkerRoot,
+            this.architectureHandleRoot,
+        );
+        this.scene.add(this.planOverlay);
 
         this.controls = new OrbitControls(this.camera, this.canvas);
         this.controls.target.set(0, 0, 0);
@@ -690,6 +787,10 @@ export class Factory3DViewer {
         this.controls.dampingFactor = 0.08;
         this.controls.enablePan = true;
         this.controls.enableZoom = true;
+        // Viewport dragging is first-person look, not an implicit orbit around
+        // the world origin. OrbitControls still owns dolly and middle-button
+        // pan, while explicit framing commands choose a focus target.
+        this.controls.enableRotate = false;
         this.controls.minDistance = 0.0001;
         this.controls.maxDistance = 1_000_000;
         this.controls.mouseButtons = {
@@ -752,8 +853,14 @@ export class Factory3DViewer {
                     if (entry) {
                         const transform = this._meshTransform(entry.mesh);
                         entry.data.transform = transform;
-                        this.options.onTransformChange(this.selectedId, transform, { final: true });
+                        this.options.onTransformChange(this.selectedId, transform, {
+                            final: true,
+                            previous_transforms: this._singleTransformStart
+                                ? { [this.selectedId]: this._singleTransformStart }
+                                : {},
+                        });
                     }
+                    this._singleTransformStart = null;
                 }
                 this._flushDirectionalLighting();
                 this._emitState();
@@ -767,6 +874,7 @@ export class Factory3DViewer {
             } else {
                 const mesh = this.selectedId ? this.objects.get(this.selectedId)?.mesh : null;
                 this._scaleDragStart = mesh ? mesh.scale.x : 1;
+                this._singleTransformStart = mesh ? this._meshTransform(mesh) : null;
             }
         });
         this.transform.addEventListener("objectChange", () => this._onTransformObjectChange());
@@ -774,12 +882,229 @@ export class Factory3DViewer {
         this.raycaster = new THREE.Raycaster();
         this.pointer = new THREE.Vector2();
         this._pointerDown = null;
+        this._planDraw = null;
+        this._lookDrag = null;
         this.canvas.addEventListener("pointerdown", event => {
             try { this.canvas.focus({ preventScroll: true }); }
             catch (_) { this.canvas.focus(); }
             this._pointerDown = [event.clientX, event.clientY];
+            if (
+                this.viewMode === "3d"
+                && (event.button === 0 || event.button === 2)
+                && !this.transform.dragging
+                && !this.transform.axis
+            ) {
+                this._lookDrag = {
+                    pointerId: event.pointerId,
+                    button: event.button,
+                    x: event.clientX,
+                    y: event.clientY,
+                    originX: event.clientX,
+                    originY: event.clientY,
+                    moved: false,
+                };
+                this.canvas.setPointerCapture?.(event.pointerId);
+                if (event.button === 2) event.preventDefault();
+            }
+            if (this.viewMode === "plan" && event.button === 0 && this.planTool !== "select") {
+                const point = this.screenToPlan(event);
+                this._planDraw = {
+                    pointerId: event.pointerId,
+                    tool: this.planTool,
+                    originX: event.clientX,
+                    originY: event.clientY,
+                    moved: false,
+                };
+                this.canvas.setPointerCapture?.(event.pointerId);
+                this.options.onPlanGesture({
+                    phase: "start",
+                    tool: this.planTool,
+                    point,
+                    event,
+                    moved: false,
+                    distance: 0,
+                });
+                event.preventDefault();
+                return;
+            }
+            if (this.viewMode === "plan" && event.button === 0 && this.planTool === "select") {
+                const handle = this._planHandleHit(event);
+                if (handle) {
+                    const wall = handle.userData.factoryHandleType === "wall"
+                        ? this.sceneData?.architecture?.walls?.find(item => item.wall_id === handle.userData.factoryHandleId)
+                        : null;
+                    let fixedPoint = null;
+                    if (wall) {
+                        const other = handle.userData.endpoint === "start" ? wall.end : wall.start;
+                        const position = new THREE.Vector3(other[0], 0, other[1]);
+                        this.architecture.buildingRoots.get(wall.building_id)?.localToWorld(position);
+                        fixedPoint = [position.x, position.z];
+                    }
+                    this._architectureDrag = {
+                        type: handle.userData.factoryHandleType,
+                        id: handle.userData.factoryHandleId,
+                        endpoint: handle.userData.endpoint || "",
+                        fixedPoint,
+                        thickness: Number(wall?.thickness) || 0.12,
+                        handle,
+                    };
+                    this.canvas.setPointerCapture?.(event.pointerId);
+                    event.preventDefault();
+                    return;
+                }
+            }
+            if (this.viewMode === "plan" && (event.button === 1 || event.button === 2)) {
+                this._planPan = {
+                    x: event.clientX,
+                    y: event.clientY,
+                    target: [...this.planCameraState.target],
+                };
+                this.canvas.setPointerCapture?.(event.pointerId);
+                event.preventDefault();
+            }
+        });
+        this.canvas.addEventListener("pointermove", event => {
+            const drawing = this._planDraw;
+            if (drawing && drawing.pointerId === event.pointerId && this.viewMode === "plan") {
+                const distance = Math.hypot(
+                    event.clientX - drawing.originX,
+                    event.clientY - drawing.originY,
+                );
+                if (distance > 4) drawing.moved = true;
+                this.options.onPlanGesture({
+                    phase: "move",
+                    tool: drawing.tool,
+                    point: this.screenToPlan(event),
+                    event,
+                    moved: drawing.moved,
+                    distance,
+                });
+                event.preventDefault();
+                return;
+            }
+            const look = this._lookDrag;
+            if (look && look.pointerId === event.pointerId && this.viewMode === "3d") {
+                const deltaX = event.clientX - look.x;
+                const deltaY = event.clientY - look.y;
+                look.x = event.clientX;
+                look.y = event.clientY;
+                if (Math.hypot(event.clientX - look.originX, event.clientY - look.originY) > 3) {
+                    look.moved = true;
+                }
+                if (look.moved && (deltaX || deltaY)) {
+                    this.rotateCameraFPV(
+                        { yaw: -deltaX * 0.18, pitch: -deltaY * 0.18 },
+                        { emit: false },
+                    );
+                    this.canvas.style.cursor = "grabbing";
+                    event.preventDefault();
+                    return;
+                }
+            }
+            if (this._architectureDrag) {
+                const point = this.options.snapPlanPoint(
+                    this.screenToPlan(event),
+                    event,
+                    { origin: this._architectureDrag.fixedPoint },
+                );
+                const level = this.sceneData?.levels?.find(item => item.level_id === this.activeLevelId);
+                this._architectureDrag.handle.position.set(
+                    point[0],
+                    (Number(level?.elevation) || 0) + 0.055,
+                    point[1],
+                );
+                this._architectureDrag.point = point;
+                if (this._architectureDrag.fixedPoint) {
+                    this.setPlanDraft({
+                        tool: "wall",
+                        points: [this._architectureDrag.fixedPoint],
+                        cursor: point,
+                        thickness: this._architectureDrag.thickness,
+                    });
+                }
+                this.invalidate();
+                event.preventDefault();
+                return;
+            }
+            if (this.viewMode === "plan" && this.planTool !== "select" && !this._planPan) {
+                this.options.onPlanHover(this.planTool, this.screenToPlan(event), event);
+            }
+            if (this.viewMode !== "plan" || !this._planPan) return;
+            const zoom = Math.max(0.01, this.planCameraState.zoom);
+            this.planCameraState.target = [
+                this._planPan.target[0] - (event.clientX - this._planPan.x) / zoom,
+                this._planPan.target[1] + (event.clientY - this._planPan.y) / zoom,
+            ];
+            this._syncPlanCamera();
+            this.invalidate();
+            event.preventDefault();
+        });
+        this.canvas.addEventListener("pointerleave", event => {
+            if (
+                this.viewMode === "plan"
+                && this.planTool !== "select"
+                && !this._planPan
+                && !this._architectureDrag
+                && !this._planDraw
+            ) {
+                this.options.onPlanHover(this.planTool, null, event);
+            }
         });
         this.canvas.addEventListener("pointerup", event => {
+            const drawing = this._planDraw?.pointerId === event.pointerId ? this._planDraw : null;
+            if (drawing) {
+                const distance = Math.hypot(
+                    event.clientX - drawing.originX,
+                    event.clientY - drawing.originY,
+                );
+                drawing.moved = drawing.moved || distance > 4;
+                this._planDraw = null;
+                this._pointerDown = null;
+                this.canvas.releasePointerCapture?.(event.pointerId);
+                this.options.onPlanGesture({
+                    phase: "end",
+                    tool: drawing.tool,
+                    point: this.screenToPlan(event),
+                    event,
+                    moved: drawing.moved,
+                    distance,
+                });
+                event.preventDefault();
+                return;
+            }
+            const look = this._lookDrag?.pointerId === event.pointerId ? this._lookDrag : null;
+            if (look) {
+                this._lookDrag = null;
+                this.canvas.releasePointerCapture?.(event.pointerId);
+                this.canvas.style.cursor = "default";
+                if (look.moved) {
+                    this._pointerDown = null;
+                    this._cameraStateDirty = false;
+                    this._emitState();
+                    event.preventDefault();
+                    return;
+                }
+            }
+            if (this._architectureDrag) {
+                const drag = this._architectureDrag;
+                this._architectureDrag = null;
+                this.setPlanDraft(null);
+                this.canvas.releasePointerCapture?.(event.pointerId);
+                this.options.onArchitectureEdit({
+                    type: drag.type,
+                    id: drag.id,
+                    endpoint: drag.endpoint,
+                    point: drag.point || this.screenToPlan(event),
+                    event,
+                });
+                return;
+            }
+            if (this._planPan) {
+                this._planPan = null;
+                this.canvas.releasePointerCapture?.(event.pointerId);
+                this._emitState();
+                return;
+            }
             if (!this._pointerDown || this.transform.dragging) return;
             const distance = Math.hypot(
                 event.clientX - this._pointerDown[0],
@@ -789,19 +1114,58 @@ export class Factory3DViewer {
             if (distance > 4 || event.button !== 0) return;
             this._pick(event);
         });
+        this.canvas.addEventListener("contextmenu", event => {
+            if (this.viewMode === "plan" || this.viewMode === "3d") event.preventDefault();
+        });
+        const cancelLook = event => {
+            if (this._planDraw && (event.pointerId === undefined || this._planDraw.pointerId === event.pointerId)) {
+                const drawing = this._planDraw;
+                this._planDraw = null;
+                this._pointerDown = null;
+                this.options.onPlanGesture({
+                    phase: "cancel",
+                    tool: drawing.tool,
+                    point: null,
+                    event,
+                    moved: drawing.moved,
+                    distance: 0,
+                });
+            }
+            if (!this._lookDrag || (event.pointerId !== undefined && this._lookDrag.pointerId !== event.pointerId)) return;
+            this._lookDrag = null;
+            this._pointerDown = null;
+            this.canvas.style.cursor = "default";
+        };
+        this.canvas.addEventListener("pointercancel", cancelLook);
+        this.canvas.addEventListener("lostpointercapture", cancelLook);
+        this.canvas.addEventListener("wheel", event => {
+            if (this.viewMode === "3d") {
+                this.dollyCamera(-event.deltaY / 100, { emit: true });
+                event.preventDefault();
+                event.stopImmediatePropagation();
+                return;
+            }
+            if (this.viewMode !== "plan") return;
+            const before = this.screenToPlan(event);
+            this.planCameraState.zoom = Math.max(
+                0.01,
+                Math.min(100000, this.planCameraState.zoom * Math.exp(-event.deltaY * 0.001)),
+            );
+            this._syncPlanCamera();
+            const after = this.screenToPlan(event);
+            this.planCameraState.target[0] += before[0] - after[0];
+            this.planCameraState.target[1] += before[1] - after[1];
+            this._syncPlanCamera();
+            this.resize();
+            this._emitState();
+            event.preventDefault();
+        }, { capture: true, passive: false });
         this.canvas.addEventListener("keydown", event => {
             const mode = { w: "translate", e: "rotate", r: "scale" }[event.key.toLowerCase()];
             if (mode) {
                 event.preventDefault();
                 this.setMode(mode);
                 return;
-            }
-            if (event.key.toLowerCase() === "f") {
-                event.preventDefault();
-                this.fit(this.selectedId);
-            } else if (event.key === "Escape") {
-                event.preventDefault();
-                this.select("");
             }
         });
 
@@ -879,7 +1243,7 @@ export class Factory3DViewer {
             ? Math.min(0.1, Math.max(0, time - this._lastRenderTime) / 1000)
             : null;
         const cameraChanged = this.controls.update(deltaSeconds);
-        this.renderer.render(this.scene, this.camera);
+        this.renderer.render(this.scene, this.activeCamera());
         this._lastRenderTime = time;
         if (this._interactionReasons.size || cameraChanged || this._renderRequested) {
             this.invalidate();
@@ -898,6 +1262,58 @@ export class Factory3DViewer {
         entry.splat.objectModifier = lightingModifier.modifier;
         entry.splat.updateGenerator();
         this._syncDirectionalLighting(entry, { regenerate: false });
+    }
+
+    _attachShadowProxy(entry) {
+        if (!entry?.mesh || !entry?.localBounds || entry.localBounds.isEmpty()) return;
+        const center = entry.localBounds.getCenter(new THREE.Vector3());
+        const size = entry.localBounds.getSize(new THREE.Vector3());
+        const geometry = new THREE.BoxGeometry(
+            Math.max(0.001, size.x),
+            Math.max(0.001, size.y),
+            Math.max(0.001, size.z),
+        );
+        geometry.translate(center.x, center.y, center.z);
+        const material = new THREE.MeshBasicMaterial({
+            colorWrite: false,
+            depthWrite: false,
+            transparent: true,
+            opacity: 0,
+        });
+        const proxy = new THREE.Mesh(geometry, material);
+        proxy.name = "VNCCS Gaussian shadow proxy";
+        proxy.customDepthMaterial = new THREE.MeshDepthMaterial({
+            depthPacking: THREE.RGBADepthPacking,
+            side: THREE.DoubleSide,
+        });
+        proxy.castShadow = true;
+        proxy.receiveShadow = false;
+        proxy.userData.factoryShadowProxy = true;
+        entry.mesh.add(proxy);
+        entry.shadowProxy = proxy;
+        this._syncShadowProxy(entry);
+    }
+
+    _syncShadowProxy(entry) {
+        if (!entry?.shadowProxy) return;
+        const transport = String(entry.data?.light_transport || "opaque");
+        entry.shadowProxy.visible = Boolean(
+            this.lighting.shadows?.enabled
+            && this.lighting.shadows?.quality !== "off"
+            && transport === "opaque",
+        );
+    }
+
+    _disposeEntry(entry) {
+        if (!entry) return;
+        if (entry.shadowProxy) {
+            entry.shadowProxy.geometry?.dispose?.();
+            entry.shadowProxy.material?.dispose?.();
+            entry.shadowProxy.customDepthMaterial?.dispose?.();
+            entry.shadowProxy.parent?.remove(entry.shadowProxy);
+            entry.shadowProxy = null;
+        }
+        entry.splat?.dispose?.();
     }
 
     _syncDirectionalLighting(entry, { regenerate = true } = {}) {
@@ -926,7 +1342,197 @@ export class Factory3DViewer {
             .normalize();
         state.baseGain.value.copy(this._lightBaseGain);
         state.directionalScale.value.copy(this._lightDirectionalScale);
+        if (this.lighting.shadows?.enabled && this.lighting.shadows?.quality !== "off") {
+            state.directionalScale.value.multiplyScalar(this._directionalVisibility(entry));
+        }
+        this._applyLocalLightGain(entry, state.baseGain.value);
         if (regenerate) entry.splat.updateVersion();
+    }
+
+    _directionalVisibility(targetEntry) {
+        return this._visibilityAlongRay(targetEntry, this._lightSourceWorld, 1000000);
+    }
+
+    _visibilityAlongRay(targetEntry, directionValue, far = 1000000) {
+        const bounds = targetEntry.localBounds?.clone().applyMatrix4(targetEntry.mesh.matrixWorld);
+        if (!bounds || bounds.isEmpty()) return 1;
+        const direction = directionValue.clone().normalize();
+        const origin = bounds.getCenter(new THREE.Vector3())
+            .addScaledVector(direction, 0.01);
+        const ray = new THREE.Ray(origin, direction);
+        let visibility = 1;
+        for (const [objectId, entry] of this.objects) {
+            if (entry === targetEntry || entry.mesh.visible === false) continue;
+            const blocker = entry.localBounds?.clone().applyMatrix4(entry.mesh.matrixWorld);
+            const intersection = blocker && !blocker.isEmpty()
+                ? ray.intersectBox(blocker, new THREE.Vector3())
+                : null;
+            if (!intersection || intersection.distanceTo(origin) > far) continue;
+            if (entry.data?.light_transport === "transmissive") {
+                const transmission = Number(entry.data.transmission);
+                visibility *= Math.max(0, Math.min(1, Number.isFinite(transmission) ? transmission : 1));
+            } else if (entry.data?.light_transport === "cutout") {
+                visibility *= 0.55;
+            } else {
+                return 0;
+            }
+            if (visibility <= 0.02) return 0;
+        }
+        const raycaster = new THREE.Raycaster(origin, direction, 0.01, far);
+        const hits = raycaster.intersectObject(this.architecture?.root, true);
+        for (const hit of hits) {
+            if (hit.object.userData?.ignoreLightOcclusion) continue;
+            const material = Array.isArray(hit.object.material)
+                ? hit.object.material[hit.face?.materialIndex || 0]
+                : hit.object.material;
+            if (!material) continue;
+            if (material.transmission > 0 || material.transparent) {
+                const opacity = Number(material.opacity);
+                visibility *= Math.max(
+                    Number(material.transmission) || 0,
+                    1 - (Number.isFinite(opacity) ? opacity : 1),
+                );
+            } else {
+                return 0;
+            }
+            if (visibility <= 0.02) return 0;
+        }
+        return Math.max(0, Math.min(1, visibility));
+    }
+
+    _applyLocalLightGain(entry, target) {
+        if (!this.lighting.lights?.length || !entry.localBounds) return;
+        const center = entry.localBounds.clone().applyMatrix4(entry.mesh.matrixWorld)
+            .getCenter(new THREE.Vector3());
+        const shadowBudget = { low: 2, medium: 4, high: 6, ultra: 8 }[
+            this.lighting.shadows?.quality
+        ] || 0;
+        let shadowCount = 0;
+        for (const light of this.lighting.lights) {
+            if (light.visible === false || light.intensity <= 0) continue;
+            const owner = this.sceneData?.architecture?.buildings?.find(
+                building => building.building_id === light.building_id,
+            );
+            if (owner?.visible === false) continue;
+            if (
+                light.level_id
+                && entry.data?.level_id
+                && light.level_id !== entry.data.level_id
+            ) continue;
+            const color = new THREE.Color(light.color);
+            let response = light.intensity * 0.12;
+            let lightDirection;
+            let maximumDistance = 1000000;
+            if (light.kind !== "directional") {
+                const source = new THREE.Vector3().fromArray(light.position);
+                const distance = center.distanceTo(source);
+                if (light.distance > 0 && distance > light.distance) continue;
+                if (light.kind === "spot") {
+                    const spotDirection = new THREE.Vector3().fromArray(light.target).sub(source).normalize();
+                    const toObject = center.clone().sub(source).normalize();
+                    const cosine = spotDirection.dot(toObject);
+                    const edge = Math.cos(THREE.MathUtils.degToRad(light.angle));
+                    if (cosine < edge) continue;
+                    const softness = Math.max(0.001, 1 - edge);
+                    response *= Math.max(0, Math.min(1, (cosine - edge) / softness));
+                }
+                response /= Math.max(1, distance * distance);
+                lightDirection = source.sub(center).normalize();
+                maximumDistance = Math.max(0.01, distance - 0.02);
+            } else {
+                lightDirection = new THREE.Vector3().fromArray(light.position)
+                    .sub(new THREE.Vector3().fromArray(light.target));
+                if (lightDirection.lengthSq() < 1e-12) lightDirection.set(0, 1, 0);
+                lightDirection.normalize();
+            }
+            if (
+                light.cast_shadow
+                && this.lighting.shadows?.enabled
+                && this.lighting.shadows?.quality !== "off"
+                && shadowCount < shadowBudget
+            ) {
+                response *= this._visibilityAlongRay(entry, lightDirection, maximumDistance);
+                shadowCount += 1;
+            }
+            target.x += color.r * response;
+            target.y += color.g * response;
+            target.z += color.b * response;
+        }
+    }
+
+    _syncThreeLights() {
+        const qualitySizes = { low: 512, medium: 1024, high: 2048, ultra: 4096 };
+        const shadowsEnabled = Boolean(
+            this.lighting.shadows?.enabled && this.lighting.shadows?.quality !== "off",
+        );
+        this.ambientLight.intensity = this.lighting.preset === "off" ? 1 : this.lighting.ambient;
+        this.sunLight.color.set(this.lighting.color);
+        this.sunLight.intensity = this.lighting.preset === "off" ? 0 : this.lighting.intensity;
+        this.sunLight.position.copy(this._lightSourceWorld).multiplyScalar(100);
+        this.sunLight.castShadow = shadowsEnabled;
+        const mapSize = qualitySizes[this.lighting.shadows?.quality] || 1024;
+        this.sunLight.shadow.mapSize.set(mapSize, mapSize);
+        this.sunLight.shadow.bias = this.lighting.shadows?.bias ?? -0.0005;
+        this.sunLight.shadow.normalBias = this.lighting.shadows?.normal_bias ?? 0.02;
+        this.sunLight.shadow.camera.left = -50;
+        this.sunLight.shadow.camera.right = 50;
+        this.sunLight.shadow.camera.top = 50;
+        this.sunLight.shadow.camera.bottom = -50;
+        for (const child of [...this.lightRig.children]) {
+            if ([this.ambientLight, this.sunLight, this.sunLight.target].includes(child)) continue;
+            this.lightRig.remove(child);
+            child.shadow?.map?.dispose?.();
+        }
+        const shadowLightBudget = { low: 2, medium: 4, high: 6, ultra: 8 }[
+            this.lighting.shadows?.quality
+        ] || 0;
+        let shadowLightCount = 0;
+        for (const data of this.lighting.lights || []) {
+            if (this.viewMode === "plan" && data.level_id && data.level_id !== this.activeLevelId) continue;
+            const owner = this.sceneData?.architecture?.buildings?.find(
+                building => building.building_id === data.building_id,
+            );
+            if (owner?.visible === false) continue;
+            let light;
+            if (data.kind === "spot") {
+                light = new THREE.SpotLight(
+                    data.color,
+                    data.intensity,
+                    data.distance,
+                    THREE.MathUtils.degToRad(data.angle),
+                    data.penumbra,
+                );
+            } else if (data.kind === "directional") {
+                light = new THREE.DirectionalLight(data.color, data.intensity);
+            } else {
+                light = new THREE.PointLight(data.color, data.intensity, data.distance);
+            }
+            light.name = data.name || "Factory light";
+            light.position.fromArray(data.position);
+            light.visible = data.visible !== false;
+            light.castShadow = Boolean(
+                data.cast_shadow
+                && shadowsEnabled
+                && shadowLightCount < shadowLightBudget,
+            );
+            if (light.castShadow) shadowLightCount += 1;
+            if (light.shadow) {
+                light.shadow.mapSize.set(mapSize, mapSize);
+                light.shadow.bias = this.lighting.shadows?.bias ?? -0.0005;
+                light.shadow.normalBias = this.lighting.shadows?.normal_bias ?? 0.02;
+                if (data.kind === "directional") {
+                    light.shadow.camera.left = -25;
+                    light.shadow.camera.right = 25;
+                    light.shadow.camera.top = 25;
+                    light.shadow.camera.bottom = -25;
+                }
+            }
+            if (light.target) {
+                light.target.position.fromArray(data.target);
+                this.lightRig.add(light.target);
+            }
+            this.lightRig.add(light);
+        }
     }
 
     _scheduleDirectionalLighting(entry, { immediate = false } = {}) {
@@ -958,6 +1564,7 @@ export class Factory3DViewer {
 
     setLighting(value = {}) {
         this.lighting = normalizedLighting({ ...DEFAULT_LIGHTING, ...value });
+        this.setLightMarkers?.(this.lighting.lights || []);
         lightSourceDirection(
             this.lighting.azimuth,
             this.lighting.elevation,
@@ -983,8 +1590,14 @@ export class Factory3DViewer {
             this._lightBaseGain.set(1, 1, 1);
             this._lightDirectionalScale.set(0, 0, 0);
         }
+        const rigSignature = JSON.stringify(this.lighting);
+        if (rigSignature !== this._lightingRigSignature) {
+            this._syncThreeLights();
+            this._lightingRigSignature = rigSignature;
+        }
         let regenerated = false;
         for (const entry of this.objects.values()) {
+            this._syncShadowProxy(entry);
             this._syncDirectionalLighting(entry);
             regenerated = true;
         }
@@ -1148,6 +1761,104 @@ export class Factory3DViewer {
         return total;
     }
 
+    _createPlanGridLines(color, opacity, renderOrder) {
+        const lines = new THREE.LineSegments(
+            new THREE.BufferGeometry(),
+            new THREE.LineBasicMaterial({
+                color,
+                transparent: true,
+                opacity,
+                depthTest: false,
+                depthWrite: false,
+                toneMapped: false,
+            }),
+        );
+        lines.name = "VNCCS Factory plan grid lines";
+        lines.renderOrder = renderOrder;
+        lines.frustumCulled = false;
+        // The grid is an editor guide, never an architecture selection target.
+        lines.raycast = EMPTY;
+        return lines;
+    }
+
+    _setPlanGridGeometry(lines, positions) {
+        const previous = lines.geometry;
+        const geometry = new THREE.BufferGeometry();
+        geometry.setAttribute("position", new THREE.Float32BufferAttribute(positions, 3));
+        lines.geometry = geometry;
+        previous?.dispose?.();
+    }
+
+    _syncPlanGrid() {
+        if (!this.planGridRoot || !this.planCamera) return;
+        const state = this.planGridState || {};
+        this.planGridRoot.visible = state.visible !== false;
+        if (!this.planGridRoot.visible) return;
+
+        const targetX = Number(this.planCameraState.target?.[0]) || 0;
+        const targetZ = Number(this.planCameraState.target?.[1]) || 0;
+        const width = Math.max(0.001, this.planCamera.right - this.planCamera.left);
+        const depth = Math.max(0.001, this.planCamera.top - this.planCamera.bottom);
+        const configuredStep = Math.max(0.001, Math.min(1000, Number(state.step) || 0.1));
+        let displayStep = configuredStep;
+        while (
+            width / displayStep > MAX_PLAN_GRID_LINES_PER_AXIS
+            || depth / displayStep > MAX_PLAN_GRID_LINES_PER_AXIS
+        ) {
+            displayStep *= 10;
+        }
+        const majorEvery = Math.max(2, Math.min(100, Math.round(Number(state.majorEvery) || 10)));
+        const level = this.sceneData?.levels?.find(item => item.level_id === this.activeLevelId);
+        const elevation = Number(level?.elevation) || 0;
+        const minX = targetX + this.planCamera.left - displayStep;
+        const maxX = targetX + this.planCamera.right + displayStep;
+        const minZ = targetZ - depth * 0.5 - displayStep;
+        const maxZ = targetZ + depth * 0.5 + displayStep;
+        const startX = Math.floor(minX / displayStep);
+        const endX = Math.ceil(maxX / displayStep);
+        const startZ = Math.floor(minZ / displayStep);
+        const endZ = Math.ceil(maxZ / displayStep);
+        const signature = [
+            startX,
+            endX,
+            startZ,
+            endZ,
+            elevation,
+            configuredStep,
+            displayStep,
+            majorEvery,
+        ].map(value => Number(value).toPrecision(12)).join("|");
+        if (signature === this._planGridSignature) return;
+        this._planGridSignature = signature;
+        this.planGridRoot.position.y = elevation + 0.035;
+
+        const minor = [];
+        const major = [];
+        const axis = [];
+        const append = (positions, ax, az, bx, bz) => {
+            positions.push(ax, 0, az, bx, 0, bz);
+        };
+        const selectBucket = index => {
+            if (index === 0) return axis;
+            return Math.abs(index) % majorEvery === 0 ? major : minor;
+        };
+        const gridMinX = startX * displayStep;
+        const gridMaxX = endX * displayStep;
+        const gridMinZ = startZ * displayStep;
+        const gridMaxZ = endZ * displayStep;
+        for (let index = startX; index <= endX; index += 1) {
+            const x = index * displayStep;
+            append(selectBucket(index), x, gridMinZ, x, gridMaxZ);
+        }
+        for (let index = startZ; index <= endZ; index += 1) {
+            const z = index * displayStep;
+            append(selectBucket(index), gridMinX, z, gridMaxX, z);
+        }
+        this._setPlanGridGeometry(this.planGridMinor, minor);
+        this._setPlanGridGeometry(this.planGridMajor, major);
+        this._setPlanGridGeometry(this.planGridAxis, axis);
+    }
+
     _desiredPixelRatio(width, height) {
         const interactive = Boolean(this._interactiveQuality);
         const heavy = this._totalGaussianCount() >= HEAVY_SCENE_GAUSSIANS;
@@ -1189,6 +1900,7 @@ export class Factory3DViewer {
             : pixelRatio;
         const ratioChanged = Math.abs(pixelRatio - currentPixelRatio) > 1e-4;
         this._updateCameraProjection(width, height);
+        this._updatePlanProjection(width, height);
         this._updateCameraFrame(width, height);
         if (ratioChanged) {
             this.renderer.setPixelRatio(pixelRatio);
@@ -1250,11 +1962,47 @@ export class Factory3DViewer {
         this.camera.updateProjectionMatrix();
     }
 
+    _updatePlanProjection(width = 0, height = 0) {
+        const viewWidth = Math.max(1, Number(width) || this.host.clientWidth || 1);
+        const viewHeight = Math.max(1, Number(height) || this.host.clientHeight || 1);
+        const zoom = Math.max(0.01, Number(this.planCameraState.zoom) || 24);
+        this.planCamera.left = -viewWidth / (2 * zoom);
+        this.planCamera.right = viewWidth / (2 * zoom);
+        this.planCamera.top = viewHeight / (2 * zoom);
+        this.planCamera.bottom = -viewHeight / (2 * zoom);
+        this.planCamera.updateProjectionMatrix();
+        this._syncPlanCamera();
+    }
+
+    _syncPlanCamera() {
+        const [x, z] = this.planCameraState.target;
+        const level = this.sceneData?.levels?.find(item => item.level_id === this.activeLevelId);
+        const elevation = Number(level?.elevation) || 0;
+        this.planCamera.position.set(x, elevation + 1000, z);
+        this.planCamera.lookAt(x, elevation, z);
+        this.planCamera.updateMatrixWorld(true);
+        this._syncPlanGrid();
+    }
+
+    activeCamera() {
+        return this.viewMode === "plan" ? this.planCamera : this.camera;
+    }
+
+    screenToPlan(event) {
+        const rect = this.canvas.getBoundingClientRect();
+        const point = new THREE.Vector3(
+            ((event.clientX - rect.left) / Math.max(1, rect.width)) * 2 - 1,
+            -((event.clientY - rect.top) / Math.max(1, rect.height)) * 2 + 1,
+            0,
+        ).unproject(this.planCamera);
+        return [Number(point.x.toFixed(6)), Number(point.z.toFixed(6))];
+    }
+
     _updateCameraFrame(width = 0, height = 0) {
         if (!this.cameraFrame) return;
         const layout = this._cameraFrameLayout(width, height);
         Object.assign(this.cameraFrame.style, {
-            display: this.cameraFrameVisible ? "block" : "none",
+            display: this.viewMode === "3d" && this.cameraFrameVisible ? "block" : "none",
             left: `${layout.left}px`,
             top: `${layout.top}px`,
             width: `${layout.width}px`,
@@ -1269,12 +2017,26 @@ export class Factory3DViewer {
             ((event.clientX - rect.left) / Math.max(1, rect.width)) * 2 - 1,
             -((event.clientY - rect.top) / Math.max(1, rect.height)) * 2 + 1,
         );
-        this.raycaster.setFromCamera(this.pointer, this.camera);
+        this.raycaster.setFromCamera(this.pointer, this.activeCamera());
+        const editorHits = [
+            ...this.raycaster.intersectObject(this.planOverlay, true),
+            ...this.raycaster.intersectObject(this.architecture.root, true),
+        ].sort((left, right) => left.distance - right.distance);
+        const architectureHit = editorHits.find(hit => hit.object?.userData?.factoryId);
         // Per-Gaussian raycasting creates long pointer tasks on dense scenes.
         // Robust trimmed bounds already describe every object well enough for
         // editor selection and keep this operation O(number of objects).
         const hit = boundedObjectHit(this.raycaster.ray, this.objects);
-        this.select(hit?.objectId || "", { additive: event.shiftKey });
+        if (architectureHit && (!hit || architectureHit.distance < hit.distance)) {
+            this.select("");
+            this.options.onArchitectureSelection({
+                type: architectureHit.object.userData.factoryType,
+                id: architectureHit.object.userData.factoryId,
+                wallId: architectureHit.object.userData.wallId || "",
+            });
+            return;
+        }
+        if (hit?.objectId) this.select(hit.objectId, { additive: event.shiftKey });
     }
 
     _applyTransform(mesh, value) {
@@ -1342,13 +2104,18 @@ export class Factory3DViewer {
         if (this.mode === "rotate") this._scheduleDirectionalLighting(entry);
         this.spark.setDirty?.();
         this.invalidate();
-        this.options.onTransformChange(this.selectedId, transform, { final: !this.transform.dragging });
+        this.options.onTransformChange(this.selectedId, transform, {
+            final: !this.transform.dragging,
+            previous_transforms: this._singleTransformStart
+                ? { [this.selectedId]: this._singleTransformStart }
+                : {},
+        });
     }
 
     _groupEntries() {
         return this.selectedGroupObjectIds
             .map(objectId => [objectId, this.objects.get(objectId)])
-            .filter(([, entry]) => Boolean(entry));
+            .filter(([, entry]) => Boolean(entry) && entry.data?.locked !== true);
     }
 
     _groupWorldBounds() {
@@ -1387,11 +2154,13 @@ export class Factory3DViewer {
         const pivotMatrix = this.groupPivot.matrixWorld.clone();
         const inversePivot = pivotMatrix.clone().invert();
         const objects = new Map();
+        const previousTransforms = {};
         for (const [objectId, entry] of this._groupEntries()) {
             entry.mesh.updateMatrixWorld(true);
             objects.set(objectId, entry.mesh.matrixWorld.clone());
+            previousTransforms[objectId] = this._meshTransform(entry.mesh);
         }
-        this._groupTransformStart = { pivotMatrix, inversePivot, objects };
+        this._groupTransformStart = { pivotMatrix, inversePivot, objects, previousTransforms };
     }
 
     _applyGroupTransform(final = false) {
@@ -1404,7 +2173,8 @@ export class Factory3DViewer {
         const position = new THREE.Vector3();
         const quaternion = new THREE.Quaternion();
         const scale = new THREE.Vector3();
-        for (const [objectId, original] of baseline.objects) {
+        const baselineEntries = Array.from(baseline.objects.entries());
+        for (const [entryIndex, [objectId, original]] of baselineEntries.entries()) {
             const entry = this.objects.get(objectId);
             if (!entry) continue;
             const matrix = delta.clone().multiply(original);
@@ -1425,6 +2195,8 @@ export class Factory3DViewer {
             this.options.onTransformChange(objectId, transform, {
                 final,
                 group_id: this.selectedGroupId,
+                previous_transforms: baseline.previousTransforms,
+                command_last: entryIndex === baselineEntries.length - 1,
             });
         }
         this._refreshSelectionBounds();
@@ -1433,6 +2205,7 @@ export class Factory3DViewer {
         this.invalidate();
         if (final) {
             this._groupTransformStart = null;
+            this._singleTransformStart = null;
         }
     }
 
@@ -1461,7 +2234,16 @@ export class Factory3DViewer {
         this.selectionBounds.updateMatrixWorld(true);
     }
 
-    async setScene(sceneData, { incremental = false } = {}) {
+    setScene(sceneData, options = {}) {
+        const operation = this._sceneSetSerial.then(
+            () => this._setSceneNow(sceneData, options),
+        );
+        this._sceneSetSerial = operation.catch(() => null);
+        return operation;
+    }
+
+    async _setSceneNow(sceneData, { incremental = false } = {}) {
+        if (this._disposed) return { loaded: 0, failures: [] };
         const previousCount = this.objects.size;
         const token = incremental
             ? (this._loadingToken || ++this._loadingToken)
@@ -1470,6 +2252,12 @@ export class Factory3DViewer {
         const loadController = new AbortController();
         this._loadController = loadController;
         this.sceneData = sceneData || { objects: [] };
+        this.activeLevelId = this.activeLevelId || this.sceneData.levels?.[0]?.level_id || "";
+        await this.architecture.set(this.sceneData);
+        if (this._disposed) return { loaded: 0, failures: [] };
+        this.architecture.sceneData = this.sceneData;
+        this.architecture.setActiveLevel(this.activeLevelId, this.viewMode === "plan");
+        this.setCameraMarkers(this.sceneData.cameras || []);
         this.setLighting(this.sceneData.lighting);
         const skydomePromise = this.setSkydome(this.sceneData.skydome);
         const source = Array.isArray(sceneData?.objects) ? sceneData.objects : [];
@@ -1485,7 +2273,7 @@ export class Factory3DViewer {
             this.selectedGroupObjectIds = [];
             for (const entry of this.objects.values()) {
                 this.scene.remove(entry.mesh);
-                entry.splat?.dispose?.();
+                this._disposeEntry(entry);
             }
             this.objects.clear();
         }
@@ -1497,7 +2285,7 @@ export class Factory3DViewer {
                 if (objectId === this.selectedId) this.selectedId = "";
                 this.selectedGroupObjectIds = this.selectedGroupObjectIds.filter(id => id !== objectId);
                 this.scene.remove(entry.mesh);
-                entry.splat?.dispose?.();
+                this._disposeEntry(entry);
                 this.objects.delete(objectId);
             }
         }
@@ -1517,12 +2305,13 @@ export class Factory3DViewer {
                     existing.splat.name = item.name || item.object_id;
                     existing.mesh.visible = visibleIds.has(item.object_id);
                     this._applyTransform(existing.mesh, item.transform);
+                    this._syncShadowProxy(existing);
                     this._syncDirectionalLighting(existing);
                     continue;
                 }
                 if (existing) {
                     this.scene.remove(existing.mesh);
-                    existing.splat?.dispose?.();
+                    this._disposeEntry(existing);
                     this.objects.delete(item.object_id);
                 }
                 const assetURL = this.options.resolveAssetURL(assetPath);
@@ -1610,6 +2399,7 @@ export class Factory3DViewer {
                     assetPath,
                 };
                 this.objects.set(item.object_id, entry);
+                this._attachShadowProxy(entry);
                 this._attachDirectionalLighting(entry);
                 this.spark.setDirty?.();
                 this.resize();
@@ -1648,10 +2438,14 @@ export class Factory3DViewer {
         if (this.selectedGroupId && this.selectedGroupObjectIds.some(id => this.objects.has(id))) {
             this.selectGroup(this.selectedGroupId, this.selectedGroupObjectIds);
         } else if (this.selectedId && this.objects.has(this.selectedId)) this.select(this.selectedId);
-        else {
+        else if (!incremental) {
             const firstVisible = source.find(item => visibleIds.has(item.object_id));
             if (firstVisible && this.objects.has(firstVisible.object_id)) this.select(firstVisible.object_id);
             else this.select("");
+        } else {
+            // Incremental geometry/history refreshes must not manufacture a
+            // Gaussian selection and replace an open architecture Inspector.
+            this.select("");
         }
         if (this.objects.size && (!incremental || previousCount === 0)) this.fit();
         this.resize();
@@ -1667,10 +2461,20 @@ export class Factory3DViewer {
             entry.mesh.name = value.name || objectId;
             entry.splat.name = value.name || objectId;
         }
-        if ("visible" in value) entry.mesh.visible = value.visible !== false;
+        if ("visible" in value || "level_id" in value || "building_id" in value) {
+            const visibleIds = effectiveVisibleObjectIds(this.sceneData || {});
+            entry.mesh.visible = visibleIds.has(objectId)
+                && (this.viewMode !== "plan" || !entry.data.level_id || entry.data.level_id === this.activeLevelId);
+        }
+        this._syncShadowProxy(entry);
         if (value.transform) {
             this._applyTransform(entry.mesh, value.transform);
-            this._syncDirectionalLighting(entry);
+            for (const candidate of this.objects.values()) {
+                this._syncDirectionalLighting(candidate);
+            }
+        }
+        if ("locked" in value && objectId === this.selectedId) {
+            this.transform.enabled = this.viewMode === "3d" && value.locked !== true;
         }
         if (objectId === this.selectedId || this.selectedGroupObjectIds.includes(objectId)) {
             this._refreshSelectionBounds();
@@ -1684,7 +2488,8 @@ export class Factory3DViewer {
         this.sceneData = sceneData || this.sceneData;
         const visibleIds = effectiveVisibleObjectIds(this.sceneData || {});
         for (const [objectId, entry] of this.objects) {
-            entry.mesh.visible = visibleIds.has(objectId);
+            entry.mesh.visible = visibleIds.has(objectId)
+                && (this.viewMode !== "plan" || !entry.data.level_id || entry.data.level_id === this.activeLevelId);
         }
         this._refreshSelectionBounds();
         this.spark.setDirty?.();
@@ -1704,18 +2509,15 @@ export class Factory3DViewer {
         const children = Array.from(new Set(
             Array.isArray(group?.children) ? group.children : objectIds,
         ));
-        const objects = new Map(
-            (Array.isArray(this.sceneData?.objects) ? this.sceneData.objects : [])
-                .filter(item => item?.object_id)
-                .map(item => [item.object_id, item]),
-        );
         const showGroup = Boolean(visible);
         if (group) group.visible = showGroup;
+        const visibleIds = effectiveVisibleObjectIds(this.sceneData || {});
         let hasVisibleChild = false;
         for (const objectId of children) {
             const entry = this.objects.get(objectId);
             if (!entry) continue;
-            const childVisible = showGroup && objects.get(objectId)?.visible !== false;
+            const childVisible = visibleIds.has(objectId)
+                && (this.viewMode !== "plan" || !entry.data.level_id || entry.data.level_id === this.activeLevelId);
             entry.mesh.visible = childVisible;
             hasVisibleChild ||= childVisible;
         }
@@ -1741,6 +2543,9 @@ export class Factory3DViewer {
         this._groupTransformStart = null;
         if (id) this.transform.attach(this.objects.get(id).mesh);
         else this.transform.detach();
+        this.transform.enabled = this.viewMode === "3d"
+            && Boolean(id)
+            && this.objects.get(id)?.data?.locked !== true;
         this._refreshSelectionBounds();
         this.options.onSelectionChange(id, { additive });
         this._emitState();
@@ -1760,6 +2565,34 @@ export class Factory3DViewer {
         this.invalidate();
     }
 
+    getGroupPivotPosition() {
+        if (!this.selectedGroupId) return [0, 0, 0];
+        this._configureGroupPivot();
+        return this.groupPivot.position.toArray();
+    }
+
+    applyGroupDelta({ position, rotation, scale } = {}) {
+        if (!this.selectedGroupId) return false;
+        this._configureGroupPivot();
+        this._beginGroupTransform();
+        if (!this._groupTransformStart) return false;
+        if (Array.isArray(position) && position.length === 3) {
+            this.groupPivot.position.fromArray(position.map(Number));
+        }
+        const angles = Array.isArray(rotation) ? rotation.map(Number) : [0, 0, 0];
+        this.groupPivot.rotation.set(
+            radians(angles[0] || 0),
+            radians(angles[1] || 0),
+            radians(angles[2] || 0),
+            "XYZ",
+        );
+        this.groupPivot.scale.setScalar(Math.max(0.001, Math.min(1000, Number(scale) || 1)));
+        this.groupPivot.updateMatrixWorld(true);
+        this._applyGroupTransform(true);
+        this._configureGroupPivot();
+        return true;
+    }
+
     setMode(mode) {
         if (!["translate", "rotate", "scale"].includes(mode)) return;
         this.mode = mode;
@@ -1773,9 +2606,557 @@ export class Factory3DViewer {
 
     setGrid(visible) {
         this.gridVisible = Boolean(visible);
-        this.grid.visible = this.gridVisible;
+        this.grid.visible = this.gridVisible && this.viewMode === "3d";
         this._emitState();
         this.invalidate();
+    }
+
+    setPlanGrid(value = {}) {
+        const next = {
+            visible: value.visible !== false,
+            step: Math.max(0.001, Math.min(1000, Number(value.step) || 0.1)),
+            majorEvery: Math.max(2, Math.min(100, Math.round(Number(value.majorEvery) || 10))),
+        };
+        const previous = this.planGridState || {};
+        const changed = previous.visible !== next.visible
+            || previous.step !== next.step
+            || previous.majorEvery !== next.majorEvery;
+        this.planGridState = next;
+        if (!changed) return;
+        this._planGridSignature = "";
+        this._syncPlanGrid();
+        this.invalidate();
+    }
+
+    setViewMode(mode) {
+        const next = mode === "plan" ? "plan" : "3d";
+        if (next === this.viewMode) return;
+        this.viewMode = next;
+        this.controls.enabled = next === "3d" && !this.transform.dragging;
+        this.transform.camera = this.activeCamera();
+        const selectionEditable = this.selectedGroupId
+            ? this._groupEntries().length > 0
+            : Boolean(this.selectedId) && this.objects.get(this.selectedId)?.data?.locked !== true;
+        this.transform.enabled = next === "3d" && selectionEditable;
+        this.transformHelper.visible = next === "3d" && Boolean(this.selectedId || this.selectedGroupId);
+        this.cameraFrame.style.display = next === "3d" && this.cameraFrameVisible ? "block" : "none";
+        this.grid.visible = next === "3d" && this.gridVisible;
+        this.architecture.setActiveLevel(this.activeLevelId, next === "plan");
+        this.applySceneVisibility(this.sceneData);
+        this._syncThreeLights();
+        this.planOverlay.visible = next === "plan";
+        this.canvas.style.cursor = next === "plan" && this.planTool !== "select"
+            ? "crosshair"
+            : "default";
+        if (next === "plan") this._syncPlanGrid();
+        this.resize();
+        this.spark.setDirty?.();
+        this._emitState();
+        this.invalidate();
+    }
+
+    setPlanTool(tool) {
+        if (!["select", "wall", "room", "opening", "camera"].includes(tool)) return;
+        this.planTool = tool;
+        this.canvas.style.cursor = this.viewMode === "plan" && tool !== "select" ? "crosshair" : "default";
+        this._emitState();
+    }
+
+    _clearPlanRoot(root) {
+        for (const child of [...root.children]) {
+            child.traverse(object => {
+                object.geometry?.dispose?.();
+                if (Array.isArray(object.material)) object.material.forEach(material => material.dispose?.());
+                else object.material?.dispose?.();
+            });
+            root.remove(child);
+        }
+    }
+
+    _planHandleHit(event) {
+        const rect = this.canvas.getBoundingClientRect();
+        this.pointer.set(
+            ((event.clientX - rect.left) / Math.max(1, rect.width)) * 2 - 1,
+            -((event.clientY - rect.top) / Math.max(1, rect.height)) * 2 + 1,
+        );
+        this.raycaster.setFromCamera(this.pointer, this.planCamera);
+        return this.raycaster.intersectObject(this.architectureHandleRoot, true)
+            .find(hit => hit.object?.userData?.factoryHandleType)?.object || null;
+    }
+
+    setArchitectureSelection(selection) {
+        this.architectureSelection = selection?.id
+            ? { type: String(selection.type || ""), id: String(selection.id) }
+            : null;
+        this._clearPlanRoot(this.architectureHandleRoot);
+        if (!selection?.id) {
+            this.invalidate();
+            return;
+        }
+        const architecture = this.sceneData?.architecture || {};
+        const addHandle = ({ type, id, point, elevation, endpoint = "", color = "#ff8fa3" }) => {
+            const radius = Math.max(0.055, 8 / Math.max(1, Number(this.planCameraState.zoom) || 24));
+            const handle = new THREE.Mesh(
+                new THREE.CircleGeometry(radius, 20),
+                new THREE.MeshBasicMaterial({ color, depthTest: false, side: THREE.DoubleSide }),
+            );
+            handle.rotation.x = -Math.PI / 2;
+            handle.position.set(point[0], elevation, point[1]);
+            handle.renderOrder = 60;
+            handle.userData = {
+                factoryHandleType: type,
+                factoryHandleId: id,
+                endpoint,
+            };
+            this.architectureHandleRoot.add(handle);
+        };
+        if (selection.type === "building") {
+            const building = architecture.buildings?.find(item => item.building_id === selection.id);
+            if (!building || building.locked) return this.invalidate();
+            const level = this.sceneData?.levels?.find(item => item.level_id === this.activeLevelId);
+            addHandle({
+                type: "building",
+                id: building.building_id,
+                point: [Number(building.position?.[0]) || 0, Number(building.position?.[2]) || 0],
+                elevation: (Number(level?.elevation) || 0)
+                    + (Number(building.position?.[1]) || 0)
+                    + 0.07,
+                color: "#b8a9e8",
+            });
+            return this.invalidate();
+        }
+        if (selection.type === "opening") {
+            const opening = architecture.openings?.find(item => item.opening_id === selection.id);
+            const wall = architecture.walls?.find(item => item.wall_id === opening?.wall_id);
+            const owner = architecture.buildings?.find(item => item.building_id === wall?.building_id);
+            if (!opening || !wall || opening.locked || wall.locked || owner?.locked) return this.invalidate();
+            const level = this.sceneData?.levels?.find(item => item.level_id === wall.level_id);
+            const offset = Math.max(0, Math.min(1, Number(opening.offset) || 0));
+            const position = new THREE.Vector3(
+                wall.start[0] + (wall.end[0] - wall.start[0]) * offset,
+                (Number(level?.elevation) || 0) + 0.075,
+                wall.start[1] + (wall.end[1] - wall.start[1]) * offset,
+            );
+            this.architecture.buildingRoots.get(wall.building_id)?.localToWorld(position);
+            addHandle({ type: "opening", id: opening.opening_id, point: [position.x, position.z], elevation: position.y, color: "#69d5e7" });
+            return this.invalidate();
+        }
+        if (selection.type === "room" || selection.type === "floor" || selection.type === "ceiling") {
+            const room = architecture.rooms?.find(item => item.room_id === selection.id);
+            const linkedWalls = new Set(room?.wall_ids || []);
+            const owner = architecture.buildings?.find(item => item.building_id === room?.building_id);
+            if (
+                !room?.polygon?.length
+                || room.locked
+                || owner?.locked
+                || architecture.walls?.some(wall => linkedWalls.has(wall.wall_id) && wall.locked)
+            ) return this.invalidate();
+            const level = this.sceneData?.levels?.find(item => item.level_id === room.level_id);
+            const center = room.polygon.reduce((sum, point) => [sum[0] + point[0], sum[1] + point[1]], [0, 0]).map(value => value / room.polygon.length);
+            const position = new THREE.Vector3(center[0], (Number(level?.elevation) || 0) + 0.065, center[1]);
+            this.architecture.buildingRoots.get(room.building_id)?.localToWorld(position);
+            addHandle({ type: "room", id: room.room_id, point: [position.x, position.z], elevation: position.y, color: "#b8a9e8" });
+            return this.invalidate();
+        }
+        if (selection.type !== "wall") {
+            this.invalidate();
+            return;
+        }
+        const wall = architecture.walls?.find(item => item.wall_id === selection.id);
+        const owner = architecture.buildings?.find(item => item.building_id === wall?.building_id);
+        if (!wall || wall.locked || owner?.locked) return this.invalidate();
+        const level = this.sceneData?.levels?.find(item => item.level_id === wall.level_id);
+        const elevation = (Number(level?.elevation) || 0) + 0.055;
+        const building = this.architecture.buildingRoots.get(wall.building_id);
+        for (const endpoint of ["start", "end"]) {
+            const position = new THREE.Vector3(wall[endpoint][0], elevation, wall[endpoint][1]);
+            if (building) building.localToWorld(position);
+            addHandle({ type: "wall", id: wall.wall_id, point: [position.x, position.z], elevation: position.y, endpoint });
+        }
+        this.invalidate();
+    }
+
+    setPlanDraft(draft) {
+        this._clearPlanRoot(this.planDraftRoot);
+        const points = Array.isArray(draft?.points) ? draft.points : [];
+        const cursor = Array.isArray(draft?.cursor) ? draft.cursor : null;
+        const opening = draft?.opening && typeof draft.opening === "object"
+            ? draft.opening
+            : null;
+        if (!points.length && !cursor && !opening) {
+            this.invalidate();
+            return;
+        }
+        const level = this.sceneData?.levels?.find(item => item.level_id === this.activeLevelId);
+        const elevation = (Number(level?.elevation) || 0) + 0.035;
+        const addLine = (source, color = "#ff8fa3", opacity = 1, order = 50) => {
+            if (!Array.isArray(source) || source.length < 2) return;
+            const vertices = source.map(point => new THREE.Vector3(point[0], elevation + 0.006, point[1]));
+            const geometry = new THREE.BufferGeometry().setFromPoints(vertices);
+            const line = new THREE.Line(
+                geometry,
+                new THREE.LineBasicMaterial({
+                    color,
+                    transparent: opacity < 1,
+                    opacity,
+                    depthTest: false,
+                    depthWrite: false,
+                }),
+            );
+            line.renderOrder = order;
+            this.planDraftRoot.add(line);
+        };
+        const addMarker = (point, color = "#ffc1cf", radius = 0.065, order = 53) => {
+            if (!Array.isArray(point)) return;
+            const marker = new THREE.Mesh(
+                new THREE.CircleGeometry(radius, 20),
+                new THREE.MeshBasicMaterial({
+                    color,
+                    depthTest: false,
+                    depthWrite: false,
+                    side: THREE.DoubleSide,
+                }),
+            );
+            marker.rotation.x = -Math.PI / 2;
+            marker.position.set(point[0], elevation + 0.01, point[1]);
+            marker.renderOrder = order;
+            this.planDraftRoot.add(marker);
+        };
+        const addStrip = (start, end, width, color, opacity = 0.35, order = 48) => {
+            if (!Array.isArray(start) || !Array.isArray(end)) return;
+            const dx = end[0] - start[0];
+            const dz = end[1] - start[1];
+            const length = Math.hypot(dx, dz);
+            if (length < 0.001) return;
+            const strip = new THREE.Mesh(
+                new THREE.BoxGeometry(length, 0.012, Math.max(0.01, Number(width) || 0.12)),
+                new THREE.MeshBasicMaterial({
+                    color,
+                    transparent: true,
+                    opacity,
+                    depthTest: false,
+                    depthWrite: false,
+                }),
+            );
+            strip.position.set((start[0] + end[0]) / 2, elevation, (start[1] + end[1]) / 2);
+            strip.rotation.y = -Math.atan2(dz, dx);
+            strip.renderOrder = order;
+            this.planDraftRoot.add(strip);
+        };
+
+        if (draft?.tool === "wall") {
+            addLine(points, "#ff8fa3", 0.58, 49);
+            for (const point of points) addMarker(point, "#ffb6c8", 0.052, 52);
+            const start = points.at(-1);
+            if (start && cursor && Math.hypot(cursor[0] - start[0], cursor[1] - start[1]) >= 0.001) {
+                addStrip(start, cursor, draft.thickness || 0.12, "#ff8fa3", 0.32, 50);
+                addLine([start, cursor], "#ffd5de", 1, 51);
+            }
+            if (cursor) addMarker(cursor, "#fff1f4", 0.075, 54);
+            this.invalidate();
+            return;
+        }
+
+        if (draft?.tool === "room") {
+            const rectangle = Array.isArray(draft.rectangle) ? draft.rectangle : [];
+            if (rectangle.length === 4) {
+                const shape = new THREE.Shape();
+                rectangle.forEach((point, index) => {
+                    if (index === 0) shape.moveTo(point[0], point[1]);
+                    else shape.lineTo(point[0], point[1]);
+                });
+                shape.closePath();
+                const fill = new THREE.Mesh(
+                    new THREE.ShapeGeometry(shape),
+                    new THREE.MeshBasicMaterial({
+                        color: "#b8a9e8",
+                        transparent: true,
+                        opacity: 0.18,
+                        depthTest: false,
+                        depthWrite: false,
+                        side: THREE.DoubleSide,
+                    }),
+                );
+                fill.geometry.rotateX(Math.PI / 2);
+                fill.position.y = elevation;
+                fill.renderOrder = 47;
+                this.planDraftRoot.add(fill);
+                for (let index = 0; index < rectangle.length; index += 1) {
+                    addStrip(
+                        rectangle[index],
+                        rectangle[(index + 1) % rectangle.length],
+                        draft.thickness || 0.12,
+                        "#b8a9e8",
+                        0.28,
+                        49,
+                    );
+                }
+                addLine([...rectangle, rectangle[0]], "#d7ccff", 1, 51);
+                for (const point of rectangle) addMarker(point, "#d7ccff", 0.052, 52);
+            } else {
+                for (const point of points) addMarker(point, "#d7ccff", 0.065, 52);
+            }
+            if (cursor) addMarker(cursor, "#f0ebff", 0.075, 54);
+            this.invalidate();
+            return;
+        }
+
+        if (draft?.tool === "camera") {
+            const position = points[0];
+            if (position) addMarker(position, "#d7ccff", 0.085, 55);
+            if (position && cursor) {
+                const dx = cursor[0] - position[0];
+                const dz = cursor[1] - position[1];
+                const distance = Math.hypot(dx, dz);
+                if (distance >= 0.001) {
+                    const length = Math.min(Math.max(0.5, distance), 2.5);
+                    const angle = Math.atan2(dx, -dz);
+                    const halfFov = THREE.MathUtils.degToRad(
+                        Math.max(5, Math.min(120, Number(draft.fov) || 42)) / 2,
+                    );
+                    const endpoint = bearing => [
+                        position[0] + Math.sin(bearing) * length,
+                        position[1] - Math.cos(bearing) * length,
+                    ];
+                    const left = endpoint(angle - halfFov);
+                    const right = endpoint(angle + halfFov);
+                    addLine([position, cursor], "#fff1f4", 1, 52);
+                    addLine([left, position, right], "#b8a9e8", 0.9, 51);
+                    addMarker(cursor, "#fff1f4", 0.065, 54);
+                }
+            } else if (cursor) {
+                addMarker(cursor, "#d7ccff", 0.085, 55);
+            }
+            this.invalidate();
+            return;
+        }
+
+        if (draft?.tool === "opening") {
+            if (opening?.start && opening?.end) {
+                const fillColor = opening.kind === "door" ? "#ffca85" : "#69d8ff";
+                const lineColor = opening.kind === "door" ? "#ffe2b5" : "#d8f5ff";
+                addStrip(
+                    opening.start,
+                    opening.end,
+                    Math.max(0.18, Number(opening.thickness) * 1.8 || 0.18),
+                    fillColor,
+                    0.62,
+                    51,
+                );
+                addLine([opening.start, opening.end], lineColor, 1, 52);
+                addMarker(opening.center, lineColor, 0.07, 54);
+            } else if (cursor) {
+                addMarker(cursor, "#ff5b6b", 0.075, 54);
+            }
+            this.invalidate();
+            return;
+        }
+
+        if (points.length > 1) addLine(points);
+        for (const point of points) addMarker(point);
+        if (cursor) addMarker(cursor, "#fff1f4", 0.075, 54);
+        this.invalidate();
+    }
+
+    setCameraMarkers(cameras = []) {
+        this._clearPlanRoot(this.cameraMarkerRoot);
+        const level = this.sceneData?.levels?.find(item => item.level_id === this.activeLevelId);
+        const elevation = (Number(level?.elevation) || 0) + 0.045;
+        const markerRadius = Math.max(0.08, 9 / Math.max(1, Number(this.planCameraState.zoom) || 24));
+        for (const camera of cameras) {
+            if (camera.level_id && camera.level_id !== this.activeLevelId) continue;
+            const owner = this.sceneData?.architecture?.buildings?.find(
+                building => building.building_id === camera.building_id,
+            );
+            if (owner?.visible === false) continue;
+            const position = new THREE.Vector3().fromArray(camera.position || [0, 1.6, 0]);
+            const target = new THREE.Vector3().fromArray(camera.target || [0, 1.6, -1]);
+            const direction = target.sub(position);
+            const angle = Math.atan2(direction.x, -direction.z);
+            const group = new THREE.Group();
+            group.position.set(position.x, elevation, position.z);
+            group.userData = { factoryType: "camera", factoryId: camera.camera_id };
+            const marker = new THREE.Mesh(
+                new THREE.CircleGeometry(markerRadius, 24),
+                new THREE.MeshBasicMaterial({ color: "#b8a9e8", depthTest: false, side: THREE.DoubleSide }),
+            );
+            marker.rotation.x = -Math.PI / 2;
+            marker.userData = group.userData;
+            marker.renderOrder = 45;
+            const arrowGeometry = new THREE.BufferGeometry().setFromPoints([
+                new THREE.Vector3(0, 0.01, 0),
+                new THREE.Vector3(Math.sin(angle) * 0.55, 0.01, -Math.cos(angle) * 0.55),
+            ]);
+            const arrow = new THREE.Line(
+                arrowGeometry,
+                new THREE.LineBasicMaterial({ color: "#d7ccff", depthTest: false }),
+            );
+            arrow.userData = marker.userData;
+            const halfFov = THREE.MathUtils.degToRad(Math.max(5, Math.min(120, Number(camera.fov) || 42)) / 2);
+            const frustumLength = 0.9;
+            const leftAngle = angle - halfFov;
+            const rightAngle = angle + halfFov;
+            const frustumGeometry = new THREE.BufferGeometry().setFromPoints([
+                new THREE.Vector3(Math.sin(leftAngle) * frustumLength, 0.01, -Math.cos(leftAngle) * frustumLength),
+                new THREE.Vector3(0, 0.01, 0),
+                new THREE.Vector3(Math.sin(rightAngle) * frustumLength, 0.01, -Math.cos(rightAngle) * frustumLength),
+            ]);
+            const frustum = new THREE.Line(
+                frustumGeometry,
+                new THREE.LineBasicMaterial({ color: "#9f8cde", transparent: true, opacity: 0.8, depthTest: false }),
+            );
+            frustum.userData = marker.userData;
+            frustum.renderOrder = 44;
+            group.add(marker, arrow, frustum);
+            this.cameraMarkerRoot.add(group);
+        }
+        this.invalidate();
+    }
+
+    setLightMarkers(lights = []) {
+        if (!this.lightMarkerRoot) return;
+        this._clearPlanRoot(this.lightMarkerRoot);
+        const level = this.sceneData?.levels?.find(item => item.level_id === this.activeLevelId);
+        const elevation = (Number(level?.elevation) || 0) + 0.05;
+        const radius = Math.max(0.07, 8 / Math.max(1, Number(this.planCameraState.zoom) || 24));
+        for (const light of lights) {
+            if (light.visible === false || (light.level_id && light.level_id !== this.activeLevelId)) continue;
+            const owner = this.sceneData?.architecture?.buildings?.find(
+                building => building.building_id === light.building_id,
+            );
+            if (owner?.visible === false) continue;
+            const [x, , z] = light.position || [0, 0, 0];
+            const marker = new THREE.Mesh(
+                new THREE.CircleGeometry(radius, 20),
+                new THREE.MeshBasicMaterial({
+                    color: light.color || "#ffffff",
+                    depthTest: false,
+                    side: THREE.DoubleSide,
+                }),
+            );
+            marker.rotation.x = -Math.PI / 2;
+            marker.position.set(Number(x) || 0, elevation, Number(z) || 0);
+            marker.renderOrder = 43;
+            marker.raycast = EMPTY;
+            this.lightMarkerRoot.add(marker);
+        }
+        this.invalidate();
+    }
+
+    setActiveLevel(levelId) {
+        if (!this.sceneData?.levels?.some(item => item.level_id === levelId)) return;
+        this.activeLevelId = levelId;
+        this.architecture.setActiveLevel(levelId, this.viewMode === "plan");
+        this.applySceneVisibility(this.sceneData);
+        const level = this.sceneData.levels.find(item => item.level_id === levelId);
+        this.grid.position.y = Number(level?.elevation) || 0;
+        this._planGridSignature = "";
+        this.setCameraMarkers(this.sceneData.cameras || []);
+        this.setLightMarkers(this.lighting.lights || []);
+        this._syncThreeLights();
+        for (const entry of this.objects.values()) this._syncDirectionalLighting(entry);
+        this._syncPlanCamera();
+        this._emitState();
+        this.invalidate();
+    }
+
+    updateArchitectureItem(type, id, sceneData = this.sceneData) {
+        this.sceneData = sceneData || this.sceneData;
+        const updated = this.architecture.updateItem(type, id, this.sceneData);
+        if (!updated) return false;
+        this.architecture.setActiveLevel(this.activeLevelId, this.viewMode === "plan");
+        this.setArchitectureSelection(this.architectureSelection);
+        this.invalidate();
+        return true;
+    }
+
+    async refreshArchitecture(sceneData = this.sceneData) {
+        this.sceneData = sceneData || this.sceneData;
+        await this.architecture.set(this.sceneData);
+        this.architecture.setActiveLevel(this.activeLevelId, this.viewMode === "plan");
+        this.setArchitectureSelection(this.architectureSelection);
+        this.setCameraMarkers(this.sceneData?.cameras || []);
+        this.invalidate();
+    }
+
+    worldToBuildingPlan(point, buildingId = "") {
+        const source = new THREE.Vector3(Number(point?.[0]) || 0, 0, Number(point?.[1]) || 0);
+        const building = this.architecture.buildingRoots.get(buildingId)
+            || this.architecture.buildingRoots.values().next().value;
+        if (building) building.worldToLocal(source);
+        return [Number(source.x.toFixed(6)), Number(source.z.toFixed(6))];
+    }
+
+    dropSelectionToSurface({ individual = false } = {}) {
+        const selectedIds = this.selectedGroupId
+            ? [...this.selectedGroupObjectIds]
+            : this.selectedId
+                ? [this.selectedId]
+                : [];
+        if (!selectedIds.length) return null;
+        const groups = individual ? selectedIds.map(id => [id]) : [selectedIds];
+        const results = [];
+        for (const group of groups) {
+            const movableGroup = group.filter(objectId => !this.objects.get(objectId)?.data?.locked);
+            if (!movableGroup.length) continue;
+            const selectedLevelIds = new Set(movableGroup
+                .map(objectId => this.objects.get(objectId)?.data?.level_id)
+                .filter(Boolean));
+            const selectedBuildingIds = new Set(movableGroup
+                .map(objectId => this.objects.get(objectId)?.data?.building_id)
+                .filter(Boolean));
+            const targetLevelId = selectedLevelIds.size === 1
+                ? selectedLevelIds.values().next().value
+                : this.activeLevelId;
+            const level = this.sceneData?.levels?.find(item => item.level_id === targetLevelId);
+            const targetBuildingId = selectedBuildingIds.size === 1
+                ? selectedBuildingIds.values().next().value
+                : "";
+            const building = this.sceneData?.architecture?.buildings?.find(
+                item => item.building_id === targetBuildingId,
+            );
+            const floorElevations = [
+                (Number(level?.elevation) || 0) + (Number(building?.position?.[1]) || 0),
+            ];
+            const eligibleEntries = new Map(Array.from(this.objects.entries()).filter(
+                ([objectId, entry]) => movableGroup.includes(objectId)
+                    || !entry.data?.level_id
+                    || (
+                        entry.data.level_id === targetLevelId
+                        && (!targetBuildingId || !entry.data.building_id || entry.data.building_id === targetBuildingId)
+                    ),
+            ));
+            const previousTransforms = Object.fromEntries(movableGroup.map(objectId => {
+                const entry = this.objects.get(objectId);
+                return [objectId, entry ? this._meshTransform(entry.mesh) : null];
+            }));
+            const result = solveDropToSurface({
+                entries: eligibleEntries,
+                selectedIds: movableGroup,
+                floorElevations,
+            });
+            if (!result) continue;
+            for (const [groupIndex, objectId] of movableGroup.entries()) {
+                const entry = this.objects.get(objectId);
+                if (!entry) continue;
+                entry.mesh.position.y += result.deltaY;
+                entry.mesh.updateMatrixWorld(true);
+                const transform = this._meshTransform(entry.mesh);
+                entry.data.transform = transform;
+                this.options.onTransformChange(objectId, transform, {
+                    final: true,
+                    source: "drop",
+                    previous_transforms: previousTransforms,
+                    command_last: groupIndex === movableGroup.length - 1,
+                });
+            }
+            results.push(result);
+        }
+        this._refreshSelectionBounds();
+        this.spark.setDirty?.();
+        this._emitState();
+        this.invalidate();
+        return results;
     }
 
     setCaptureSettings(value = {}) {
@@ -1800,20 +3181,73 @@ export class Factory3DViewer {
         };
     }
 
-    fit(objectId = "", { emit = true } = {}) {
+    _expandVisibleObjectBounds(box, root) {
+        if (!root?.visible) return box;
+        root.updateMatrixWorld?.(true);
+        root.traverseVisible?.(child => {
+            const geometry = child.geometry;
+            if (!geometry || child.userData?.factoryPlanOnly) return;
+            if (!geometry.boundingBox) geometry.computeBoundingBox?.();
+            if (!geometry.boundingBox?.isEmpty?.()) {
+                box.union(geometry.boundingBox.clone().applyMatrix4(child.matrixWorld));
+            }
+        });
+        return box;
+    }
+
+    _viewBounds({ scope = "scene", objectId = "" } = {}) {
         const box = new THREE.Box3();
-        const entries = objectId && this.objects.has(objectId)
-            ? [this.objects.get(objectId)]
-            : this.selectedGroupId
-                ? this._groupEntries().map(([, entry]) => entry)
-                : Array.from(this.objects.values()).filter(entry => entry.mesh.visible !== false);
+        let entries = [];
+        if (objectId && this.objects.has(objectId)) {
+            entries = [this.objects.get(objectId)];
+        } else if (scope === "selection" && this.selectedGroupId) {
+            entries = this._groupEntries().map(([, entry]) => entry);
+        } else if (scope === "selection" && this.selectedId && this.objects.has(this.selectedId)) {
+            entries = [this.objects.get(this.selectedId)];
+        } else if (scope === "scene") {
+            entries = Array.from(this.objects.values()).filter(entry => entry.mesh.visible !== false);
+        }
         for (const entry of entries) {
             try {
                 entry.mesh.updateMatrixWorld(true);
                 box.union(entry.localBounds.clone().applyMatrix4(entry.mesh.matrixWorld));
             } catch (_) {}
         }
-        if (box.isEmpty()) return;
+
+        if (scope === "scene") {
+            this._expandVisibleObjectBounds(box, this.architecture?.root);
+        } else if (scope === "selection" && box.isEmpty() && this.architectureSelection?.id) {
+            const selection = this.architectureSelection;
+            const itemType = selection.type === "floor" || selection.type === "ceiling"
+                ? "room"
+                : selection.type;
+            let architectureObject = this.architecture?.items?.get(`${itemType}:${selection.id}`);
+            if (selection.type === "opening") {
+                const opening = this.sceneData?.architecture?.openings?.find(
+                    item => item.opening_id === selection.id,
+                );
+                architectureObject = opening
+                    ? this.architecture?.items?.get(`wall:${opening.wall_id}`)
+                    : null;
+            }
+            if (selection.type === "level") {
+                for (const [key, object] of this.architecture?.items || []) {
+                    if (key.startsWith("building:")) continue;
+                    const [type, id] = key.split(":");
+                    const source = type === "wall"
+                        ? this.sceneData?.architecture?.walls?.find(item => item.wall_id === id)
+                        : this.sceneData?.architecture?.rooms?.find(item => item.room_id === id);
+                    if (source?.level_id === selection.id) this._expandVisibleObjectBounds(box, object);
+                }
+            } else if (architectureObject) {
+                this._expandVisibleObjectBounds(box, architectureObject);
+            }
+        }
+        return box;
+    }
+
+    _frameBounds(box, { direction = null, emit = true } = {}) {
+        if (!box || box.isEmpty()) return false;
         const sphere = box.getBoundingSphere(new THREE.Sphere());
         const radius = Math.max(sphere.radius, 0.001);
         // Fit against the export camera, not the editor canvas. Portrait
@@ -1827,15 +3261,182 @@ export class Factory3DViewer {
             Math.min(verticalHalfFov, horizontalHalfFov),
         );
         const distance = radius / Math.sin(limitingHalfFov) * 1.16;
-        const direction = this.camera.position.clone().sub(this.controls.target);
-        if (direction.lengthSq() < 1e-12) direction.set(0.7, 0.5, 1);
-        direction.normalize();
+        const viewDirection = direction
+            ? new THREE.Vector3().fromArray(direction)
+            : this.camera.position.clone().sub(this.controls.target);
+        if (viewDirection.lengthSq() < 1e-12) viewDirection.set(0.7, 0.5, 1);
+        viewDirection.normalize();
         this.controls.target.copy(sphere.center);
-        this.camera.position.copy(sphere.center).addScaledVector(direction, distance);
+        this.camera.position.copy(sphere.center).addScaledVector(viewDirection, distance);
         this.controls.minDistance = radius * 0.001;
         this.controls.maxDistance = radius * 10000;
+        this.camera.lookAt(this.controls.target);
         this.controls.update();
         this._updateClipPlanes(radius);
+        this.invalidate();
+        if (emit) {
+            this._cameraStateDirty = false;
+            this._emitState();
+        }
+        return true;
+    }
+
+    fit(objectId = "", { emit = true } = {}) {
+        return this._frameBounds(
+            this._viewBounds({ scope: objectId ? "selection" : "scene", objectId }),
+            { emit },
+        );
+    }
+
+    frameScene({ emit = true } = {}) {
+        return this._frameBounds(this._viewBounds({ scope: "scene" }), { emit });
+    }
+
+    frameSelection({ emit = true } = {}) {
+        return this._frameBounds(this._viewBounds({ scope: "selection" }), { emit });
+    }
+
+    resetView({ emit = true } = {}) {
+        this.camera.up.set(0, 1, 0);
+        const framed = this._frameBounds(
+            this._viewBounds({ scope: "scene" }),
+            { direction: [0.62, 0.46, 0.78], emit },
+        );
+        if (framed) return true;
+        this.camera.position.set(2.8, 2.1, 4.2);
+        this.controls.target.set(0, 0, 0);
+        this.controls.minDistance = 0.0001;
+        this.controls.maxDistance = 1_000_000;
+        this.camera.lookAt(this.controls.target);
+        this.controls.update();
+        this._updateClipPlanes();
+        this.invalidate();
+        if (emit) {
+            this._cameraStateDirty = false;
+            this._emitState();
+        }
+        return true;
+    }
+
+    setViewPreset(preset = "perspective", { emit = true } = {}) {
+        const directions = {
+            perspective: [0.62, 0.46, 0.78],
+            front: [0, 0, 1],
+            right: [1, 0, 0],
+            top: [0, 1, 0.000001],
+        };
+        const direction = directions[preset] || directions.perspective;
+        this.camera.up.set(0, 1, 0);
+        if (preset === "top") this.camera.up.set(0, 0, -1);
+        const box = this._viewBounds({ scope: "scene" });
+        if (this._frameBounds(box, { direction, emit })) return true;
+        const distance = Math.max(this.camera.position.distanceTo(this.controls.target), 1);
+        this.camera.position.copy(this.controls.target).addScaledVector(
+            new THREE.Vector3().fromArray(direction).normalize(),
+            distance,
+        );
+        this.camera.lookAt(this.controls.target);
+        this.controls.update();
+        this._updateClipPlanes();
+        this.invalidate();
+        if (emit) this._emitState();
+        return true;
+    }
+
+    orbitCamera({ yaw = 0, pitch = 0 } = {}, { emit = true } = {}) {
+        const offset = this.camera.position.clone().sub(this.controls.target);
+        if (offset.lengthSq() < 1e-12) offset.set(0.7, 0.5, 1);
+        const spherical = new THREE.Spherical().setFromVector3(offset);
+        spherical.theta += THREE.MathUtils.degToRad(Number(yaw) || 0);
+        spherical.phi = THREE.MathUtils.clamp(
+            spherical.phi + THREE.MathUtils.degToRad(Number(pitch) || 0),
+            THREE.MathUtils.degToRad(1),
+            THREE.MathUtils.degToRad(179),
+        );
+        this.camera.up.set(0, 1, 0);
+        this.camera.position.copy(this.controls.target).add(
+            new THREE.Vector3().setFromSpherical(spherical),
+        );
+        this.camera.lookAt(this.controls.target);
+        this.controls.update();
+        this._updateClipPlanes();
+        this.invalidate();
+        if (emit) {
+            this._cameraStateDirty = false;
+            this._emitState();
+        }
+    }
+
+    panCamera({ right = 0, forward = 0 } = {}, { emit = true } = {}) {
+        const distance = Math.max(this.camera.position.distanceTo(this.controls.target), 0.001);
+        const viewForward = this.controls.target.clone().sub(this.camera.position);
+        viewForward.y = 0;
+        if (viewForward.lengthSq() < 1e-12) viewForward.set(0, 0, -1);
+        viewForward.normalize();
+        const viewRight = new THREE.Vector3().crossVectors(viewForward, new THREE.Vector3(0, 1, 0));
+        if (viewRight.lengthSq() < 1e-12) viewRight.set(1, 0, 0);
+        viewRight.normalize();
+        const step = THREE.MathUtils.clamp(distance * 0.08, 0.01, 1000);
+        const delta = viewRight.multiplyScalar((Number(right) || 0) * step)
+            .addScaledVector(viewForward, (Number(forward) || 0) * step);
+        if (delta.lengthSq() < 1e-12) return;
+        this.camera.position.add(delta);
+        this.controls.target.add(delta);
+        this.camera.lookAt(this.controls.target);
+        this.controls.update();
+        this._updateClipPlanes();
+        this.invalidate();
+        if (emit) {
+            this._cameraStateDirty = false;
+            this._emitState();
+        }
+    }
+
+    dollyCamera(amount = 0, { emit = true } = {}) {
+        const units = Number(amount) || 0;
+        if (!units) return;
+        const distance = Math.max(this.camera.position.distanceTo(this.controls.target), 0.001);
+        const forward = this.controls.target.clone().sub(this.camera.position);
+        if (forward.lengthSq() < 1e-12) forward.set(0, 0, -1);
+        const step = THREE.MathUtils.clamp(distance * 0.1, 0.01, 1000);
+        const delta = forward.normalize().multiplyScalar(
+            THREE.MathUtils.clamp(units, -10, 10) * step,
+        );
+        this.camera.position.add(delta);
+        this.controls.target.add(delta);
+        this.camera.lookAt(this.controls.target);
+        this.controls.update();
+        this._updateClipPlanes();
+        this.invalidate();
+        if (emit) {
+            this._cameraStateDirty = false;
+            this._emitState();
+        }
+    }
+
+    setCameraDistance(value, { emit = true } = {}) {
+        const distance = THREE.MathUtils.clamp(Number(value) || 0, 0.0001, 1_000_000);
+        const direction = this.camera.position.clone().sub(this.controls.target);
+        if (direction.lengthSq() < 1e-12) direction.set(0.62, 0.46, 0.78);
+        this.camera.position.copy(this.controls.target).addScaledVector(direction.normalize(), distance);
+        this.camera.lookAt(this.controls.target);
+        this.controls.update();
+        this._updateClipPlanes();
+        this.invalidate();
+        if (emit) {
+            this._cameraStateDirty = false;
+            this._emitState();
+        }
+    }
+
+    setCameraHeight(value, { emit = true } = {}) {
+        const height = THREE.MathUtils.clamp(Number(value) || 0, -1_000_000, 1_000_000);
+        const delta = height - this.camera.position.y;
+        this.camera.position.y += delta;
+        this.controls.target.y += delta;
+        this.camera.lookAt(this.controls.target);
+        this.controls.update();
+        this._updateClipPlanes();
         this.invalidate();
         if (emit) {
             this._cameraStateDirty = false;
@@ -1863,6 +3464,13 @@ export class Factory3DViewer {
             selected_group_id: this.selectedGroupId,
             mode: this.mode,
             grid: this.gridVisible,
+            view_mode: this.viewMode,
+            plan_tool: this.planTool,
+            active_level_id: this.activeLevelId,
+            plan_camera: {
+                target: [...this.planCameraState.target],
+                zoom: this.planCameraState.zoom,
+            },
             camera: this.getCameraState(),
         };
     }
@@ -1898,6 +3506,14 @@ export class Factory3DViewer {
         this._cameraStateDirty = false;
         this.invalidate();
         if (emit) this._emitState();
+    }
+
+    setCameraPlayback(active) {
+        const playing = Boolean(active);
+        this.controls.enableDamping = !playing;
+        this.controls.enabled = !playing && this.viewMode === "3d" && !this.transform.dragging;
+        if (!playing) this.controls.update();
+        this.invalidate();
     }
 
     rotateCameraFPV({ yaw = 0, pitch = 0 } = {}, { emit = true } = {}) {
@@ -1946,7 +3562,19 @@ export class Factory3DViewer {
     setState(value = {}) {
         if (value.mode) this.setMode(value.mode);
         if ("grid" in value) this.setGrid(value.grid);
+        if (value.plan_camera) {
+            this.planCameraState = {
+                target: finiteVector(
+                    [value.plan_camera.target?.[0], value.plan_camera.target?.[1], 0],
+                    [0, 0, 0],
+                ).slice(0, 2),
+                zoom: Math.max(0.01, Number(value.plan_camera.zoom) || 24),
+            };
+        }
+        if (value.active_level_id) this.setActiveLevel(value.active_level_id);
+        if (value.plan_tool) this.setPlanTool(value.plan_tool);
         this.setCameraState(value.camera || {}, { emit: false });
+        if (value.view_mode) this.setViewMode(value.view_mode);
     }
 
     _emitState() {
@@ -1954,20 +3582,20 @@ export class Factory3DViewer {
     }
 
     async _waitForRenderable(timeoutMs = 15000) {
-        if (Number(this.spark.activeSplats) > 0) {
-            return Number(this.spark.activeSplats);
+        if (Number(this.spark.activeSplats) > 0 || this.architecture.root.children.length > 0) {
+            return Math.max(1, Number(this.spark.activeSplats) || 0);
         }
         const started = performance.now();
         this.spark.setDirty?.();
         while (!this._disposed && performance.now() - started < timeoutMs) {
             await new Promise(resolve => setTimeout(resolve, 32));
-            this.renderer.render(this.scene, this.camera);
-            if (Number(this.spark.activeSplats) > 0) {
-                return Number(this.spark.activeSplats);
+            this.renderer.render(this.scene, this.activeCamera());
+            if (Number(this.spark.activeSplats) > 0 || this.architecture.root.children.length > 0) {
+                return Math.max(1, Number(this.spark.activeSplats) || 0);
             }
         }
         throw new Error(
-            `3D viewport did not produce renderable splats within ${Math.round(timeoutMs / 1000)} seconds`,
+            `3D viewport did not produce renderable scene content within ${Math.round(timeoutMs / 1000)} seconds`,
         );
     }
 
@@ -2016,11 +3644,14 @@ export class Factory3DViewer {
             grid: this.grid.visible,
             transform: this.transformHelper.visible,
             bounds: this.selectionBounds.visible,
+            plan: this.planOverlay.visible,
         };
         const previousCaptureState = this._capturing;
         this.grid.visible = false;
         this.transformHelper.visible = false;
         this.selectionBounds.visible = false;
+        this.planOverlay.visible = false;
+        this.architecture.setActiveLevel(this.activeLevelId, false);
         this._capturing = true;
         if (captureSkydomeTexture) {
             this.skydomeTexture = captureSkydomeTexture;
@@ -2096,12 +3727,14 @@ export class Factory3DViewer {
             this.grid.visible = overlayVisibility.grid;
             this.transformHelper.visible = overlayVisibility.transform;
             this.selectionBounds.visible = overlayVisibility.bounds;
+            this.planOverlay.visible = overlayVisibility.plan;
+            this.architecture.setActiveLevel(this.activeLevelId, this.viewMode === "plan");
             this._capturing = previousCaptureState;
             // Re-read the local viewport after capture. The Comfy graph may
             // have been zoomed or the node resized while the exact-size render
             // was being encoded.
             this.resize();
-            this.renderer.render(this.scene, this.camera);
+            this.renderer.render(this.scene, this.activeCamera());
             this.invalidate();
         }
         return await new Promise((resolve, reject) => {
@@ -2181,7 +3814,7 @@ export class Factory3DViewer {
                 } catch (error) {
                     this.options.onError(error);
                 }
-                this.renderer.render(this.scene, this.camera);
+                this.renderer.render(this.scene, this.activeCamera());
                 this.invalidate();
             } finally {
                 this._capturing = previousCaptureState;
@@ -2299,7 +3932,7 @@ export class Factory3DViewer {
                 } catch (error) {
                     this.options.onError(error);
                 }
-                this.renderer.render(this.scene, this.camera);
+                this.renderer.render(this.scene, this.activeCamera());
             } finally {
                 this._capturing = previousCaptureState;
                 this._suppressStateEvents = previousSuppressState;
@@ -2333,7 +3966,13 @@ export class Factory3DViewer {
         this.selectionBounds.geometry.dispose();
         this.selectionBounds.material.dispose();
         this.controls.dispose();
-        for (const entry of this.objects.values()) entry.splat?.dispose?.();
+        this.architecture?.dispose?.();
+        this._clearPlanRoot(this.planGridRoot);
+        this._clearPlanRoot(this.planDraftRoot);
+        this._clearPlanRoot(this.cameraMarkerRoot);
+        this._clearPlanRoot(this.architectureHandleRoot);
+        this.scene.remove(this.planOverlay);
+        for (const entry of this.objects.values()) this._disposeEntry(entry);
         this.objects.clear();
         this.skydomeTexture?.dispose?.();
         this.skydomeTexture = null;
@@ -2341,6 +3980,8 @@ export class Factory3DViewer {
         this.scene.remove(this.spark);
         this.spark.onDirty = null;
         this.spark?.dispose?.();
+        for (const child of this.lightRig.children) child.shadow?.map?.dispose?.();
+        this.scene.remove(this.lightRig);
         this.grid.geometry.dispose();
         this.grid.material.dispose();
         this.renderer.dispose();

--- a/web/vnccs_pose_studio.js
+++ b/web/vnccs_pose_studio.js
@@ -9528,13 +9528,20 @@ class PoseStudioWidget {
             const applied = this.viewer.applySAM3DImport(
                 poseForAnalysis,
                 this._shoulderYOffset || 0,
-                { recordState: false },
+                {
+                    recordState: false,
+                    dispatchPoseChange: false,
+                },
             );
             if (!applied) {
                 throw new Error("Failed to fit SAM 3D Body proportions.");
             }
             if (fitData?.meshData) {
-                this.applySAM3DMeshOverlayFit(fitData.meshData, poseForAnalysis);
+                this.applySAM3DMeshOverlayFit(
+                    fitData.meshData,
+                    poseForAnalysis,
+                    { dispatchPoseChange: false },
+                );
             }
             this.syncMeshProportionSlidersFromViewer();
 
@@ -9594,12 +9601,15 @@ class PoseStudioWidget {
         return true;
     }
 
-    applySAM3DMeshOverlayFit(meshData, poseData) {
+    applySAM3DMeshOverlayFit(meshData, poseData, options = {}) {
         if (!meshData || !this.viewer?.setSAMMeshOverlayData) return false;
         const ok = this.viewer.setSAMMeshOverlayData(meshData, poseData);
         this.viewer.setSAMMeshOverlayVisible?.(!!this.exportParams.debugShowSAMMeshOverlay);
         if (ok && this.viewer.fitCurrentPoseToSAMMeshOverlay) {
-            return this.viewer.fitCurrentPoseToSAMMeshOverlay();
+            return this.viewer.fitCurrentPoseToSAMMeshOverlay(
+                0,
+                { dispatchPoseChange: options.dispatchPoseChange !== false },
+            );
         }
         return ok;
     }

--- a/web/vnccs_pose_studio_core.js
+++ b/web/vnccs_pose_studio_core.js
@@ -5958,7 +5958,7 @@ export class PoseViewerCore {
         return applied;
     }
 
-    fitCurrentPoseToSAMMeshOverlay(shoulderYOffset = 0) {
+    fitCurrentPoseToSAMMeshOverlay(shoulderYOffset = 0, options = {}) {
         const worldKps = this._samMeshOverlayWorldKps;
         const passCount = 6;
         for (let pass = 0; pass < passCount; pass++) {
@@ -5974,7 +5974,7 @@ export class PoseViewerCore {
                 footLocalRotations: this._sam3dImportedFootLocalRotations || null,
                 drawFigure: finalPass,
                 updateMarkers: finalPass,
-                dispatchPoseChange: finalPass,
+                dispatchPoseChange: finalPass && options.dispatchPoseChange !== false,
             });
             if (!applied) return false;
         }
@@ -8405,6 +8405,7 @@ export class PoseViewerCore {
                 alignHead: options.alignHead ?? !usedRotationImport,
                 alignFeet: options.alignFeet !== false,
                 footLocalRotations: this._sam3dImportedFootLocalRotations,
+                dispatchPoseChange: options.dispatchPoseChange !== false,
             });
         }
 
@@ -8413,7 +8414,7 @@ export class PoseViewerCore {
             this.skinnedMesh.updateMatrixWorld(true);
             this.updateMarkers();
             this.requestRender();
-            this.dispatchPoseChange();
+            if (options.dispatchPoseChange !== false) this.dispatchPoseChange();
             return true;
         }
         return false;


### PR DESCRIPTION
# Version 0.6.6
## 3D Factory Interior Planning, Camera Paths, and Production Editing

### New Features

*   **Top-down interior Plan mode**: Added a dedicated orthographic workspace for designing interiors directly in the 3D Factory viewport.
    *   Walls, rectangular rooms, wall openings, and saved cameras use press-drag-release creation with live geometry previews.
    *   The configurable plan grid supports independent visibility, spacing, major-line intervals, and optional snapping to the grid, angles, wall endpoints, wall midpoints, and orthogonal directions.
    *   Plan navigation includes corrected two-axis panning, mouse-wheel zoom, persistent framing, live room movement, shift selection, and scale-correct marquee selection inside zoomed ComfyUI nodes.

*   **Persistent architectural scenes**: Added floor levels, walls, rooms, floors, ceilings, doors, windows, empty openings, materials, and complete structure transforms to saved scenes and workflow state.
    *   A room is edited as one envelope: its perimeter walls, floor, and ceiling move, resize, change level, visibility, lock state, height, thickness, and material together.
    *   Wall endpoints, height, thickness, elevation offset, side materials, cap materials, and attached openings remain editable after creation.
    *   Opening controls are constrained by the host wall and prevent overlaps or geometry outside the available wall span.
    *   Buildings are optional hierarchy containers. New blank scenes contain no synthetic `Building 1`; moving or rotating an existing building transforms its architecture, assigned Gaussian objects, cameras, paths, and lights as one unit. Deleting it removes its architecture and safely unassigns or reassigns the remaining scene objects without creating a replacement building.

*   **Architectural materials and textures**: Added reusable solid, glass, and uploaded texture materials for wall sides, wall caps, floors, ceilings, and window panes.
    *   JPEG, PNG, and WebP textures are validated, converted to scene-owned PNG assets, exposed through bounded scene routes, and support UV scale and rotation.

*   **Production camera workflow**: Reworked viewport and saved-camera control for precise scene navigation and repeatable shots.
    *   The Cameras panel now contains perspective, front, right, and top projections plus adjustable mouse-wheel zoom speed for both large scenes and close interior work.
    *   In-place FPV look preserves camera position and world-up orientation, while framing commands establish an explicit orbit target instead of implicitly rotating around the world origin.
    *   Saved cameras can be placed and aimed in Plan mode, entered non-destructively, updated from the current view, assigned to levels or buildings, and edited through exact position, rotation, FOV, and focus-distance fields.
    *   Added persistent camera paths with editable points, timing, linear or centripetal Catmull-Rom interpolation, easing, optional constant-speed traversal, looping, playback, and exact per-point camera values.

*   **Floor-aware object placement**: Added one-action surface dropping for individual or grouped selections.
    *   Objects stop on the active floor or on the highest colliding object beneath them instead of passing through scene geometry.
    *   Automatic, custom-box, and disabled collision proxies are available per object, including control over whether an object can support other objects.

*   **Local point lights and occlusion shadows**: Added scene-owned spherical point lights with editable position, level, building, color, strength, range, visibility, and shadow casting.
    *   Light helpers are selectable objects in Plan and 3D views but are excluded from current-view and saved-camera exports.
    *   Directional and local lights now cast configurable occlusion shadows from closed architectural geometry and opaque Gaussian collision proxies, while transmissive objects and glass openings allow light through.
    *   Low, Medium, High, and Ultra shadow presets use bounded active-light budgets and tuned bias values to control browser cost while keeping distant wall lighting stable.

*   **Viewport-only interior cutaway**: Added separate Plan and 3D cutaway state that hides ceilings and the nearest horizontally blocking wall for interior editing.
    *   Cutaway never changes scene data and is automatically disabled during camera and node-output captures, so exported views retain the complete architecture.

### Workflow and UX Improvements

*   **Task-oriented workspace layout**: Reorganized the editor into Generate/Cameras tabs on the left, a clear central viewport, and Objects/Inspector/Export tabs on the right, removing controls that previously competed with the viewport.
*   **Unified scene selection**: Gaussian objects, rooms, walls, openings, buildings, saved cameras, and local lights participate in consistent selection, visibility, locking, inspection, and object-tree workflows.
    *   Plan Select mode supports shift-additive selection and drag marquee selection across rooms, architecture, Gaussian objects, cameras, and lights.
    *   Copy, paste, Delete/Backspace, Undo, and Redo are scoped to the active Factory editor and ignore text, numeric, select, and content-editable controls.
    *   Copied rooms retain their perimeter walls and openings; pasted architecture, cameras, lights, and Gaussian objects receive independent IDs and a visible placement offset.
*   **Live precision Inspector**: Transform gizmos remain available for coarse editing while paired sliders and exact numeric fields provide hundredth-step model, group, architecture, camera, and light control.
    *   Continuous changes update the viewport during interaction, remain usable across repeated drags, and commit one bounded history operation when editing finishes.
*   **Contextual level controls**: The level panel appears only while an architectural drawing tool is active and provides level creation, selection, elevation, height, slab thickness, visibility, and deletion without occupying the normal 3D workspace.

### Fixes

*   **Pose Manager proportion-only analysis**: Fixed **Auto-analyze proportions** allowing the temporary SAM-detected pose to replace the active Pose Manager card. Both the initial SAM import and the subsequent mesh-overlay fitting now suppress pose-change synchronization during proportion analysis, so only body proportions are transferred and every managed pose is preserved.

### Persistence and Compatibility

*   Added strict shared normalization and validation for levels, optional buildings, room perimeters, wall openings, materials, textures, object collision and light-transport properties, camera paths, local lights, and shadow settings.
*   Added an independent edit revision so concurrent or stale editors cannot silently overwrite newer scene work, while render revisions continue to invalidate only affected captures and exports.
*   Extended `.vnccs3d` scene packages to preserve architecture, floor levels, texture assets, camera paths, local lights, shadows, and object assignments; restored packages remap scene-owned IDs and validate every reference.
*   Existing 3D Factory scenes remain loadable. Migration removes only the recognizable empty synthetic `Building 1` created by the temporary mandatory-building schema and preserves every user-created or transformed structure.